### PR TITLE
feat: workday statistics

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,5 +37,5 @@ module.exports = {
   supportEmail: 'ask@leancloud.rocks',
   // Used in CustomerServiceStats.
   // 0/-1/-2/...: a week ends at 23:59:59 Sunday/Saturday/Friday/...
-  offsetDays: Number(process.env.OFFSET_DAYS || '0')
+  offsetDays: (typeof window !== 'undefined' && window.ENABLE_LEANCLOUD_INTERGRATION) ? -3 : 0
 }

--- a/config.js
+++ b/config.js
@@ -37,5 +37,6 @@ module.exports = {
   supportEmail: 'ask@leancloud.rocks',
   // Used in CustomerServiceStats.
   // 0/-1/-2/...: a week ends at 23:59:59 Sunday/Saturday/Friday/...
-  offsetDays: (typeof window !== 'undefined' && window.ENABLE_LEANCLOUD_INTERGRATION) ? -3 : 0
+  offsetDays: Number(process.env.OFFSET_DAYS || '0'),
+  disableWeekendWarning: Boolean(process.env.DISABLE_WEEKEND_WARNING),
 }

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -7,6 +7,7 @@ import {auth, cloud, db} from '../lib/leancloud'
 import docsearch from 'docsearch.js'
 
 import TextareaWithPreview from './components/TextareaWithPreview'
+import {WeekendWarning} from './components/WeekendWarning'
 import {
   defaultLeanCloudRegion,
   depthFirstSearchFind,
@@ -292,6 +293,7 @@ class NewTicket extends React.Component {
     return (
       <div>
         <DocumentTitle title={`${t('newTicket')} - LeanTicket`} />
+        <WeekendWarning />
         <form onSubmit={this.handleSubmit.bind(this, t)}>
           {this.props.organizations.length > 0 && <OrganizationSelect organizations={this.props.organizations}
             selectedOrgId={this.props.selectedOrgId}

--- a/modules/StatsChart.js
+++ b/modules/StatsChart.js
@@ -8,7 +8,7 @@ import DatePicker from 'react-datepicker'
 import randomColor from 'randomcolor'
 import Color from 'color'
 import {fetchUsers} from './common'
-import offsetDays from '../config'
+import {offsetDays} from '../config'
 import translate from './i18n/translate'
 import {getUserDisplayName} from '../lib/common'
 import { cloud } from '../lib/leancloud'
@@ -218,7 +218,7 @@ class StatsChart extends React.Component {
         })
       })
   }
-  
+
   render() {
     const {t} = this.props
     return (
@@ -267,14 +267,11 @@ class StatsChart extends React.Component {
         </div>
     )
   }
-  
-  }
-  
+}
+
 StatsChart.propTypes = {
   categories: PropTypes.array.isRequired,
   t: PropTypes.func
 }
-  
+
 export default translate(StatsChart)
-  
-  

--- a/modules/StatsSummary.js
+++ b/modules/StatsSummary.js
@@ -204,7 +204,7 @@ class StatsSummary extends React.Component {
               <th>{t('createdTicket')}</th>
               <th>{t('activeTicket')}</th>
               <th>{t('averageFirstReplyTime')}</th>
-              <th>{t('workday') + t('averageFirstReplyTime')}</th>
+              <th>{t('averageFirstReplyTimeInTheWorkday')}</th>
               <th>{t('averageReplyTime')}</th>
             </tr>
           </thead>

--- a/modules/StatsSummary.js
+++ b/modules/StatsSummary.js
@@ -1,3 +1,5 @@
+/*global OFFSET_DAYS*/
+
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
@@ -6,7 +8,6 @@ import {Table, Button} from 'react-bootstrap'
 import {Link} from 'react-router'
 import {cloud, db} from '../lib/leancloud'
 import {fetchUsers} from './common'
-import {offsetDays} from '../config'
 import translate from './i18n/translate'
 import {getUserDisplayName} from '../lib/common'
 import { UserTagGroup } from './components/UserTag'
@@ -93,8 +94,8 @@ class StatsSummary extends React.Component {
       }
     } else {
       return {
-        startDate: moment().startOf('week').subtract(1, 'weeks').add(offsetDays, 'days'),
-        endDate: moment().startOf('week').add(1, 'weeks').add(offsetDays, 'days'),
+        startDate: moment().startOf('week').subtract(1, 'weeks').add(OFFSET_DAYS, 'days'),
+        endDate: moment().startOf('week').add(1, 'weeks').add(OFFSET_DAYS, 'days'),
         timeUnit: 'weeks',
       }
     }

--- a/modules/Ticket.js
+++ b/modules/Ticket.js
@@ -490,7 +490,7 @@ class Ticket extends Component {
       <div>
         <div className="row">
           <div className="col-sm-12">
-            <WeekendWarning />
+            {!isCustomerService && <WeekendWarning />}
             <DocumentTitle title={ticket.get('title') + ' - LeanTicket' || 'LeanTicket'} />
             <h1>{ticket.get('title')}</h1>
             <div className={css.meta}>

--- a/modules/Ticket.js
+++ b/modules/Ticket.js
@@ -18,6 +18,7 @@ import TicketReply from './TicketReply'
 import TicketStatusLabel from './TicketStatusLabel'
 import translate from './i18n/translate'
 import Tag from './Tag'
+import {WeekendWarning} from './components/WeekendWarning'
 
 // get a copy of default whiteList
 const whiteList = xss.getDefaultWhiteList()
@@ -489,6 +490,7 @@ class Ticket extends Component {
       <div>
         <div className="row">
           <div className="col-sm-12">
+            <WeekendWarning />
             <DocumentTitle title={ticket.get('title') + ' - LeanTicket' || 'LeanTicket'} />
             <h1>{ticket.get('title')}</h1>
             <div className={css.meta}>

--- a/modules/components/WeekendWarning/index.js
+++ b/modules/components/WeekendWarning/index.js
@@ -1,9 +1,14 @@
+/*global DISABLE_WEEKEND_WARNING*/
+
 import React from 'react'
 import {Alert} from 'react-bootstrap'
 
 import translate from '../../i18n/translate'
 
 export const WeekendWarning = translate(({t}) => {
+  if (DISABLE_WEEKEND_WARNING) {
+    return null
+  }
   const day = new Date().getDay()
   if (day >= 1 && day <= 5) {
     return null

--- a/modules/components/WeekendWarning/index.js
+++ b/modules/components/WeekendWarning/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {Alert} from 'react-bootstrap'
+
+import translate from '../../i18n/translate'
+
+export const WeekendWarning = translate(({t}) => {
+  const day = new Date().getDay()
+  if (day >= 1 && day <= 5) {
+    return null
+  }
+
+  return <Alert bsStyle="warning">{t('weekendWarning')}</Alert>
+})

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -195,8 +195,8 @@ const messages = {
     '总览'
   ],
   'weekendWarning': [
-    '', // TODO
-    '非工作日提醒：我们会尽快回复工单，请稍等'
+    'Your tickets is submitted out of hours. Please expect a delay in responses.',
+    '在周末或假期提交的工单，回复可能会有延迟。'
   ],
   'password': [
     'Password',

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -194,6 +194,14 @@ const messages = {
     'Overview',
     '总览'
   ],
+  'workday': [
+    'Workday',
+    '工作日'
+  ],
+  'weekendWarning': [
+    '', // TODO
+    '当前为非工作日，您的请求可能会被延迟受理。'
+  ],
   'password': [
     'Password',
     '密码'

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -194,10 +194,6 @@ const messages = {
     'Overview',
     '总览'
   ],
-  'workday': [
-    'Workday',
-    '工作日'
-  ],
   'weekendWarning': [
     '', // TODO
     '当前为非工作日，您的请求可能会被延迟受理。'
@@ -797,6 +793,10 @@ const messages = {
   'averageFirstReplyTime': [
     'Average first reply time',
     '平均首次响应'
+  ],
+  'averageFirstReplyTimeInTheWorkday': [
+    'Average first reply time in the workday',
+    '工作日平均首次响应'
   ],
   'toWeekly': [
     'Switch to weekly report',

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -196,7 +196,7 @@ const messages = {
   ],
   'weekendWarning': [
     '', // TODO
-    '当前为非工作日，您的请求可能会被延迟受理。'
+    '非工作日提醒：我们会尽快回复工单，请稍等'
   ],
   'password': [
     'Password',

--- a/server.js
+++ b/server.js
@@ -57,6 +57,8 @@ const getIndexPage = () => {
   ORG_NAME = '${orgName}'
   USE_OAUTH = ${!!process.env.OAUTH_KEY}
   ENABLE_LEANCLOUD_INTERGRATION = ${!!process.env.ENABLE_LEANCLOUD_INTERGRATION}
+  OFFSET_DAYS = '${config.offsetDays}'
+  DISABLE_WEEKEND_WARNING = ${config.disableWeekendWarning}
   ALGOLIA_API_KEY = '${process.env.ALGOLIA_API_KEY}'
   FAQ_VIEWS = '${process.env.FAQ_VIEWS || ''}'
 </script>

--- a/server.js
+++ b/server.js
@@ -57,7 +57,7 @@ const getIndexPage = () => {
   ORG_NAME = '${orgName}'
   USE_OAUTH = ${!!process.env.OAUTH_KEY}
   ENABLE_LEANCLOUD_INTERGRATION = ${!!process.env.ENABLE_LEANCLOUD_INTERGRATION}
-  OFFSET_DAYS = '${config.offsetDays}'
+  OFFSET_DAYS = ${config.offsetDays}
   DISABLE_WEEKEND_WARNING = ${config.disableWeekendWarning}
   ALGOLIA_API_KEY = '${process.env.ALGOLIA_API_KEY}'
   FAQ_VIEWS = '${process.env.FAQ_VIEWS || ''}'


### PR DESCRIPTION
Close #142

### 改动说明

#### 新增
- 增加工作日的响应时间统计
  ![image](https://user-images.githubusercontent.com/33412425/105658563-aacb7a80-5f01-11eb-93ae-35c3fa9a2c74.png)

- 周末提交工单时增加文字提醒，内容类似「非工作日提醒：我们会尽快回复工单，请稍等」之类的。
  周末时，在创建工单页、工单详情页（用户视角）下显示：
  ![image](https://user-images.githubusercontent.com/33412425/105658672-e8300800-5f01-11eb-9282-8ca62f8cbed3.png)


#### 修复
- 活跃工单数（分类）下面所有分类的统计数量累加与总览中活跃工单总数不一致
- 有的客服名字是 undefined
- 统计页新用户标签显示在客服列表中（可能是重构时粘错了）
- 获取 offsetDays 的逻辑
- 统计页组件补充 key 属性

#### 私货
- 删除未使用的云函数