### PR TITLE
feat: 当前工单回复通知

### DIFF
--- a/api/notify.js
+++ b/api/notify.js
@@ -1,29 +1,67 @@
+const AV = require('leancloud-storage')
 const mail = require('./mail')
+const request = require('request-promise')
 const config = require('../config')
+const { NewReplyNotificaion } = require('../modules/notification')
 
 exports.newTicket = (ticket, author) => {
-  return ticket.get('assignee').fetch((assignee) => {
-    if (assignee.get('email')) {
-      return mail.send({
-        from: `${author.get('username')} <ticket@leancloud.cn>`,
-        to: assignee.get('email'),
-        subject: `[LeanTicket] ${ticket.get('title')} (#${ticket.get('nid')})`,
-        text: ticket.get('content'),
-        url: `${config.host}/tickets/${ticket.get('nid')}`,
-      })
-    }
-  })
+  return Promise.all([
+    // online notification
+    new AV.Object('_Conversation').save({
+      tr: true,
+      ticket: ticket.get('nid'),
+    }),
+    // mail
+    ticket.get('assignee').fetch((assignee) => {
+      if (assignee.get('email')) {
+        return mail.send({
+          from: `${author.get('username')} <ticket@leancloud.cn>`,
+          to: assignee.get('email'),
+          subject: `[LeanTicket] ${ticket.get('title')} (#${ticket.get('nid')})`,
+          text: ticket.get('content'),
+          url: `${config.host}/tickets/${ticket.get('nid')}`,
+        })
+      }
+    })
+  ])
 }
 
 exports.replyTicket = (ticket, reply, replyAuthor) => {
-  const to = reply.get('isCustomerService') ? ticket.get('author') : ticket.get('assignee')
-  if (to.get('email')) {
-    return mail.send({
-      from: `${replyAuthor.get('username')} <ticket@leancloud.cn>`,
-      to: to.get('email'),
-      subject: `[LeanTicket] ${ticket.get('title')} (#${ticket.get('nid')})`,
-      text: reply.get('content'),
-      url: `${config.host}/tickets/${ticket.get('nid')}`,
+  return Promise.all([
+    // online notification
+    new AV.Query('_Conversation').equalTo('ticket', ticket.get('nid')).first().then(conversation => {
+      if (conversation) {
+        return request({
+          url: 'https://api.leancloud.cn/1.1/rtm/messages',
+          method: 'POST',
+          headers: {
+            'X-LC-Id': process.env.LEANCLOUD_APP_ID,
+            'X-LC-KEY': `${process.env.LEANCLOUD_APP_MASTER_KEY},master`,
+          },
+          json: true,
+          body: {
+            from_peer: 'LeanTicket Bot',
+            conv_id: conversation.id,
+            transient: true,
+            message: JSON.stringify(new NewReplyNotificaion({
+              id: reply.id
+            }).toJSON()),
+          }
+        })
+      }
+    }),
+    // mail    
+    Promise.resolve().then(() => {
+      const to = reply.get('isCustomerService') ? ticket.get('author') : ticket.get('assignee')
+      if (to.get('email')) {
+        return mail.send({
+          from: `${replyAuthor.get('username')} <ticket@leancloud.cn>`,
+          to: to.get('email'),
+          subject: `[LeanTicket] ${ticket.get('title')} (#${ticket.get('nid')})`,
+          text: reply.get('content'),
+          url: `${config.host}/tickets/${ticket.get('nid')}`,
+        })
+      }
     })
-  }
+  ])
 }

--- a/modules/App.js
+++ b/modules/App.js
@@ -4,6 +4,8 @@ import AV from 'leancloud-storage'
 
 import common from './common'
 import GlobalNav from './GlobalNav'
+import Notification from './notification'
+import { tap } from '../utils/promise'
 
 export default React.createClass({
   getInitialState() {
@@ -12,10 +14,12 @@ export default React.createClass({
     }
   },
   componentDidMount() {
-    common.isCustomerService(AV.User.current())
-    .then((isCustomerService) => {
-      this.setState({isCustomerService})
-    })
+    const user = AV.User.current()
+    common.isCustomerService(user)
+      .then((isCustomerService) => {
+        this.setState({isCustomerService})
+      })
+    if (user) Notification.login(user.id)
   },
   contextTypes: {
     router: React.PropTypes.object
@@ -26,6 +30,7 @@ export default React.createClass({
     .setPassword(password)
     .logIn()
     .then((user) => {
+      Notification.login(user.id)
       return common.isCustomerService(user)
     }).then((isCustomerService) => {
       this.setState({isCustomerService})
@@ -39,6 +44,7 @@ export default React.createClass({
   },
   loginByToken(token) {
     AV.User.become(token).then((user) => {
+      Notification.login(user.id)
       return common.isCustomerService(user)
     }).then((isCustomerService) => {
       this.setState({isCustomerService})
@@ -50,6 +56,7 @@ export default React.createClass({
       .setUsername(username)
       .setPassword(password)
       .signUp()
+      .then(tap(user => Notification.login(user.id)))
   },
   render() {
     return (

--- a/modules/GlobalNav.js
+++ b/modules/GlobalNav.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router'
 import AV from 'leancloud-storage'
+import Notification from './notification'
 
 export default React.createClass({
   handleLogout() {
     AV.User.logOut()
+    Notification.logout()
   },
   handleNewTicketClick() {
     this.context.router.push('/tickets/new')

--- a/modules/notification.js
+++ b/modules/notification.js
@@ -1,0 +1,40 @@
+// also required by server hook
+const { Realtime, TypedMessage, messageType, messageField } = require('leancloud-realtime')
+
+class NotificationMessage extends TypedMessage {
+  constructor(payload) {
+    super()
+    this.payload = payload
+  }
+}
+messageType(100)(NotificationMessage)
+messageField(['payload'])(NotificationMessage)
+
+class NewReplyNotificaion extends NotificationMessage {}
+messageType(101)(NewReplyNotificaion)
+
+const realtime = new Realtime({
+  appId: process.env.LEANCLOUD_APP_ID,
+})
+realtime.register([NewReplyNotificaion])
+
+let clientPromise = null
+
+module.exports = {
+  NotificationMessage,
+  NewReplyNotificaion,
+  login(id) {
+    clientPromise = 
+      (clientPromise ? this.logout() : Promise.resolve())
+      .then(() => realtime.createIMClient(id))
+    return clientPromise
+  },
+  logout() {
+    return clientPromise.then(client => client.close()).then(() => {
+      clientPromise = null
+    })
+  },
+  getClient() {
+    return clientPromise || Promise.reject(new Error('Notification service not logged in'))
+  },
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "compression": "^1.6.2",
     "express": "^4.14.0",
     "highlight.js": "^9.10.0",
+    "leancloud-realtime": "^3.3.4",
     "leancloud-storage": "^2.1.1",
     "leanengine": "github:leancloud/leanengine-node-sdk#v2",
     "lodash": "^4.17.4",

--- a/utils/promise.js
+++ b/utils/promise.js
@@ -1,0 +1,7 @@
+export const tap = interceptor => value => ((interceptor(value), value))
+export const wait = time => new Promise(resolve => setTimeout(resolve, time))
+export const hold = time => result => wait(time).then(() => result)
+export const series = promiseGens => promiseGens.reduce(
+  (m, p) => m.then(v => Promise.all([...v, p()])),
+  Promise.resolve([])
+)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
         LEANCLOUD_APP_ID: 'qJnLgVRA9mnzVSw4Ho3HtIaI-gzGzoHsz',
         LEANCLOUD_APP_KEY: 'zWbsVPeSQtQOSy2bN3ixRVOq',
       })
-    })
-  ])
+    }),
+    new webpack.optimize.UglifyJsPlugin()
+  ]),
 }


### PR DESCRIPTION
做了以下几件事情：

1. 登录时/已登录时以当前 user id 登录实时通讯
2. Ticket afterSave 时为这个 Ticket(nid) 创建一个暂态的 Conversation
3. 进入某个 Ticket 页面 join 对应的 Convesation
4. Replay afterSave 时向这个 Conversation 发送一条 NewReplyNotification

UI 的更新没有在这个 PR 里实现（因为估计会改）。