### PR TITLE
docs(readme): markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ npm run dev:client
 
 [LeanTicket Demo](https://ticket-demo.avosapps.us/)
 
-用户名 | 密码 | 角色
-- | - | -
-demo | demo | 客服
-test | test | 用户
+| 用户名 | 密码 | 角色 |
+| - | - | - |
+| demo | demo | 客服 |
+| test | test | 用户 |
 
 ### 内部贡献
 


### PR DESCRIPTION
It seems that omitting beginning and ending `|` in table
renders incorrectly on GitHub README.