### PR TITLE
fix: 工单详情页增加工单分类和当前负责人的信息

### DIFF
--- a/modules/Ticket.css
+++ b/modules/Ticket.css
@@ -2,6 +2,10 @@
 
 }
 
+.meta {
+  color: #999;
+}
+
 .panelModerator {
   border-color: #c1d5e4;
 }
@@ -49,6 +53,16 @@
 .category {
   vertical-align: inherit;
   margin-left: 0;
+}
+
+.categoryBlock {
+  font-size: inherit;
+  display: inline-block;
+  vertical-align: inherit;
+  margin-left: 0;
+  padding: 4px 8px;
+  color: #777;
+  border-color: #777;
 }
 
 .form {

--- a/modules/Ticket.js
+++ b/modules/Ticket.js
@@ -312,10 +312,10 @@ export default class Ticket extends Component {
         <div className="row">
           <div className="col-sm-12">
             <DocumentTitle title={ticket.get('title') + ' - LeanTicket' || 'LeanTicket'} />
-            <h1>{ticket.get('title')} <small>#{ticket.get('nid')}</small></h1>
-            <div>
+            <h1>{ticket.get('title')}</h1>
+            <div className={css.meta}>
+              <span className={csCss.nid}>#{ticket.get('nid')}</span>
               <TicketStatusLabel status={ticket.get('status')} />
-              <span className={csCss.category}>{ticket.get('category').name}</span>
               {' '}
               <span>
                 <UserLabel user={ticket.get('author')} /> 创建于 <span title={moment(ticket.get('createdAt')).format()}>{moment(ticket.get('createdAt')).fromNow()}</span>
@@ -323,9 +323,6 @@ export default class Ticket extends Component {
                   <span>，更新于 <span title={moment(ticket.get('updatedAt')).format()}>{moment(ticket.get('updatedAt')).fromNow()}</span></span>
                 }
               </span>
-              {ticket.get('assignee') &&
-                <span>，当前负责人 <span className={css.assignee}><UserLabel user={ticket.get('assignee')} /></span></span>
-              }
             </div>
             <hr />
           </div>
@@ -367,8 +364,21 @@ export default class Ticket extends Component {
           <div className={'col-sm-4 ' + css.sidebar}>
             <div>{tags}</div>
 
+            {ticket.get('assignee') &&
+              <FormGroup>
+                <label className="label-block">负责人</label>
+                <span className={css.assignee}><UserLabel user={ticket.get('assignee')} /></span>
+              </FormGroup>
+            }
+
+            <FormGroup>
+              <label className="label-block">类别</label>
+              <span className={csCss.category + ' ' + css.categoryBlock}>{ticket.get('category').name}</span>
+            </FormGroup>
+
             {isTicketOpen(ticket) &&
               <div>
+                <hr />
                 <UpdateTicket ticket={ticket}
                   isCustomerService={this.props.isCustomerService}
                   updateTicketCategory={this.updateTicketCategory.bind(this)}

--- a/modules/UpdateTicket.js
+++ b/modules/UpdateTicket.js
@@ -58,15 +58,15 @@ export default class UpdateTicket extends Component {
     })
     return <div>
       <FormGroup>
-        <ControlLabel>修改类别</ControlLabel>
-        <FormControl componentClass='select' value={this.props.ticket.get('category').objectId} onChange={this.handleCategoryChange.bind(this)}>
-          {categoryOptions}
-        </FormControl>
-      </FormGroup>
-      <FormGroup>
         <ControlLabel>修改负责人</ControlLabel>
         <FormControl componentClass='select' value={this.props.ticket.get('assignee').id} onChange={this.handleAssigneeChange.bind(this)}>
           {assigneesOptions}
+        </FormControl>
+      </FormGroup>
+      <FormGroup>
+        <ControlLabel>修改类别</ControlLabel>
+        <FormControl componentClass='select' value={this.props.ticket.get('category').objectId} onChange={this.handleCategoryChange.bind(this)}>
+          {categoryOptions}
         </FormControl>
       </FormGroup>
     </div>

--- a/public/index.css
+++ b/public/index.css
@@ -116,3 +116,7 @@ body,
 .timestamp:hover {
   color: #3090e4;
 }
+
+.label-block {
+  display: block;
+}


### PR DESCRIPTION
麻烦 @sparanoid 看下样式是否需要调整。

![image](https://user-images.githubusercontent.com/1127984/28349594-6178b414-6c76-11e7-89c5-efdf11e6d5af.png)
