### PR TITLE
fix(CSProfile): hide wechat form when no wechat plugin

### DIFF
--- a/modules/settings/CustomerServiceProfile.js
+++ b/modules/settings/CustomerServiceProfile.js
@@ -1,3 +1,5 @@
+/* global INTEGRATIONS */
+
 import React, { Component } from 'react'
 import { withTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
@@ -16,12 +18,14 @@ class CustomerServiceProfile extends Component {
   }
 
   componentDidMount() {
-    cloud.run('getWechatEnterpriseUsers', {})
-    .then((wechatUsers) => {
-      this.setState({wechatUsers})
-      return
-    })
-    .catch(this.context.addNotification)
+    if (INTEGRATIONS.includes('Wechat')) {
+      cloud.run('getWechatEnterpriseUsers', {})
+        .then((wechatUsers) => {
+          this.setState({wechatUsers})
+          return
+        })
+        .catch(this.context.addNotification)
+    }
   }
 
   handleWechatIdChange(e) {
@@ -45,16 +49,18 @@ class CustomerServiceProfile extends Component {
     return (
       <div>
         <h2>{t('associatedAccounts')}</h2>
-        <Form>
-          <FormGroup>
-            <ControlLabel>{t('weCom')}</ControlLabel>
-            <FormControl componentClass="select" value={this.state.wechatUserId} onChange={this.handleWechatIdChange.bind(this)}>
-              <option key='undefined' value=''>{t('unlinked')}</option>
-              {wechatUserOptions}
-            </FormControl>
-          </FormGroup>
-          <Button type='button' onClick={this.handleSubmit.bind(this)}>{t('save')}</Button>
-        </Form>
+        {INTEGRATIONS.includes('Wechat') && (
+          <Form>
+            <FormGroup>
+              <ControlLabel>{t('weCom')}</ControlLabel>
+              <FormControl componentClass="select" value={this.state.wechatUserId} onChange={this.handleWechatIdChange.bind(this)}>
+                <option key='undefined' value=''>{t('unlinked')}</option>
+                {wechatUserOptions}
+              </FormControl>
+            </FormGroup>
+            <Button type='button' onClick={this.handleSubmit.bind(this)}>{t('save')}</Button>
+          </Form>
+        )}
         <Vacation />
       </div>
     )

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ const getIndexPage = () => {
 <script src="/js/bootstrap.min.js"></script>
 <div id=app></div>
 <script>
+  INTEGRATIONS = ${JSON.stringify(config.integrations.map(t => t.name))}
   LEANCLOUD_APP_ID = '${process.env.LEANCLOUD_APP_ID}'
   LEANCLOUD_APP_KEY = '${process.env.LEANCLOUD_APP_KEY}'
   LEANCLOUD_API_HOST = ${process.env.LEANCLOUD_API_HOST ? ('"' + process.env.LEANCLOUD_API_HOST + '"') : undefined}


### PR DESCRIPTION
xd 的工单没配 Wechat 插件，导致没有 `getWechatEnterpriseUsers` 这个云函数，进而导致客服个人配置页面报错。先临时这样修一下。