### PR TITLE
feat: config file of webapp

### DIFF
--- a/api/common.js
+++ b/api/common.js
@@ -112,3 +112,5 @@ exports.getCategoriesTree = (authOptions) => {
       return exports.makeTree(categories)
     })
 }
+
+exports.getUserDisplayName = (user) => user.get('name') || user.get('username')

--- a/config.js
+++ b/config.js
@@ -37,8 +37,4 @@ module.exports = {
   // Use HELP_EMAIL instead of SUPPORT_EMAIL, because there is a bug in LeanEngine.
   // See #1830 of LeanEngine repo (private) for more information.
   supportEmail: process.env.HELP_EMAIL,
-  // Used in CustomerServiceStats.
-  // 0/-1/-2/...: a week ends at 23:59:59 Sunday/Saturday/Friday/...
-  offsetDays: Number(process.env.OFFSET_DAYS || '0'),
-  disableWeekendWarning: Boolean(process.env.DISABLE_WEEKEND_WARNING),
 }

--- a/config.webapp.js
+++ b/config.webapp.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+
+export function userDisplayName(user, inCustomerServiceView = false) {
+  return user.data.name || user.data.username
+}
+
+export function customerServiceDisplayName(user) {
+  return userDisplayName(user)
+}

--- a/config.webapp.js
+++ b/config.webapp.js
@@ -7,3 +7,9 @@ export function userDisplayName(user, inCustomerServiceView = false) {
 export function customerServiceDisplayName(user) {
   return userDisplayName(user)
 }
+
+// Used in CustomerServiceStats.
+// 0/-1/-2/...: a week ends at 23:59:59 Sunday/Saturday/Friday/...
+export const offsetDays = -3
+
+export const enableWeekendWarning = true

--- a/lib/common.js
+++ b/lib/common.js
@@ -208,9 +208,6 @@ exports.getTicketAcl = (ticketAuthor, organization) => {
   return result
 }
 
-exports.getUserDisplayName = (user) =>
-  user.get ? user.get('name') || user.get('username') : undefined
-
 exports.getUserTags = (user) => {
   const userTags = []
   const now = moment()

--- a/modules/CustomerServiceTickets.js
+++ b/modules/CustomerServiceTickets.js
@@ -9,8 +9,9 @@ import {auth, cloud, db} from '../lib/leancloud'
 import css from './CustomerServiceTickets.css'
 import DocumentTitle from 'react-document-title'
 
+import {customerServiceDisplayName} from '../config.webapp'
 import {UserLabel, getCustomerServices, getCategoriesTree, depthFirstSearchMap, depthFirstSearchFind, getNodeIndentString, getNodePath, getTinyCategoryInfo, getCategoryName} from './common'
-import {TICKET_STATUS, TICKET_STATUS_MSG, ticketOpenedStatuses, ticketClosedStatuses, getUserDisplayName, TIME_RANGE_MAP} from '../lib/common'
+import {TICKET_STATUS, TICKET_STATUS_MSG, ticketOpenedStatuses, ticketClosedStatuses, TIME_RANGE_MAP} from '../lib/common'
 import TicketStatusLabel from './TicketStatusLabel'
 import translate from './i18n/translate'
 
@@ -272,7 +273,7 @@ class CustomerServiceTickets extends Component {
               <div className={css.left}>
                 <span className={css.nid}>#{ticket.get('nid')}</span>
                 <Link className={css.statusLink} to={this.getQueryUrl({status: ticket.get('status'), isOpen: undefined})}><span className={css.status}><TicketStatusLabel status={ticket.get('status')} /></span></Link>
-                <span className={css.creator}><UserLabel user={ticket.get('author')} displayTags /></span> {t('createdAt')} {moment(ticket.get('createdAt')).fromNow()}
+                <span className={css.creator}><UserLabel user={ticket.get('author')} inCustomerServiceView /></span> {t('createdAt')} {moment(ticket.get('createdAt')).fromNow()}
                 {moment(ticket.get('createdAt')).fromNow() === moment(ticket.get('updatedAt')).fromNow() ||
                   <span> {t('updatedAt')} {moment(ticket.get('updatedAt')).fromNow()}</span>
                 }
@@ -295,9 +296,11 @@ class CustomerServiceTickets extends Component {
       const value = TICKET_STATUS[key]
       return <MenuItem key={value} eventKey={value}>{t(TICKET_STATUS_MSG[value])}</MenuItem>
     })
-    const assigneeMenuItems = this.state.customerServices.map((user) => {
-      return <MenuItem key={user.id} eventKey={user.id}>{getUserDisplayName(user)}</MenuItem>
-    })
+    const assigneeMenuItems = this.state.customerServices.map((user) => (
+      <MenuItem key={user.id} eventKey={user.id}>
+        {customerServiceDisplayName(user)}
+      </MenuItem>
+    ))
     const categoryMenuItems = depthFirstSearchMap(this.state.categoriesTree, c => {
       return <MenuItem key={c.id} eventKey={c.id}>{getNodeIndentString(c) + getCategoryName(c, t)}</MenuItem>
     })
@@ -317,7 +320,7 @@ class CustomerServiceTickets extends Component {
     if (filters.assigneeId) {
       const assignee = this.state.customerServices.find(user => user.id === filters.assigneeId)
       if (assignee) {
-        assigneeTitle = getUserDisplayName(assignee)
+        assigneeTitle = customerServiceDisplayName(assignee)
       } else {
         assigneeTitle = `assigneeId ${t('invalid')}`
       }

--- a/modules/OrganizationSelect.js
+++ b/modules/OrganizationSelect.js
@@ -3,22 +3,24 @@ import PropTypes from 'prop-types'
 import {FormGroup, FormControl, ControlLabel} from 'react-bootstrap'
 import {auth} from '../lib/leancloud'
 import translate from './i18n/translate'
-import {getUserDisplayName} from '../lib/common'
+import {userDisplayName} from '../config.webapp'
 
 class OrganizationSelect extends React.Component {
 
   render() {
     const {t} = this.props
-    return <FormGroup controlId='orgSelect'>
-        <ControlLabel>{t('belong')}: </ControlLabel>
+    return (
+      <FormGroup controlId='orgSelect'>
+        <ControlLabel>{t('belong')}:&nbsp;</ControlLabel>
         <FormControl componentClass='select' value={this.props.selectedOrgId} onChange={this.props.onOrgChange}>
           {this.props.organizations.map(o => <option key={o.id} value={o.id}>{t('organization')}: {o.get('name')}</option>)}
-          <option value=''>{t('individual')}: {getUserDisplayName(auth.currentUser())}</option>
+          <option value=''>{t('individual')}: {userDisplayName(auth.currentUser())}</option>
         </FormControl>
       </FormGroup>
+    )
   }
 }
-  
+
 OrganizationSelect.propTypes = {
   organizations: PropTypes.array,
   selectedOrgId: PropTypes.string,

--- a/modules/StatsChart.js
+++ b/modules/StatsChart.js
@@ -8,9 +8,8 @@ import DatePicker from 'react-datepicker'
 import randomColor from 'randomcolor'
 import Color from 'color'
 import {fetchUsers} from './common'
-import {offsetDays} from '../config'
 import translate from './i18n/translate'
-import {userDisplayName} from '../config.webapp'
+import {offsetDays, userDisplayName} from '../config.webapp'
 import { cloud } from '../lib/leancloud'
 
 const ticketCountLineChartData = (statses, t) => {

--- a/modules/StatsChart.js
+++ b/modules/StatsChart.js
@@ -10,7 +10,7 @@ import Color from 'color'
 import {fetchUsers} from './common'
 import {offsetDays} from '../config'
 import translate from './i18n/translate'
-import {getUserDisplayName} from '../lib/common'
+import {userDisplayName} from '../config.webapp'
 import { cloud } from '../lib/leancloud'
 
 const ticketCountLineChartData = (statses, t) => {
@@ -29,7 +29,7 @@ const ticketCountLineChartData = (statses, t) => {
     }]
   })
 }
-  
+
 const replyCountLineChartData = (statses, t) => {
   return _.reduce(statses, (result, stats) => {
     result.labels.push(moment(stats.date).format('MM-DD'))
@@ -82,7 +82,7 @@ const categoryCountLineChartData = (statses, categories) => {
     datasets: []
   })
 }
-  
+
 const assigneeCountLineChartData = (statses, users) => {
   let index = 0
   return _.reduce(statses, (result, stats) => {
@@ -94,7 +94,7 @@ const assigneeCountLineChartData = (statses, users) => {
         const user = _.find(users, u => u.id === key)
         lineData = {
           id: key,
-          label: user && getUserDisplayName(user) || key,
+          label: user && userDisplayName(user, true) || key,
           fill: true,
           borderColor: color,
           backgroundColor: Color(color).fade(.9),
@@ -111,7 +111,7 @@ const assigneeCountLineChartData = (statses, users) => {
     datasets: []
   })
 }
-  
+
 const firstReplyTimeLineChartData = (statses, users) => {
   let index = 0
   return _.reduce(statses, (result, stats) => {
@@ -123,7 +123,7 @@ const firstReplyTimeLineChartData = (statses, users) => {
         const user = _.find(users, u => u.id === userId)
         lineData = {
           id: userId,
-          label: user && getUserDisplayName(user) || userId,
+          label: user && userDisplayName(user, true) || userId,
           fill: true,
           borderColor: color,
           backgroundColor: Color(color).fade(.9),
@@ -140,7 +140,7 @@ const firstReplyTimeLineChartData = (statses, users) => {
     datasets: []
   })
 }
-  
+
 const replyTimeLineChartData = (statses, users) => {
   let index = 0
   return _.reduce(statses, (result, stats) => {
@@ -152,7 +152,7 @@ const replyTimeLineChartData = (statses, users) => {
         const user = _.find(users, u => u.id === userId)
         lineData = {
           id: userId,
-          label: user && getUserDisplayName(user) || userId,
+          label: user && userDisplayName(user, true) || userId,
           fill: true,
           borderColor: color,
           backgroundColor: Color(color).fade(.9),
@@ -179,15 +179,15 @@ class StatsChart extends React.Component {
       endDate: moment().startOf('week').add(1, 'weeks').add(offsetDays, 'days'),
     }
   }
-  
+
   handleChangeStart(startDate) {
     this.setState({startDate})
   }
-  
+
   handleChangeEnd(endDate) {
     this.setState({endDate})
   }
-  
+
   handleSubmit(t, e) {
     e.preventDefault()
     let timeUnit = 'day'

--- a/modules/StatsSummary.js
+++ b/modules/StatsSummary.js
@@ -9,7 +9,7 @@ import {Link} from 'react-router'
 import {cloud, db} from '../lib/leancloud'
 import {fetchUsers} from './common'
 import translate from './i18n/translate'
-import {userDisplayName} from '../config.webapp'
+import {userDisplayName, customerServiceDisplayName} from '../config.webapp'
 import { UserTagGroup } from './components/UserTag'
 import { getUserTags, USER_TAG_NAME } from '../lib/common'
 
@@ -243,7 +243,7 @@ class StatsSummary extends React.Component {
         return [
           row[0],
           row.index,
-          user && userDisplayName(user, true) || row[0],
+          user && customerServiceDisplayName(user) || row[0],
           row[1],
         ]
       })
@@ -295,7 +295,7 @@ class StatsSummary extends React.Component {
         return [
           userId,
           index,
-          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && userDisplayName(user, true) || userId}</Link>,
+          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && customerServiceDisplayName(user) || userId}</Link>,
           (replyTime / replyCount / 1000 / 60 / 60).toFixed(2) + ' ' + t('hour'),
           replyCount,
         ]
@@ -312,7 +312,7 @@ class StatsSummary extends React.Component {
         return [
           userId,
           index,
-          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && userDisplayName(user, true) || userId}</Link>,
+          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && customerServiceDisplayName(user) || userId}</Link>,
           (replyTime / replyCount / 1000 / 60 / 60).toFixed(2) + ' ' + t('hour'),
           replyCount,
         ]

--- a/modules/StatsSummary.js
+++ b/modules/StatsSummary.js
@@ -1,5 +1,3 @@
-/*global OFFSET_DAYS*/
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
@@ -9,7 +7,7 @@ import {Link} from 'react-router'
 import {cloud, db} from '../lib/leancloud'
 import {fetchUsers} from './common'
 import translate from './i18n/translate'
-import {userDisplayName, customerServiceDisplayName} from '../config.webapp'
+import {offsetDays, userDisplayName, customerServiceDisplayName} from '../config.webapp'
 import { UserTagGroup } from './components/UserTag'
 import { getUserTags, USER_TAG_NAME } from '../lib/common'
 
@@ -94,8 +92,8 @@ class StatsSummary extends React.Component {
       }
     } else {
       return {
-        startDate: moment().startOf('week').subtract(1, 'weeks').add(OFFSET_DAYS, 'days'),
-        endDate: moment().startOf('week').add(1, 'weeks').add(OFFSET_DAYS, 'days'),
+        startDate: moment().startOf('week').subtract(1, 'weeks').add(offsetDays, 'days'),
+        endDate: moment().startOf('week').add(1, 'weeks').add(offsetDays, 'days'),
         timeUnit: 'weeks',
       }
     }

--- a/modules/StatsSummary.js
+++ b/modules/StatsSummary.js
@@ -9,7 +9,7 @@ import {Link} from 'react-router'
 import {cloud, db} from '../lib/leancloud'
 import {fetchUsers} from './common'
 import translate from './i18n/translate'
-import {getUserDisplayName} from '../lib/common'
+import {userDisplayName} from '../config.webapp'
 import { UserTagGroup } from './components/UserTag'
 import { getUserTags, USER_TAG_NAME } from '../lib/common'
 
@@ -29,12 +29,12 @@ class SummaryTable extends React.Component {
       isOpen: false
     }
   }
-  
+
   open(e) {
     e.preventDefault()
     this.setState({isOpen: true})
   }
-  
+
   render() {
     let trs
     const fn = (row) => {
@@ -65,12 +65,12 @@ class SummaryTable extends React.Component {
       </Table>
   }
 }
-  
+
 SummaryTable.propTypes = {
   header: PropTypes.array.isRequired,
   body: PropTypes.array.isRequired,
 }
-  
+
 
 class StatsSummary extends React.Component {
 
@@ -84,7 +84,7 @@ class StatsSummary extends React.Component {
       statsDatas: [],
     })
   }
-  
+
   getTimeRange(timeUnit) {
     if (timeUnit === 'month') {
       return {
@@ -103,7 +103,7 @@ class StatsSummary extends React.Component {
 
   fetchTickets(ids) {
     return Promise.all(
-      _.chunk(ids, 50).map(ids => 
+      _.chunk(ids, 50).map(ids =>
         db.class('Ticket')
           .select('author', 'assignee', 'category')
           .where('objectId', 'in', ids)
@@ -170,11 +170,11 @@ class StatsSummary extends React.Component {
       users: await fetchUsers(Array.from(userIdSet)),
     }
   }
-  
+
   componentDidMount() {
     this.changeTimeUnit('weeks')
   }
-  
+
   changeTimeUnit(timeUnit) {
     const {startDate, endDate} = (this.getTimeRange(timeUnit))
     return this.fetchStatsDatas(startDate, endDate, timeUnit)
@@ -183,13 +183,13 @@ class StatsSummary extends React.Component {
         return
       })
   }
-  
+
   render() {
     const {t} = this.props
     if (!this.state) {
       return <div>{t('loading')}……</div>
     }
-  
+
     const dateDoms = this.state.statsDatas.map(data => {
       if (this.state.timeUnit === 'month') {
         return <span>{moment(data.date).format('YYYY-MM')}</span>
@@ -197,7 +197,7 @@ class StatsSummary extends React.Component {
         return <span>{t('until')} {moment(data.date).add(1, 'weeks').format('YYYY-MM-DD, [W]WW')}</span>
       }
     })
-  
+
     const summaryDoms = this.state.statsDatas.map(data => {
       return <Table>
           <thead>
@@ -220,7 +220,7 @@ class StatsSummary extends React.Component {
           </tbody>
         </Table>
     })
-  
+
     const activeTicketCountsByCategoryDoms = this.state.statsDatas.map(d => {
       const body = d.activeTicketCountsByCategory.map(row => {
         const category = _.find(this.props.categories, c => c.id === row[0])
@@ -236,14 +236,14 @@ class StatsSummary extends React.Component {
           body={body}
         />
     })
-  
+
     const activeTicketCountByAssigneeDoms = this.state.statsDatas.map(data => {
       const body = data.activeTicketCountByAssignee.map(row => {
         const user = _.find(this.state.users, c => c.id === row[0])
         return [
           row[0],
           row.index,
-          user && getUserDisplayName(user) || row[0],
+          user && userDisplayName(user, true) || row[0],
           row[1],
         ]
       })
@@ -258,7 +258,7 @@ class StatsSummary extends React.Component {
         const user = _.find(this.state.users, c => c.id === row[0])
         const username = (
           <span>
-            {user && getUserDisplayName(user) || row[0]}
+            {user && userDisplayName(user, true) || row[0]}
             <UserTagGroup tags={getUserTags(user).filter(tag => tag === USER_TAG_NAME.NEW)} />
           </span>
         )
@@ -295,7 +295,7 @@ class StatsSummary extends React.Component {
         return [
           userId,
           index,
-          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && getUserDisplayName(user) || userId}</Link>,
+          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && userDisplayName(user, true) || userId}</Link>,
           (replyTime / replyCount / 1000 / 60 / 60).toFixed(2) + ' ' + t('hour'),
           replyCount,
         ]
@@ -312,7 +312,7 @@ class StatsSummary extends React.Component {
         return [
           userId,
           index,
-          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && getUserDisplayName(user) || userId}</Link>,
+          <Link to={`/customerService/stats/users/${userId}?start=${startTime.toISOString()}&end=${endTime.toISOString()}`}>{user && userDisplayName(user, true) || userId}</Link>,
           (replyTime / replyCount / 1000 / 60 / 60).toFixed(2) + ' ' + t('hour'),
           replyCount,
         ]
@@ -322,7 +322,7 @@ class StatsSummary extends React.Component {
           body={body}
         />
     })
-  
+
     const tagDoms = this.state.statsDatas.map(data => {
       const tables = data.tagsArray.map(tags => {
         const body = tags.map((row, index) => {

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -498,7 +498,7 @@ class Ticket extends Component {
               <TicketStatusLabel status={ticket.get('status')} />
               {' '}
               <span>
-                <UserLabel user={ticket.get('author')} displayTags={isCustomerService} /> {t('createdAt')} <span title={moment(ticket.get('createdAt')).format()}>{moment(ticket.get('createdAt')).fromNow()}</span>
+                <UserLabel user={ticket.get('author')} inCustomerServiceView={isCustomerService} /> {t('createdAt')} <span title={moment(ticket.get('createdAt')).format()}>{moment(ticket.get('createdAt')).fromNow()}</span>
                 {moment(ticket.get('createdAt')).fromNow() === moment(ticket.get('updatedAt')).fromNow() ||
                   <span>, {t('updatedAt')} <span title={moment(ticket.get('updatedAt')).format()}>{moment(ticket.get('updatedAt')).fromNow()}</span></span>
                 }

--- a/modules/common.js
+++ b/modules/common.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 import {Link} from 'react-router'
 import _ from 'lodash'
 import {auth, db, storage} from '../lib/leancloud'
-import {depthFirstSearchFind, getUserDisplayName, makeTree, getUserTags} from '../lib/common'
+import {depthFirstSearchFind, makeTree, getUserTags} from '../lib/common'
+import {userDisplayName} from '../config.webapp'
 import {UserTagGroup} from './components/UserTag'
 import {Avatar} from './Avatar'
 
@@ -110,28 +111,26 @@ export const fetchUsers = (userIds) => {
   .then(_.flatten)
 }
 
-export const UserLabel = (props) => {
-  if (!props.user) {
-    return <span>data err</span>
+export const UserLabel = ({user, simple, inCustomerServiceView}) => {
+  if (!user) {
+    return <span>{'<unknown>'}</span>
   }
-  const username =
-    props.user.username ||
-    (props.user.get ? props.user.get('username') : undefined)
-  const name = props.user.name || getUserDisplayName(props.user) || username
 
-  if (props.simple) {
+  const username = user.username || user.data.username
+  const name = user.name || (user.data ? userDisplayName(user, inCustomerServiceView) : username)
+
+  if (simple) {
     return <span>{name}</span>
   }
-
   return (
     <span>
       <Link to={'/users/' + username} className="avatar">
-        <Avatar user={props.user} />
+        <Avatar user={user} />
       </Link>
       <Link to={'/users/' + username} className="username">
         {name}
       </Link>
-      {props.displayTags && <UserTagGroup tags={getUserTags(props.user)} />}
+      {inCustomerServiceView && user.get && <UserTagGroup tags={getUserTags(user)} />}
     </span>
   )
 }
@@ -139,7 +138,7 @@ UserLabel.displayName = 'UserLabel'
 UserLabel.propTypes = {
   user: PropTypes.object,
   simple: PropTypes.bool,
-  displayTags: PropTypes.bool
+  inCustomerServiceView: PropTypes.bool,
 }
 
 export const getCategoriesTree = (hiddenDisable = true) => {

--- a/modules/components/WeekendWarning/index.js
+++ b/modules/components/WeekendWarning/index.js
@@ -1,12 +1,11 @@
-/*global DISABLE_WEEKEND_WARNING*/
-
 import React from 'react'
 import {Alert} from 'react-bootstrap'
 
+import {enableWeekendWarning} from '../../../config.webapp'
 import translate from '../../i18n/translate'
 
 export const WeekendWarning = translate(({t}) => {
-  if (DISABLE_WEEKEND_WARNING) {
+  if (!enableWeekendWarning) {
     return null
   }
   const day = new Date().getDay()

--- a/modules/settings/Vacation.js
+++ b/modules/settings/Vacation.js
@@ -7,7 +7,7 @@ import {auth, db} from '../../lib/leancloud'
 
 import {getCustomerServices} from '../common'
 import translate from '../i18n/translate'
-import {getUserDisplayName} from '../../lib/common'
+import {customerServiceDisplayName} from '../../config.webapp'
 
 class Vacation extends Component {
 
@@ -23,7 +23,7 @@ class Vacation extends Component {
       isEndHalfDay: false,
     }
   }
-  
+
   componentDidMount() {
     Promise.all([
       getCustomerServices(),
@@ -36,8 +36,7 @@ class Vacation extends Component {
             vacationer: auth.currentUser(),
           }
         ])
-        .include('vacationer')
-        .include('operator')
+        .include('vacationer', 'operator')
         .orderBy('createdAt', 'desc')
         .find(),
     ])
@@ -45,27 +44,27 @@ class Vacation extends Component {
         this.setState({users, vacations})
       })
   }
-  
+
   handleVacationUserChange(e) {
     this.setState({vacationerId: e.target.value})
   }
-  
+
   handleChangeStart(startDate) {
     this.setState({startDate})
   }
-  
+
   handleStartHalfDayClick(e) {
     this.setState({isStartHalfDay: e.target.checked})
   }
-  
+
   handleChangeEnd(endDate) {
     this.setState({endDate})
   }
-  
+
   handleEndHalfDayClick(e) {
     this.setState({isEndHalfDay: e.target.checked})
   }
-  
+
   handleSubmit(e) {
     e.preventDefault()
     return db.class('Vacation')
@@ -83,28 +82,28 @@ class Vacation extends Component {
         this.setState({vacations})
       })
   }
-  
+
   handleRemove(vacation) {
     vacation.delete()
       .then(() => {
         this.setState({vacations: this.state.vacations.filter(v => v.id !== vacation.id)})
       })
   }
-  
+
   render() {
     const {t} = this.props
     const userOptions = this.state.users.map(user => {
-      return <option key={user.id} value={user.id}>{getUserDisplayName(user)}</option>
+      return <option key={user.id} value={user.id}>{customerServiceDisplayName(user)}</option>
     })
-  
+
     const vacationTrs = this.state.vacations.map(vacation => {
       const startDate = moment(vacation.get('startDate'))
       const endDate = moment(vacation.get('endDate'))
       return <tr key={vacation.id}>
-          <td>{getUserDisplayName(vacation.get('vacationer'))}</td>
+          <td>{customerServiceDisplayName(vacation.get('vacationer'))}</td>
           <td>{startDate.format('YYYY-MM-DD') + (startDate.hours() === 12 ? t('pm') : '')}</td>
           <td>{endDate.format('YYYY-MM-DD') + (endDate.hours() === 12 ? t('pm') : '')}</td>
-          <td>{getUserDisplayName(vacation.get('operator'))}</td>
+          <td>{customerServiceDisplayName(vacation.get('operator'))}</td>
           <td>{moment(vacation.createdAt).fromNow()}</td>
           <td><Button type='button' onClick={() => this.handleRemove(vacation)}>{t('delete')}</Button></td>
         </tr>
@@ -168,12 +167,9 @@ class Vacation extends Component {
     )
   }
 }
-  
+
 Vacation.propTypes = {
   t: PropTypes.func
 }
 
 export default translate(Vacation)
-
-
-

--- a/server.js
+++ b/server.js
@@ -57,8 +57,6 @@ const getIndexPage = () => {
   ORG_NAME = '${orgName}'
   USE_OAUTH = ${!!process.env.OAUTH_KEY}
   ENABLE_LEANCLOUD_INTERGRATION = ${!!process.env.ENABLE_LEANCLOUD_INTERGRATION}
-  OFFSET_DAYS = ${config.offsetDays}
-  DISABLE_WEEKEND_WARNING = ${config.disableWeekendWarning}
   ALGOLIA_API_KEY = '${process.env.ALGOLIA_API_KEY}'
   FAQ_VIEWS = '${process.env.FAQ_VIEWS || ''}'
   SUPPORT_EMAIL = '${config.supportEmail || ''}'


### PR DESCRIPTION
为自定义用户、客服名称的显示方式铺路。

把 lib/common.js 中的 getUserDisplayName 挪到 api/common.js 中，目前这个方法仅后端用来在 mail / bearychat / wechat 的提醒中获取客服的名称。前端通过 /config.webapp.js 中的 userDisplayName 获取用户名称，customerServiceDisplayName 获取客服名称。
