### PR TITLE
refactor: get LEANCLOUD_API_HOST from window object

### DIFF
--- a/lib/leancloud.js
+++ b/lib/leancloud.js
@@ -5,7 +5,7 @@ import * as LC from 'open-leancloud-storage'
 export const app = LC.init({
   appId: LEANCLOUD_APP_ID,
   appKey: LEANCLOUD_APP_KEY,
-  serverURL: LEANCLOUD_API_HOST,
+  serverURL: typeof LEANCLOUD_API_HOST === 'string' ? LEANCLOUD_API_HOST : undefined,
 })
 
 if (LEANCLOUD_APP_ENV === 'development') {

--- a/lib/leancloud.js
+++ b/lib/leancloud.js
@@ -1,11 +1,11 @@
-/*global LEANCLOUD_APP_ID, LEANCLOUD_APP_KEY, LEANCLOUD_API_HOST, LEANCLOUD_APP_ENV, LEAN_CLI_HAVE_STAGING */
+/*global LEANCLOUD_APP_ENV, LEAN_CLI_HAVE_STAGING */
 
 import * as LC from 'open-leancloud-storage'
 
 export const app = LC.init({
-  appId: LEANCLOUD_APP_ID,
-  appKey: LEANCLOUD_APP_KEY,
-  serverURL: typeof LEANCLOUD_API_HOST === 'string' ? LEANCLOUD_API_HOST : undefined,
+  appId: window.LEANCLOUD_APP_ID,
+  appKey: window.LEANCLOUD_APP_KEY,
+  serverURL: window.LEANCLOUD_API_HOST,
 })
 
 if (LEANCLOUD_APP_ENV === 'development') {


### PR DESCRIPTION
国际节点没有也没必要设置 LEANCLOUD_API_HOST 环境变量，进而导致应用因使用未定义的变量而 panic 。或许应该通过 window.VAR_NAME 这种方式获取环境变量的值？