### PR TITLE
便于工单 review 的细节修改

### DIFF
--- a/api/oauth.js
+++ b/api/oauth.js
@@ -205,11 +205,11 @@ AV.Cloud.define('getLeanCloudAppUrl', (req) => {
     }
     const {appId, region} = req.params
     if (region === 'cn-e1') {
-      return format(config.leancloudAppUrl, 'admin-e1', appId)
+      return format(config.leancloudAppUrl, 'cn', appId)
     } else if (region === 'us-w1') {
-      return format(config.leancloudAppUrl, 'admin-us', appId)
+      return format(config.leancloudAppUrl, 'app', appId)
     } else {
-      return format(config.leancloudAppUrl, 'admin', appId)
+      return format(config.leancloudAppUrl, 'cn', appId)
     }
   })
 })

--- a/lib/common.js
+++ b/lib/common.js
@@ -10,6 +10,10 @@ exports.TIME_RANGE_MAP = {
   '上月更新':{
     starts:moment().startOf('month').subtract('month',1).toDate(),
     ends: moment().endOf('month').subtract('month',1).endOf('month').toDate()
+  },
+  '两月前':{
+    starts:moment().startOf('month').subtract('month',2).toDate(),
+    ends: moment().endOf('month').subtract('month',2).endOf('month').toDate()
   }
 }
 

--- a/modules/CustomerServiceTickets.js
+++ b/modules/CustomerServiceTickets.js
@@ -72,8 +72,8 @@ export default class CustomerServiceTickets extends Component {
     }
 
     if(timeRange){
-      query.greaterThanOrEqualTo('updatedAt', TIME_RANGE_MAP[timeRange].starts)
-      query.lessThan('updatedAt', TIME_RANGE_MAP[timeRange].ends)
+      query.greaterThanOrEqualTo('createdAt', TIME_RANGE_MAP[timeRange].starts)
+      query.lessThan('createdAt', TIME_RANGE_MAP[timeRange].ends)
     }
 
     if (statuses.length !== 0) {
@@ -113,14 +113,14 @@ export default class CustomerServiceTickets extends Component {
       if (searchString && searchString.trim().length > 0) {
         return Promise.all([
           new AV.SearchQuery('Ticket').queryString(`title:*${searchString}* OR content:*${searchString}*`)
-            .addDescending('updatedAt')
+            .addDescending('latestReply.updatedAt')
             .limit(1000)
             .find()
             .then(tickets => {
               return tickets.map(t => t.id)
             }),
           new AV.SearchQuery('Reply').queryString(`content:*${searchString}*`)
-            .addDescending('updatedAt')
+            .addDescending('latestReply.updatedAt')
             .limit(1000)
             .find()
         ])
@@ -136,7 +136,7 @@ export default class CustomerServiceTickets extends Component {
       .include('assignee')
       .limit(parseInt(size))
       .skip(parseInt(page) * parseInt(size))
-      .addDescending('updatedAt')
+      .addDescending('latestReply.updatedAt')
       .find()
       .then(tickets => {
         tickets.forEach(t => {
@@ -385,6 +385,7 @@ export default class CustomerServiceTickets extends Component {
                   <MenuItem key='undefined'>全部时间</MenuItem>
                   <MenuItem key='本月更新' eventKey='本月更新'>本月更新</MenuItem>
                   <MenuItem key='上月更新' eventKey="上月更新">上月更新</MenuItem>
+                  <MenuItem key='两月前' eventKey="两月前">两月前</MenuItem>
                 </DropdownButton>
               </ButtonGroup>
             </ButtonToolbar>


### PR DESCRIPTION
解决 review 工单的时候遇到的问题：

* 客服工单列表按照最后一条回复时间排序（新增标签不影响客服列表展示）
* 可以 review 两月前工单
* 工单的「上月/上月/两月前」按照工单创建时间而不是更新时间更便于 review。
