### PR TITLE
refactor(slack): send messages in non-block mode

### DIFF
--- a/integrations/slack/server.js
+++ b/integrations/slack/server.js
@@ -130,9 +130,9 @@ class SlackIntegration {
       url: getTicketUrl(ticket),
     })
     if (to.has('email')) {
-      await this.send(to.get('email'), message)
+      this.send(to.get('email'), message)
     }
-    await this.broadcast(message)
+    this.broadcast(message)
   }
 
   async notifyChangeAssignee(ticket, from, to) {
@@ -145,9 +145,9 @@ class SlackIntegration {
       latestReply: ticket.get('latestReply')?.content,
     })
     if (to.has('email')) {
-      await this.send(to.get('email'), message)
+      this.send(to.get('email'), message)
     }
-    await this.broadcast(message)
+    this.broadcast(message)
   }
 
   async notifyReplyTicket({ ticket, reply, from, to, isCustomerServiceReply }) {
@@ -162,9 +162,9 @@ class SlackIntegration {
       reply: reply.get('content'),
     })
     if (to.has('email')) {
-      await this.send(to.get('email'), message)
+      this.send(to.get('email'), message)
     }
-    await this.broadcast(message)
+    this.broadcast(message)
   }
 
   async delayNotify(ticket, to) {
@@ -176,9 +176,9 @@ class SlackIntegration {
       latestReply: ticket.get('latestReply')?.content,
     })
     if (to.has('email')) {
-      await this.send(to.get('email'), message)
+      this.send(to.get('email'), message)
     }
-    await this.broadcast(message)
+    this.broadcast(message)
   }
 
   async notifyEvaluation(ticket, from, to) {
@@ -192,9 +192,9 @@ class SlackIntegration {
       url: getTicketUrl(ticket),
     })
     if (to.has('email')) {
-      await this.send(to.get('email'), message)
+      this.send(to.get('email'), message)
     }
-    await this.broadcast(message)
+    this.broadcast(message)
   }
 }
 


### PR DESCRIPTION
如果没有设置 Slack 邮箱的话，发送私信的步骤会抛异常，导致无法发送广播消息。
Slack 通知功能的代码完全是按照 Zulip 通知写的，但之前使用的过程中好像没有暴露出这个问题 🤔 。

我觉得发送消息这一步失败也无所谓，就不 await 了吧。目前失败了还会导致后续无法创建 Message Object 。