### PR TITLE
feat(Ticket): rename status REJECTED to CLOSED

### DIFF
--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -175,8 +175,10 @@ const getTargetStatus = (action, isCustomerService) => {
     return TICKET_STATUS.WAITING_CUSTOMER_SERVICE
   case 'resolve':
     return isCustomerService ? TICKET_STATUS.PRE_FULFILLED : TICKET_STATUS.FULFILLED
+  case 'close':
+  // 向前兼容
   case 'reject':
-    return TICKET_STATUS.REJECTED
+    return TICKET_STATUS.CLOSED
   case 'reopen':
     return TICKET_STATUS.WAITING_CUSTOMER
   default:

--- a/lib/common.js
+++ b/lib/common.js
@@ -26,7 +26,7 @@ exports.TICKET_STATUS = {
   // 200~299 处理完成
   PRE_FULFILLED: 220, // 技术支持人员点击“解决”时会设置该状态，用户确认后状态变更为 FULFILLED
   FULFILLED: 250, // 已解决
-  REJECTED: 280, // 已关闭
+  CLOSED: 280, // 已关闭
 }
 
 exports.TICKET_STATUS_MSG = {
@@ -35,7 +35,7 @@ exports.TICKET_STATUS_MSG = {
   [exports.TICKET_STATUS.WAITING_CUSTOMER]: 'statusWaitingCustomer',
   [exports.TICKET_STATUS.PRE_FULFILLED]: 'statusPreFulfilled',
   [exports.TICKET_STATUS.FULFILLED]: 'statusFulfilled',
-  [exports.TICKET_STATUS.REJECTED]: 'statusRejected',
+  [exports.TICKET_STATUS.CLOSED]: 'statusClosed',
 }
 
 exports.USER_TAG_NAME = {
@@ -70,7 +70,7 @@ exports.ticketClosedStatuses = () => {
   return [
     exports.TICKET_STATUS.PRE_FULFILLED,
     exports.TICKET_STATUS.FULFILLED,
-    exports.TICKET_STATUS.REJECTED,
+    exports.TICKET_STATUS.CLOSED,
   ]
 }
 

--- a/modules/TicketStatusLabel.js
+++ b/modules/TicketStatusLabel.js
@@ -8,7 +8,7 @@ const TicketStatusLabel = (props) => {
   switch (props.status) {
   case TICKET_STATUS.FULFILLED:
     return <span className='label label-success'>{t(TICKET_STATUS_MSG[props.status])}</span>
-  case TICKET_STATUS.REJECTED:
+  case TICKET_STATUS.CLOSED:
     return <span className='label label-default'>{t(TICKET_STATUS_MSG[props.status])}</span>
   case TICKET_STATUS.PRE_FULFILLED:
     return <span className='label label-primary'>{t(TICKET_STATUS_MSG[props.status])}</span>

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -869,7 +869,7 @@ const messages = {
     'Resolved',
     '已解决'
   ],
-  'statusRejected': [
+  'statusClosed': [
     'Closed',
     '已关闭'
   ]


### PR DESCRIPTION
在整理工单状态机的时候发现，「关闭工单」操作 reject 以及对应的状态 REJECTED 特别难理解。所以重命名为 close / CLOSED。

我理解 reject 是与 fulfill 相对的，但「二次确认」应该是一个可选的功能，如果不需要的话，只剩一个 reject 很不好理解。而且实际上文案都是用的「关闭」这个词，所以不如直接一点用 close / CLOSED。

状态转移如图所示： https://sketchviz.com/@leeyeh/bf19ae9be26aa29c8b16b3d4f6721556/6c3065a73860a2b2da2b726807706597cd5b4a4f