### PR TITLE
feat: comment of tap metadata

### DIFF
--- a/config.webapp.js
+++ b/config.webapp.js
@@ -13,3 +13,7 @@ export function customerServiceDisplayName(user) {
 export const offsetDays = -3
 
 export const enableWeekendWarning = true
+
+/* eslint-disable i18n/no-chinese-character */
+export const customTicketMetadataComments = {}
+/* esline-enable i18n/no-chinese-character */

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -11,6 +11,7 @@ import csCss from '../CustomerServiceTickets.css'
 import translate from '../i18n/translate'
 import {depthFirstSearchFind} from '../../lib/common'
 import CategoriesSelect from '../CategoriesSelect'
+import {customTicketMetadataComments} from '../../config.webapp'
 
 class TicketMetadata extends Component {
 
@@ -105,12 +106,18 @@ class TicketMetadata extends Component {
 
         {isCustomerService && ticket.data.metaData && (
           <FormGroup>
-            <label className="label-block">Metadata</label>
-            {Object.entries(ticket.data.metaData).map(([key, value]) => (
-              <div className={css.customMetadata} key={key}>
-                <span className={css.key}>{key}: </span>{value}
-              </div>
-            ))}
+            <label className="label-block">{t('details')}</label>
+            {Object.entries(ticket.data.metaData).map(([key, value]) => {
+              if (!value) {
+                return null
+              }
+              return (
+                <div className={css.customMetadata} key={key}>
+                  <span className={css.key}>{customTicketMetadataComments[key] || key}: </span>
+                  {value}
+                </div>
+              )
+            })}
           </FormGroup>
         )}
 

--- a/modules/Ticket/index.css
+++ b/modules/Ticket/index.css
@@ -6,6 +6,7 @@
   font-size: 13px;
   color: grey;
   margin-top: 4px;
+  overflow-wrap: break-word;
 }
 .customMetadata .key {
   font-weight: 600;

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -102,6 +102,10 @@ const messages = {
     'Description',
     '描述'
   ],
+  'details': [
+    'Details',
+    '详细信息'
+  ],
   'disable': [
     'Disable',
     '停用'
@@ -917,7 +921,7 @@ const messages = {
   'statusClosed': [
     'Closed',
     '已关闭'
-  ]
+  ],
 }
 
 function splitIntoLocales(messages, localeIndex) {

--- a/modules/i18n/locales.js
+++ b/modules/i18n/locales.js
@@ -921,7 +921,7 @@ const messages = {
   'statusClosed': [
     'Closed',
     '已关闭'
-  ],
+  ]
 }
 
 function splitIntoLocales(messages, localeIndex) {


### PR DESCRIPTION
- 新增：翻译 Tap Metadata
- 修复：长字符串换行

已部署到 ticket-xd 的预备环境。

感觉 `VID` 和 `taptapID` 重复了，`gameName` 和 `appName` 弄混了 🤔
