### PR TITLE
feat: user tags & mark new users in stats

### DIFF
--- a/api/User.js
+++ b/api/User.js
@@ -59,3 +59,22 @@ const addRole = (name, initUser) => {
   return role.save()
 }
 
+AV.Cloud.define('modifyUserTags', async (req) => {
+  if (! await common.isCustomerService(req.currentUser)) {
+    throw new AV.Cloud.Error('unauthorized', {status: 401})
+  }
+
+  const {objectId, tags, action} = req.params
+  const user = AV.Object.createWithoutData('_User', objectId)
+  switch (action) {
+  case 'add':
+    user.addUnique('tags', tags)
+    break
+  case 'remove':
+    user.remove('tags', tags)
+    break
+  default:
+    throw new AV.Cloud.Error('unsupport action: ' + action, {status: 400})
+  }
+  return user.save(null, {useMasterKey: true})
+})

--- a/lib/common.js
+++ b/lib/common.js
@@ -41,6 +41,26 @@ exports.TICKET_STATUS_MSG = {
   [exports.TICKET_STATUS.REJECTED]: '已关闭',
 }
 
+exports.USER_TAG_NAME = {
+  NEW: 'new',
+  LONG_TERM: 'long-term',
+  MAJOR: 'major'
+}
+
+exports.USER_TAG = {
+  [exports.USER_TAG_NAME.NEW]: {
+    name: '新用户',
+    tip: '本月注册的用户'
+  },
+  [exports.USER_TAG_NAME.LONG_TERM]: {
+    name: '老用户',
+    tip: '注册时间超过2年的用户'
+  },
+  [exports.USER_TAG_NAME.MAJOR]: {
+    name: '大用户'
+  }
+}
+
 exports.ticketOpenedStatuses = () => {
   return [
     exports.TICKET_STATUS.NEW,
@@ -130,7 +150,8 @@ exports.getTinyUserInfo = (user) => {
       objectId: user.id,
       username: user.get('username'),
       name: user.get('name'),
-      gravatarHash: exports.getGravatarHash(user.get('email'))
+      gravatarHash: exports.getGravatarHash(user.get('email')),
+      tags: exports.getUserTags(user)
     })
   }
   return user.fetch().then((user) => {
@@ -138,7 +159,8 @@ exports.getTinyUserInfo = (user) => {
       objectId: user.id,
       username: user.get('username'),
       name: user.get('name'),
-      gravatarHash: exports.getGravatarHash(user.get('email'))
+      gravatarHash: exports.getGravatarHash(user.get('email')),
+      tags: exports.getUserTags(user)
     }
   })
 }
@@ -211,3 +233,19 @@ exports.getTicketAcl = (ticketAuthor, organization) => {
 }
 
 exports.getUserDisplayName = user => user.get('name') || user.get('username')
+
+exports.getUserTags = (user) => {
+  const userTags = []
+  const now = moment()
+  const createdAt = moment(user.get('createdAt'))
+  if (createdAt.diff(now.startOf('month'), 'month') === 0) {
+    userTags.push(exports.USER_TAG_NAME.NEW)
+  }
+  if (now.diff(createdAt, 'year') >= 2) {
+    userTags.push(exports.USER_TAG_NAME.LONG_TERM)
+  }
+  if (user.has('tags')) {
+    user.get('tags').forEach(tag => userTags.push(tag))
+  }
+  return _.uniq(userTags)
+}

--- a/lib/common.js
+++ b/lib/common.js
@@ -43,20 +43,20 @@ exports.TICKET_STATUS_MSG = {
 
 exports.USER_TAG_NAME = {
   NEW: 'new',
-  LONG_TERM: 'long-term',
-  MAJOR: 'major'
+  EARLY_ADOPTER: 'early-adopter',
+  VIP: 'vip'
 }
 
 exports.USER_TAG = {
   [exports.USER_TAG_NAME.NEW]: {
     name: '新用户',
-    tip: '本月注册的用户'
+    tip: '注册时间小于3个月的用户'
   },
-  [exports.USER_TAG_NAME.LONG_TERM]: {
+  [exports.USER_TAG_NAME.EARLY_ADOPTER]: {
     name: '老用户',
     tip: '注册时间超过2年的用户'
   },
-  [exports.USER_TAG_NAME.MAJOR]: {
+  [exports.USER_TAG_NAME.VIP]: {
     name: '大用户'
   }
 }
@@ -238,11 +238,11 @@ exports.getUserTags = (user) => {
   const userTags = []
   const now = moment()
   const createdAt = moment(user.get('createdAt'))
-  if (createdAt.diff(now.startOf('month'), 'month') === 0) {
+  if (now.diff(createdAt, 'month') <= 3) {
     userTags.push(exports.USER_TAG_NAME.NEW)
   }
   if (now.diff(createdAt, 'year') >= 2) {
-    userTags.push(exports.USER_TAG_NAME.LONG_TERM)
+    userTags.push(exports.USER_TAG_NAME.EARLY_ADOPTER)
   }
   if (user.has('tags')) {
     user.get('tags').forEach(tag => userTags.push(tag))

--- a/modules/CustomerServiceStats.js
+++ b/modules/CustomerServiceStats.js
@@ -11,6 +11,8 @@ import randomColor from 'randomcolor'
 import Color from 'color'
 import DocumentTitle from 'react-document-title'
 import {getUserDisplayName} from './common'
+import { UserTagGroup } from './components/UserTag'
+import { getUserTags, USER_TAG_NAME } from '../lib/common'
 
 // 默认情况，周统计按照周日 23 点 59 分 59 秒作为统计周期分割
 // 可以通过修改统计偏移日期调整周期分割
@@ -489,10 +491,16 @@ class StatsSummary extends React.Component {
     const activeTicketCountByAuthorDoms = this.state.statsDatas.map(data => {
       const body = data.activeTicketCountByAuthor.map(row => {
         const user = _.find(this.state.users, c => c.id === row[0])
+        const username = (
+          <span>
+            {user && getUserDisplayName(user) || row[0]}
+            <UserTagGroup tags={getUserTags(user).filter(tag => tag === USER_TAG_NAME.NEW)} />
+          </span>
+        )
         return [
           row[0],
           row.index,
-          user && getUserDisplayName(user) || row[0],
+          username,
           row[1],
         ]
       })

--- a/modules/CustomerServiceTickets.js
+++ b/modules/CustomerServiceTickets.js
@@ -59,7 +59,7 @@ export default class CustomerServiceTickets extends Component {
     const {assigneeId, isOpen, status, categoryId, authorId,
       tagKey, tagValue, isOnlyUnlike, searchString, page = '0', size = '10', timeRange} = filters
     const query = new AV.Query('Ticket')
-    
+
     let statuses = []
     if (isOpen === 'true') {
       statuses = ticketOpenedStatuses()
@@ -267,7 +267,7 @@ export default class CustomerServiceTickets extends Component {
               <div className={css.left}>
                 <span className={css.nid}>#{ticket.get('nid')}</span>
                 <Link className={css.statusLink} to={this.getQueryUrl({status: ticket.get('status'), isOpen: undefined})}><span className={css.status}><TicketStatusLabel status={ticket.get('status')} /></span></Link>
-                <span className={css.creator}><UserLabel user={ticket.get('author')} /></span> 创建于 {moment(ticket.get('createdAt')).fromNow()}
+                <span className={css.creator}><UserLabel user={ticket.get('author')} displayTags /></span> 创建于 {moment(ticket.get('createdAt')).fromNow()}
                 {moment(ticket.get('createdAt')).fromNow() === moment(ticket.get('updatedAt')).fromNow() ||
                   <span>，更新于 {moment(ticket.get('updatedAt')).fromNow()}</span>
                 }
@@ -332,7 +332,7 @@ export default class CustomerServiceTickets extends Component {
       categoryTitle = '全部分类'
     }
 
-    
+
 
     const ticketAdminFilters = (
       <div>
@@ -382,10 +382,10 @@ export default class CustomerServiceTickets extends Component {
                 }
               </ButtonGroup>
               <ButtonGroup>
-                <DropdownButton 
-                  className={(filters.timeRange ? ' active' : '')} 
-                  id='timeRange' 
-                  title={TIME_RANGE_MAP[filters.timeRange]? TIME_RANGE_MAP[filters.timeRange].name : '全部时间'} 
+                <DropdownButton
+                  className={(filters.timeRange ? ' active' : '')}
+                  id='timeRange'
+                  title={TIME_RANGE_MAP[filters.timeRange]? TIME_RANGE_MAP[filters.timeRange].name : '全部时间'}
                   onSelect={(eventKey) => this.updateFilter({timeRange: eventKey})}
                 >
                     <MenuItem key='undefined'>全部时间</MenuItem>

--- a/modules/Ticket.js
+++ b/modules/Ticket.js
@@ -487,7 +487,7 @@ export default class Ticket extends Component {
               <TicketStatusLabel status={ticket.get('status')} />
               {' '}
               <span>
-                <UserLabel user={ticket.get('author')} /> 创建于 <span title={moment(ticket.get('createdAt')).format()}>{moment(ticket.get('createdAt')).fromNow()}</span>
+                <UserLabel user={ticket.get('author')} displayTags={isCustomerService} /> 创建于 <span title={moment(ticket.get('createdAt')).format()}>{moment(ticket.get('createdAt')).fromNow()}</span>
                 {moment(ticket.get('createdAt')).fromNow() === moment(ticket.get('updatedAt')).fromNow() ||
                   <span>，更新于 <span title={moment(ticket.get('updatedAt')).format()}>{moment(ticket.get('updatedAt')).fromNow()}</span></span>
                 }
@@ -857,7 +857,7 @@ class TicketMetadata extends Component {
           :
           <span className={css.assignee}>
             <UserLabel user={ticket.get('assignee')} />
-            {isCustomerService && 
+            {isCustomerService &&
               <Button bsStyle='link' onClick={() => this.setState({isUpdateAssignee: true})}>
                 <span className='glyphicon glyphicon-pencil' aria-hidden="true"></span>
               </Button>

--- a/modules/User.js
+++ b/modules/User.js
@@ -41,15 +41,19 @@ export default class User extends Component {
   }
 
   addTag(tag) {
-    const user = AV.Object.createWithoutData('_User', this.state.user.objectId)
-    user.addUnique('tags', tag)
-    return user.save().then(() => this.refreshUserInfo(this.props))
+    return AV.Cloud.run('modifyUserTags', {
+      objectId: this.state.user.objectId,
+      action: 'add',
+      tags: [tag]
+    }).then(() => this.refreshUserInfo(this.props))
   }
 
   removeTag(tag) {
-    const user = AV.Object.createWithoutData('_User', this.state.user.objectId)
-    user.remove('tags', tag)
-    return user.save().then(() => this.refreshUserInfo(this.props))
+    return AV.Cloud.run('modifyUserTags', {
+      objectId: this.state.user.objectId,
+      action: 'remove',
+      tags: [tag]
+    }).then(() => this.refreshUserInfo(this.props))
   }
 
   render() {

--- a/modules/User.js
+++ b/modules/User.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import AV from 'leancloud-storage/live-query'
 import {Avatar} from './common'
 import css from './User.css'
+import {UserTagManager} from './components/UserTag'
 
 export default class User extends Component {
 
@@ -39,6 +40,18 @@ export default class User extends Component {
     })
   }
 
+  addTag(tag) {
+    const user = AV.Object.createWithoutData('_User', this.state.user.objectId)
+    user.addUnique('tags', tag)
+    return user.save().then(() => this.refreshUserInfo(this.props))
+  }
+
+  removeTag(tag) {
+    const user = AV.Object.createWithoutData('_User', this.state.user.objectId)
+    user.remove('tags', tag)
+    return user.save().then(() => this.refreshUserInfo(this.props))
+  }
+
   render() {
     if (!this.state.user) {
       return <div>读取中……</div>
@@ -52,6 +65,9 @@ export default class User extends Component {
           </div>
           <div className={css.info}>
             <h2>{this.state.user.username}</h2>
+            {this.props.isCustomerService && (
+              <UserTagManager tags={this.state.user.tags} onAdd={this.addTag.bind(this)} onRemove={this.removeTag.bind(this)} />
+            )}
             <p><Link to={`/customerService/tickets?authorId=${this.state.user.objectId}&page=0&size=10`}>工单列表</Link></p>
             {this.state.leancloudUsers &&
               <div>
@@ -88,6 +104,9 @@ export default class User extends Component {
       </div>
     )
   }
+}
+User.propTypes = {
+  isCustomerService: PropTypes.bool
 }
 
 const LeanCloudApps = (props) => {

--- a/modules/common.js
+++ b/modules/common.js
@@ -12,6 +12,8 @@ import {
 import _ from 'lodash'
 import validUrl from 'valid-url'
 import AV from 'leancloud-storage/live-query'
+import {UserTagGroup} from './components/UserTag'
+import {getUserTags} from '../lib/common'
 
 Object.assign(exports, require('../lib/common'))
 
@@ -138,6 +140,7 @@ exports.UserLabel = props => {
       <Link to={'/users/' + username} className="username">
         {name}
       </Link>
+      {props.displayTags && <UserTagGroup tags={getUserTags(props.user)} />}
     </span>
   )
 }
@@ -145,7 +148,8 @@ exports.UserLabel = props => {
 exports.UserLabel.displayName = 'UserLabel'
 exports.UserLabel.propTypes = {
   user: PropTypes.object,
-  simple: PropTypes.bool
+  simple: PropTypes.bool,
+  displayTags: PropTypes.bool
 }
 
 exports.TicketStatusLabel = props => {

--- a/modules/components/UserTag/index.css
+++ b/modules/components/UserTag/index.css
@@ -14,12 +14,12 @@
   background-color: #21ba45;
 }
 
-.long-term {
+.early-adopter {
   color: #fff;
   background-color: #f2711c;
 }
 
-.major {
+.vip {
   color: #ffc107;
   background-color: #343a40;
 }

--- a/modules/components/UserTag/index.css
+++ b/modules/components/UserTag/index.css
@@ -1,0 +1,29 @@
+.tag {
+  margin: 0 0.3em;
+  padding: 0.3em 0.6em;
+  font-size: 0.85em;
+  font-weight: bold;
+  color: #555;
+  background-color: rgba(85,85,85,.1);
+  border-radius: 0.2em;
+  cursor: default;
+}
+
+.new {
+  color: #fff;
+  background-color: #21ba45;
+}
+
+.long-term {
+  color: #fff;
+  background-color: #f2711c;
+}
+
+.major {
+  color: #ffc107;
+  background-color: #343a40;
+}
+
+.manager {
+  margin: 1em 0;
+}

--- a/modules/components/UserTag/index.js
+++ b/modules/components/UserTag/index.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Checkbox, OverlayTrigger, Tooltip} from 'react-bootstrap'
+import {USER_TAG, USER_TAG_NAME} from '../../../lib/common'
+import css from './index.css'
+
+export function UserTag({tag}) {
+  if (tag in USER_TAG) {
+    const {name, tip} = USER_TAG[tag]
+    const content = <span className={`${css.tag} ${css[tag]}`}>{name}</span>
+    return tip
+      ? (
+        <OverlayTrigger placement="bottom" overlay={<Tooltip id={`${tag}-tip`}>{tip}</Tooltip>}>
+          {content}
+        </OverlayTrigger>
+      )
+      : content
+  }
+  return <span className={css.tag}>{tag}</span>
+}
+UserTag.propTypes = {
+  tag: PropTypes.string
+}
+
+export function UserTagGroup({tags}) {
+  if (!tags || tags.length === 0) {
+    return null
+  }
+  return (
+    <span>
+      {tags.map(tag => <UserTag key={tag} tag={tag} />)}
+    </span>
+  )
+}
+UserTagGroup.propTypes = {
+  tags: PropTypes.arrayOf(PropTypes.string)
+}
+
+export class UserTagManager extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      loading: false
+    }
+  }
+
+  toggleTag(tag) {
+    let ret
+    if (this.props.tags.includes(tag)) {
+      ret = this.props.onRemove(tag)
+    } else {
+      ret = this.props.onAdd(tag)
+    }
+    if (typeof ret.finally === 'function') {
+      this.setState({loading: true})
+      return ret.finally(() => this.setState({loading: false}))
+    }
+  }
+
+  render() {
+    return (
+      <div className={css.manager}>
+        <UserTagGroup tags={this.props.tags} />
+        <div>
+          <Checkbox
+            checked={this.props.tags.includes(USER_TAG_NAME.MAJOR)}
+            onChange={() => this.toggleTag(USER_TAG_NAME.MAJOR)}
+            disabled={this.state.loading}
+          >
+            标记为{USER_TAG[USER_TAG_NAME.MAJOR].name}
+          </Checkbox>
+        </div>
+      </div>
+    )
+  }
+}
+UserTagManager.propTypes = {
+  tags: PropTypes.arrayOf(PropTypes.string),
+  onAdd: PropTypes.func,
+  onRemove: PropTypes.func
+}

--- a/modules/components/UserTag/index.js
+++ b/modules/components/UserTag/index.js
@@ -63,11 +63,11 @@ export class UserTagManager extends React.Component {
         <UserTagGroup tags={this.props.tags} />
         <div>
           <Checkbox
-            checked={this.props.tags.includes(USER_TAG_NAME.MAJOR)}
-            onChange={() => this.toggleTag(USER_TAG_NAME.MAJOR)}
+            checked={this.props.tags.includes(USER_TAG_NAME.VIP)}
+            onChange={() => this.toggleTag(USER_TAG_NAME.VIP)}
             disabled={this.state.loading}
           >
-            标记为{USER_TAG[USER_TAG_NAME.MAJOR].name}
+            标记为{USER_TAG[USER_TAG_NAME.VIP].name}
           </Checkbox>
         </div>
       </div>

--- a/resources/schema/_User.json
+++ b/resources/schema/_User.json
@@ -58,6 +58,9 @@
     },
     "salt": {
       "type": "String"
+    },
+    "tags":{
+      "type": "Array"
     }
   },
   "permissions": {


### PR DESCRIPTION
本 PR 新增了两个功能

### 在工单回复页面顶部 / 客服工单列表中增加用户标签

仅在客服视角下展示用户标签。目前的标签有以下 3 种：

名称|显示为|说明
-|-|-
`new`|新用户|注册时间小于3个月的用户，前端自动添加
`early-adopter`|老用户|注册时间超过2年的用户，前端自动添加
`vip`|大用户|由客服在用户详情页面手动标注

可以在 [这里](https://ticket.sdjdd.com/) 预览下效果（要先控制台中把自己变为客服，appid: `02AXSPNhJaEqgBfHftLpIsj2-gzGzoHsz`） 。

客服手动标注的用户标签存放在 _User Class 中的 `tags` (Array) 列中。

### 在统计页面中标注新用户

原需求为：新增本月（本周）的新用户活跃工单统计，即新添加一个表格展示新用户的工单统计。

因新用户的统计仅是原统计表格中的一小部分数据，在原表格中将其标出可以少创建一个表格。

预览图：
![image](https://user-images.githubusercontent.com/33412425/101336120-06d83200-38b5-11eb-9cc8-5c608573cfdd.png)

请 @SXiaoXu 确认下是否可以使用这种方式实现。
