### PR TITLE
refactor: 将 LeanCloud 相关的功能收敛为一个开关

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,5 +37,5 @@ module.exports = {
   supportEmail: 'ask@leancloud.rocks',
   // Used in CustomerServiceStats.
   // 0/-1/-2/...: a week ends at 23:59:59 Sunday/Saturday/Friday/...
-  offsetDays: -3
+  offsetDays: Number(process.env.OFFSET_DAYS || '0')
 }

--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ module.exports = {
   host,
   oauthKey: process.env.OAUTH_KEY,
   oauthSecret: process.env.OAUTH_SECRET,
+  enableLeanCloudIntergration: process.env.ENABLE_LEANCLOUD_INTERGRATION,
   leancloudAppUrl: process.env.LEANCLOUD_APP_URL_V2,
   mailgunKey: process.env.MAILGUN_KEY,
   mailgunDomain: process.env.MAILGUN_DOMAIN,

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto')
+const md5 = require('blueimp-md5')
 const _ = require('lodash')
 const moment = require('moment')
 
@@ -78,12 +78,7 @@ exports.isTicketOpen = (ticket) => {
   return exports.ticketOpenedStatuses().indexOf(ticket.get('status')) != -1
 }
 
-exports.getGravatarHash = (email) => {
-  email = email || ''
-  const shasum = crypto.createHash('md5')
-  shasum.update(email.trim().toLocaleLowerCase())
-  return shasum.digest('hex')
-}
+exports.getGravatarHash = (email) => md5(email.trim().toLocaleLowerCase() || '')
 
 const regionMetadatas = [
   {
@@ -138,28 +133,20 @@ exports.getLeanCloudRegionText = (region) => {
   return metadata.regionText
 }
 
-exports.getTinyUserInfo = (user) => {
+exports.getTinyUserInfo = async (user) => {
   if (!user) {
-    return Promise.resolve()
+    return
   }
-  if (user.get('username')) {
-    return Promise.resolve({
-      objectId: user.id,
-      username: user.get('username'),
-      name: user.get('name'),
-      gravatarHash: exports.getGravatarHash(user.get('email')),
-      tags: exports.getUserTags(user)
-    })
+  if (!user.get('username')) {
+    await user.fetch()
   }
-  return user.fetch().then((user) => {
-    return {
-      objectId: user.id,
-      username: user.get('username'),
-      name: user.get('name'),
-      gravatarHash: exports.getGravatarHash(user.get('email')),
-      tags: exports.getUserTags(user)
-    }
-  })
+  return {
+    objectId: user.id,
+    username: user.get('username'),
+    name: user.get('name'),
+    gravatarHash: exports.getGravatarHash(user.get('email') || user.get('username')),
+    tags: exports.getUserTags(user)
+  }
 }
 
 exports.makeTree = (objs) => {

--- a/lib/common.js
+++ b/lib/common.js
@@ -144,7 +144,6 @@ exports.getTinyUserInfo = async (user) => {
     objectId: user.id,
     username: user.get('username'),
     name: user.get('name'),
-    gravatarHash: exports.getGravatarHash(user.get('email') || user.get('username')),
     tags: exports.getUserTags(user)
   }
 }

--- a/modules/App.js
+++ b/modules/App.js
@@ -6,7 +6,6 @@ import Raven from 'raven-js'
 
 import {auth, db} from '../lib/leancloud'
 import { isCustomerService } from './common'
-import { getGravatarHash } from '../lib/common'
 import GlobalNav from './GlobalNav'
 import css from './App.css'
 import {locale} from './i18n/I18nProvider'
@@ -121,9 +120,6 @@ export default class App extends Component {
   updateCurrentUser(props) {
     const user = this.state.currentUser
     const data = _.clone(props)
-    if (props.email) {
-      data.gravatarHash = getGravatarHash(props.email)
-    }
     return user.update(data).then((user) => {
       Object.assign(user.data, data)
       this.setState({ currentUser: user })

--- a/modules/Login.js
+++ b/modules/Login.js
@@ -58,7 +58,8 @@ class Login extends Component {
     }
   }
 
-  handleLogin() {
+  handleLogin(e) {
+    e.preventDefault()
     return auth.login(this.state.username, this.state.password)
       .then(user => {
         this.props.onLogin(user)
@@ -107,12 +108,12 @@ class Login extends Component {
 
   render() {
     const {t} = this.props
-    if (USE_OAUTH === 'false') {
+    if (!USE_OAUTH) {
       return (
         <div className={css.wrap}>
           <h1 className="font-logo">{t('loginOrSignup')}</h1>
           <hr />
-          <form>
+          <form onSubmit={this.handleLogin.bind(this)}>
             <FormGroup>
               <ControlLabel>{t('username')}</ControlLabel>
               <FormControl
@@ -131,9 +132,8 @@ class Login extends Component {
             </FormGroup>
             <FormGroup>
               <Button
-                type="button"
+                type="submit"
                 bsStyle="primary"
-                onClick={this.handleLogin.bind(this)}
               >
                 {t('login')} 
               </Button>{' '}

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -1,4 +1,4 @@
-/*global $, ALGOLIA_API_KEY*/
+/*global $, ALGOLIA_API_KEY, ENABLE_LEANCLOUD_INTERGRATION*/
 import _ from 'lodash'
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -60,13 +60,13 @@ class NewTicket extends React.Component {
     .then(() => {
       return Promise.all([
         getCategoriesTree(),
-        cloud.run('getLeanCloudApps')
+        ENABLE_LEANCLOUD_INTERGRATION ? cloud.run('getLeanCloudApps')
         .catch((err) => {
           if (err.message.indexOf('Could not find LeanCloud authData:') === 0) {
             return []
           }
           throw err
-        }),
+        }) : Promise.resolve([]),
       ])
     })
     .then(([categoriesTree, apps]) => {
@@ -301,17 +301,18 @@ class NewTicket extends React.Component {
             <input type="text" className="form-control docsearch-input" value={ticket.title}
                onChange={this.handleTitleChange.bind(this)} />
           </FormGroup>
-          <FormGroup>
-            <ControlLabel>
-              {t('associatedApplication')} <OverlayTrigger placement="top" overlay={appTooltip}>
-                <span className='icon-wrap'><span className='glyphicon glyphicon-question-sign'></span></span>
-              </OverlayTrigger>
-            </ControlLabel>
-            <FormControl componentClass="select" value={this.state.appId} onChange={this.handleAppChange.bind(this)}>
-              <option key='empty'></option>
-              {appOptions}
-            </FormControl>
-          </FormGroup>
+          {ENABLE_LEANCLOUD_INTERGRATION && 
+            <FormGroup>
+              <ControlLabel>
+                {t('associatedApplication')} <OverlayTrigger placement="top" overlay={appTooltip}>
+                  <span className='icon-wrap'><span className='glyphicon glyphicon-question-sign'></span></span>
+                </OverlayTrigger>
+              </ControlLabel>
+              <FormControl componentClass="select" value={this.state.appId} onChange={this.handleAppChange.bind(this)}>
+                <option key='empty'></option>
+                {appOptions}
+              </FormControl>
+            </FormGroup>}
 
           {categorySelects}
 

--- a/modules/Tag.js
+++ b/modules/Tag.js
@@ -1,3 +1,4 @@
+/*global ENABLE_LEANCLOUD_INTERGRATION */
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {Label} from 'react-bootstrap'
@@ -8,7 +9,7 @@ import translate from './i18n/translate'
 class Tag extends Component {
 
   componentDidMount() {
-    if (this.props.tag.get('key') === 'appId') {
+    if (ENABLE_LEANCLOUD_INTERGRATION && this.props.tag.get('key') === 'appId') {
       const appId = this.props.tag.get('value')
       if (!appId) {
         return

--- a/modules/User.js
+++ b/modules/User.js
@@ -1,3 +1,4 @@
+/*global ENABLE_LEANCLOUD_INTERGRATION */
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {Link} from 'react-router'
@@ -29,8 +30,8 @@ class User extends Component {
     const username = props.params.username
     return Promise.all([
       cloud.run('getUserInfo', {username}),
-      props.isCustomerService ? cloud.run('getLeanCloudUserInfosByUsername', {username}) : null,
-      props.isCustomerService ? cloud.run('getLeanCloudAppsByUsername', {username}) : null,
+      ENABLE_LEANCLOUD_INTERGRATION && props.isCustomerService ? cloud.run('getLeanCloudUserInfosByUsername', {username}) : null,
+      ENABLE_LEANCLOUD_INTERGRATION && props.isCustomerService ? cloud.run('getLeanCloudAppsByUsername', {username}) : null,
     ]).then(([user, leancloudUsers, leancloudApps]) => {
       this.setState({
         user,

--- a/modules/common.js
+++ b/modules/common.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router'
 import {Image} from 'react-bootstrap'
 import _ from 'lodash'
 import {auth, db, storage} from '../lib/leancloud'
-import {depthFirstSearchFind, getUserDisplayName, makeTree, getUserTags} from '../lib/common'
+import {depthFirstSearchFind, getUserDisplayName, makeTree, getUserTags, getGravatarHash} from '../lib/common'
 import {UserTagGroup} from './components/UserTag'
 
 Object.assign(exports, require('../lib/common'))
@@ -146,12 +146,16 @@ exports.UserLabel.propTypes = {
 
 
 exports.Avatar = props => {
-  let src = `https://cdn.v2ex.com/gravatar/${props.user.gravatarHash ||
-    props.user.get('gravatarHash')}?s=${props.height || 16}&r=pg&d=identicon`
+  const { user, height, width } = props
+  let src = `https://cdn.v2ex.com/gravatar/${
+    user.gravatarHash ||
+    user.get('gravatarHash') ||
+    getGravatarHash(user.username || user.get('username'))
+  }?s=${height || 16}&r=pg&d=identicon`
   return (
     <Image
-      height={props.height || 16}
-      width={props.width || 16}
+      height={height || 16}
+      width={width || 16}
       src={src}
       rounded
     />

--- a/modules/common.js
+++ b/modules/common.js
@@ -118,7 +118,7 @@ exports.UserLabel = (props) => {
   const username =
     props.user.username ||
     (props.user.get ? props.user.get('username') : undefined)
-  const name = props.user.name || getUserDisplayName(props.user)
+  const name = props.user.name || getUserDisplayName(props.user) || username
 
   if (props.simple) {
     return <span>{name}</span>
@@ -147,10 +147,9 @@ exports.UserLabel.propTypes = {
 
 exports.Avatar = props => {
   const { user, height, width } = props
+  const userInfo = user.toJSON ? user.toJSON() : user
   let src = `https://cdn.v2ex.com/gravatar/${
-    user.gravatarHash ||
-    user.get('gravatarHash') ||
-    getGravatarHash(user.username || user.get('username'))
+    userInfo.gravatarHash || getGravatarHash(userInfo.username)
   }?s=${height || 16}&r=pg&d=identicon`
   return (
     <Image

--- a/modules/settings/Profile.js
+++ b/modules/settings/Profile.js
@@ -1,3 +1,4 @@
+/*global ENABLE_LEANCLOUD_INTERGRATION */
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {Form, FormGroup, ControlLabel, FormControl, Button} from 'react-bootstrap'
@@ -55,7 +56,7 @@ class Profile extends Component {
             </FormGroup>
             <Button type='button' onClick={this.handleSubmit.bind(this)}>{t('save')}</Button>
           </Form>
-          <AccountLink currentUser={this.props.currentUser} />
+          {ENABLE_LEANCLOUD_INTERGRATION && <AccountLink currentUser={this.props.currentUser} />}
         </div>
         <div className="col-md-4">
           <Form>

--- a/modules/settings/Vacation.js
+++ b/modules/settings/Vacation.js
@@ -170,7 +170,6 @@ class Vacation extends Component {
 }
   
 Vacation.propTypes = {
-  addNotification: PropTypes.func.isRequired,
   t: PropTypes.func
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1490,6 +1490,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
+    "blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.23.0",
     "bluebird": "^3.4.7",
+    "blueimp-md5": "^2.18.0",
     "bootstrap": "^3.3.7",
     "chart.js": "^2.7.2",
     "color": "^1.0.3",

--- a/server.js
+++ b/server.js
@@ -55,7 +55,8 @@ const getIndexPage = () => {
   LEAN_CLI_HAVE_STAGING = '${process.env.LEAN_CLI_HAVE_STAGING}'
   SENTRY_DSN_PUBLIC = '${config.sentryDSNPublic || ''}'
   ORG_NAME = '${orgName}'
-  USE_OAUTH = '${!!process.env.OAUTH_KEY}'
+  USE_OAUTH = ${!!process.env.OAUTH_KEY}
+  ENABLE_LEANCLOUD_INTERGRATION = ${!!process.env.ENABLE_LEANCLOUD_INTERGRATION}
   ALGOLIA_API_KEY = '${process.env.ALGOLIA_API_KEY}'
   FAQ_VIEWS = '${process.env.FAQ_VIEWS || ''}'
 </script>


### PR DESCRIPTION
- 把 LeanCloud 相关的功能使用 ENABLE_LEANCLOUD_INTERGRATION 环境变量来控制。
- Avatar 组件，如果用户没有 email，使用 username 计算 hash。并且不再在 OpsLog 中冗余用户的 gravatarHash 了，除了 _User 表自带的冗余 hash，其他所有要显示头像的地方都在前端计算。

分别在 leanticket.cn 与 xd.leanticket.cn 测试了（需要客服权限的可以找我加）。