### PR TITLE
fix(NewTicket): category level

### DIFF
--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -236,7 +236,7 @@ class NewTicket extends React.Component {
       })
       return (
         <FormGroup key={'categorySelect' + index}>
-          <ControlLabel>{index == 0 ? t('category') + ' ' : t('categoryLevel') + ' ' + index + 1 + ' ' + t('thCategory') + ' '}</ControlLabel>
+          <ControlLabel>{index == 0 ? t('category') + ' ' : t('categoryLevel') + ' ' + (index + 1) + ' ' + t('thCategory') + ' '}</ControlLabel>
           <FormControl componentClass="select" value={selectCategory && selectCategory.id || ''} onChange={(e) => this.handleCategoryChange(e, index, t)}>
             <option key='empty'></option>
             {options}


### PR DESCRIPTION
number + string 会变成 string ，导致 「2 级菜单」显示为「11 级菜单」。