### PR TITLE
fix(Ticket): ensure ACL by hook

### DIFF
--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -5,7 +5,7 @@ const common = require('./common')
 const {getTinyUserInfo, htmlify, getTinyReplyInfo} = common
 const oauth = require('./oauth')
 const notify = require('./notify')
-const {TICKET_STATUS, ticketClosedStatuses} = require('../lib/common')
+const {TICKET_STATUS, ticketClosedStatuses, getTicketAcl} = require('../lib/common')
 const errorHandler = require('./errorHandler')
 
 AV.Cloud.beforeSave('Ticket', (req, res) => {
@@ -22,6 +22,7 @@ AV.Cloud.beforeSave('Ticket', (req, res) => {
       throw new AV.Cloud.Error('category 不能为空')
     }
 
+    ticket.setACL(getTicketAcl(req.currentUser), ticket.get('organization'))
     ticket.set('status', TICKET_STATUS.NEW)
     ticket.set('content_HTML', htmlify(ticket.get('content')))
     ticket.set('author', req.currentUser)

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -12,7 +12,6 @@ import {
   defaultLeanCloudRegion,
   depthFirstSearchFind,
   getLeanCloudRegionText,
-  getTicketAcl,
   getTinyCategoryInfo
 } from '../lib/common'
 import {uploadFiles, getCategoriesTree} from './common'
@@ -38,7 +37,6 @@ class NewTicket extends React.Component {
         content: '',
         files: [],
         tags: [],
-        ACL: getTicketAcl(auth.currentUser(), org),
       },
       categoriesTree: [],
       apps: [],
@@ -204,7 +202,6 @@ class NewTicket extends React.Component {
             value: this.state.appId,
             ticket,
             author: auth.currentUser(),
-            ACL: getTicketAcl(auth.currentUser(), ticket.get('organization')),
           })
         }
         return

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -12,6 +12,7 @@ import {
   defaultLeanCloudRegion,
   depthFirstSearchFind,
   getLeanCloudRegionText,
+  getTicketAcl,
   getTinyCategoryInfo
 } from '../lib/common'
 import {uploadFiles, getCategoriesTree} from './common'
@@ -202,6 +203,7 @@ class NewTicket extends React.Component {
             value: this.state.appId,
             ticket,
             author: auth.currentUser(),
+            ACL: getTicketAcl(auth.currentUser(), ticket.get('organization')),
           })
         }
         return


### PR DESCRIPTION
Ticket 的 ACL 是在客户端指定的。这个 PR 把这个逻辑移到了 beforeSave hook 里。

@sdjcw 不是很确定当初这么设计是不是有什么玄机。