### PR TITLE
fix: 在渲染前对 joinedCustomerServices 去重

### DIFF
--- a/modules/CustomerServiceTickets.js
+++ b/modules/CustomerServiceTickets.js
@@ -162,7 +162,7 @@ export default class CustomerServiceTickets extends Component {
     const filters = this.props.location.query
     const tickets = this.state.tickets
     const ticketTrs = tickets.map((ticket) => {
-      const customerServices = (ticket.get('joinedCustomerServices') || []).map((user) => {
+      const customerServices = _.uniqBy(ticket.get('joinedCustomerServices') || [], 'objectId').map((user) => {
         return (
           <span key={user.objectId}><UserLabel user={user} /> </span>
         )

--- a/modules/Tickets.js
+++ b/modules/Tickets.js
@@ -46,7 +46,7 @@ export default class Tickets extends Component {
 
   render() {
     const ticketLinks = this.state.tickets.map((ticket) => {
-      const customerServices = (ticket.get('joinedCustomerServices') || []).map((user) => {
+      const customerServices = _.uniqBy(ticket.get('joinedCustomerServices') || [], 'objectId').map((user) => {
         return (
           <span key={user.objectId}><UserLabel user={user} /> </span>
         )


### PR DESCRIPTION
修复 React 打印的 Encountered two children with the same key 警告。

mongo 比较两个 Object 的时候会受 key 顺序的影响。
在
 https://github.com/leancloud/ticket/commit/d7ecb6997215aa41ed4da3a970f9bf8e69090872#diff-4eab0151cec66b2872440caad75abb1cR46 这次数据订正中，
joinedCustomerServices 被添加了 name 字段。但是在之后再 addUnique 的时候 mongo 认为这两个 Object 是不同的。