### PR TITLE
build: use upstream version of remarkable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8461,27 +8461,12 @@
       }
     },
     "remarkable": {
-      "version": "git+ssh://git@github.com/leeyeh/remarkable.git#1bfaefe6c037ca58ec7277f90bcea2a5864717c8",
-      "from": "remarkable@leeyeh/remarkable",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
       "requires": {
-        "argparse": "~0.1.15",
+        "argparse": "^1.0.10",
         "autolinker": "~0.28.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-          "requires": {
-            "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
-          }
-        },
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        }
       }
     },
     "remove-trailing-separator": {
@@ -10011,11 +9996,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
     "unescape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-dom": "^15.4.2",
     "react-notification-system": "^0.2.14",
     "react-router": "^3.0.2",
-    "remarkable": "leeyeh/remarkable",
+    "remarkable": "^1.7.2",
     "request": "^2.87.0",
     "request-promise": "^4.1.1",
     "serve-favicon": "^2.4.3",


### PR DESCRIPTION
Using a fork is unnecessary since
jonschlinkert/remarkable#277 has been merged
and released in 1.7.2.
