### PR TITLE
feat: automations

### DIFF
--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -375,4 +375,4 @@ async function tickAutomation() {
     await AV.Object.saveAll(ticketsToUpdate, { useMasterKey: true })
   }
 }
-AV.Cloud.define('__tickAutomation', tickAutomation)
+AV.Cloud.define('tickAutomation', { fetchUser: false, internal: true }, tickAutomation)

--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -10,11 +10,18 @@ const {
 } = require('./common')
 const { checkPermission } = require('./oauth')
 const notification = require('./notification')
-const { TICKET_ACTION, TICKET_STATUS, getTicketAcl, ticketStatus } = require('../lib/common')
+const {
+  TICKET_ACTION,
+  TICKET_STATUS,
+  getTicketAcl,
+  ticketStatus,
+  ticketOpenedStatuses,
+} = require('../lib/common')
 const errorHandler = require('./errorHandler')
 const { invokeWebhooks } = require('./webhook')
 const { Context } = require('./rule/context')
-const { getActiveTriggers } = require('./rule/trigger')
+const { getActiveTriggers, recordTriggerLog } = require('./rule/trigger')
+const { getActiveAutomations } = require('./rule/automation')
 
 function addOpsLog(ticket, action, data) {
   return new AV.Object('OpsLog')
@@ -32,28 +39,20 @@ async function invokeTriggers(ticket, updateType) {
   if (ticketStatus.isClosed(ticket.get('status')) && !ticket.updatedKeys?.includes('status')) {
     return
   }
+
   const ctx = new Context(ticket.toJSON(), updateType, ticket.updatedKeys)
   const triggers = await getActiveTriggers()
   triggers.exec(ctx)
-  const updatedTicket = await ctx.commitUpdate()
-  if (updatedTicket) {
-    afterUpdateTicketHandler(updatedTicket, {
-      skipTriggers: updateType === 'update',
-    })
+  if (ctx.isUpdated()) {
+    const updatedTicket = AV.Object.createWithoutData('Ticket', ticket.id)
+    Object.entries(ctx.data).forEach(([key, value]) => (updatedTicket.attributes[key] = value))
+    const updatedData = ctx.getUpdatedData()
+    await updatedTicket.save(updatedData, { useMasterKey: true })
+    updatedTicket.updatedKeys = Object.keys(updatedData)
+    afterUpdateTicketHandler(updatedTicket, { skipTriggers: updateType === 'update' })
   }
-  const firedTriggers = triggers.getFiredTriggers()
-  if (firedTriggers.length) {
-    const logs = firedTriggers.map((trigger) => {
-      return AV.Object('TriggerLog', {
-        ACL: {},
-        ticket: AV.Object.createWithoutData('Ticket', ticket.id),
-        trigger: AV.Object.createWithoutData('Trigger', trigger.id),
-        actions: trigger.rawActions,
-        conditions: trigger.rawConditions,
-      })
-    })
-    AV.Object.saveAll(logs, { useMasterKey: true })
-  }
+
+  recordTriggerLog(triggers, ticket.id)
 }
 
 /**
@@ -351,3 +350,26 @@ const getVacationers = () => {
     .find({ useMasterKey: true })
     .then((vacations) => vacations.map((v) => v.get('vacationer')))
 }
+
+async function tickAutomation() {
+  const query = new AV.Query('Ticket')
+  query.containedIn('status', ticketOpenedStatuses())
+  query.addAscending('createdAt')
+  query.limit(1000)
+  const [tickets, automations] = await Promise.all([
+    query.find({ useMasterKey: true }),
+    getActiveAutomations(),
+  ])
+  const ticketsToUpdate = []
+  for (const ticket of tickets) {
+    const ctx = new Context(ticket.toJSON())
+    automations.exec(ctx)
+    if (ctx.isUpdated()) {
+      ticketsToUpdate.push(ticket.set(ctx.getUpdatedData()))
+    }
+  }
+  if (ticketsToUpdate.length) {
+    await AV.Object.saveAll(ticketsToUpdate, { useMasterKey: true })
+  }
+}
+AV.Cloud.define('__tickAutomation', tickAutomation)

--- a/api/index.js
+++ b/api/index.js
@@ -31,6 +31,7 @@ router.use(loginCallbackPath, require('./oauth').loginCallback(loginCallbackUrl)
 router.use('/api/1/files', require('./file'))
 router.use('/api/1/dynamic-contents', require('./DynamicContent'))
 router.use('/api/1/triggers', require('./rule/trigger/api'))
+router.use('/api/1/automations', require('./rule/automation/api'))
 
 const { integrations } = require('../config')
 console.log(`Using plugins: ${integrations.map((integration) => integration.name).join(', ')}`)

--- a/api/rule/automation/action/types.js
+++ b/api/rule/automation/action/types.js
@@ -1,0 +1,5 @@
+const types = require('../../action/types')
+
+module.exports = {
+  ...types,
+}

--- a/api/rule/automation/api.js
+++ b/api/rule/automation/api.js
@@ -3,24 +3,24 @@ const { check } = require('express-validator')
 const { Router } = require('express')
 
 const { requireAuth, customerServiceOnly, catchError } = require('../../middleware')
-const { Trigger } = require('./trigger')
+const { ticketOpenedStatuses } = require('../../../lib/common')
+const { Context } = require('../context')
+const { Automation } = require('./automation')
 
 const router = Router().use(requireAuth, customerServiceOnly)
 
 router.post(
   '/',
   check('title').isString().isLength({ min: 1 }),
-  check('description').isString().optional(),
   check('conditions').isObject().optional(),
   check('actions').isArray().optional(),
   catchError(async (req, res) => {
-    const { title, description, conditions, actions } = req.body
-    Trigger.parseConditions(conditions)
-    Trigger.parseActions(actions)
-    const object = await new AV.Object('Trigger', {
+    const { title, conditions, actions } = req.body
+    Automation.parseConditions(conditions)
+    Automation.parseActions(actions)
+    const object = await new AV.Object('Automation', {
       ACL: {},
       title,
-      description,
       conditions,
       actions,
       active: true,
@@ -32,8 +32,8 @@ router.post(
 router.get(
   '/',
   catchError(async (req, res) => {
-    const query = new AV.Query('Trigger')
-      .select('title', 'description', 'position', 'active')
+    const query = new AV.Query('Automation')
+      .select('title', 'position', 'active')
       .addAscending('position')
       .addAscending('createdAt')
     const objects = await query.find({ useMasterKey: true })
@@ -41,7 +41,6 @@ router.get(
       objects.map((o) => ({
         id: o.id,
         title: o.get('title'),
-        description: o.get('description'),
         position: o.get('position'),
         active: !!o.get('active'),
       }))
@@ -53,7 +52,7 @@ router.get(
   '/:id',
   catchError(async (req, res) => {
     const { id } = req.params
-    const object = await new AV.Query('Trigger').get(id, { useMasterKey: true })
+    const object = await new AV.Query('Automation').get(id, { useMasterKey: true })
     res.json(object.toJSON())
   })
 )
@@ -61,26 +60,22 @@ router.get(
 router.patch(
   '/:id',
   check('title').isString().isLength({ min: 1 }).optional(),
-  check('description').isString().optional(),
   check('conditions').isObject().optional(),
   check('actions').isArray().optional(),
   check('active').isBoolean().optional(),
   catchError(async (req, res) => {
     const { id } = req.params
-    const { title, description, conditions, actions, active } = req.body
-    const object = AV.Object.createWithoutData('Trigger', id)
-    if (title !== undefined) {
+    const { title, conditions, actions, active } = req.body
+    const object = AV.Object.createWithoutData('Automation', id)
+    if (title) {
       object.set('title', title)
     }
-    if (description !== undefined) {
-      object.set('description', description)
-    }
     if (conditions) {
-      Trigger.parseConditions(conditions)
+      Automation.parseConditions(conditions)
       object.set('conditions', conditions)
     }
     if (actions) {
-      Trigger.parseActions(actions)
+      Automation.parseActions(actions)
       object.set('actions', actions)
     }
     if (active !== undefined) {
@@ -95,7 +90,7 @@ router.delete(
   '/:id',
   catchError(async (req, res) => {
     const { id } = req.params
-    const object = AV.Object.createWithoutData('Trigger', id)
+    const object = AV.Object.createWithoutData('Automation', id)
     await object.destroy({ useMasterKey: true })
     res.json({})
   })
@@ -103,17 +98,38 @@ router.delete(
 
 router.post(
   '/reorder',
-  check('triggerIds').isArray({ min: 1 }),
-  check('triggerIds.*').isString(),
+  check('automationIds').isArray({ min: 1 }),
+  check('automationIds.*').isString(),
   catchError(async (req, res) => {
-    const { triggerIds } = req.body
-    const objects = triggerIds.map((id, index) => {
-      const object = AV.Object.createWithoutData('Trigger', id)
+    const { automationIds } = req.body
+    const objects = automationIds.map((id, index) => {
+      const object = AV.Object.createWithoutData('Automation', id)
       object.set('position', index)
       return object
     })
     await AV.Object.saveAll(objects, { useMasterKey: true })
     res.json({})
+  })
+)
+
+router.post(
+  '/preview',
+  check('conditions').isObject(),
+  catchError(async (req, res) => {
+    const query = new AV.Query('Ticket')
+    query.containedIn('status', ticketOpenedStatuses())
+    query.limit(1000)
+    query.addAscending('createdAt')
+    const tickets = await query.find({ useMasterKey: true })
+    const conditions = Automation.parseConditions(req.body.conditions)
+    const matchedTicketIds = []
+    tickets.forEach((ticket) => {
+      const ctx = new Context(ticket.toJSON())
+      if (conditions.test(ctx)) {
+        matchedTicketIds.push(ticket.id)
+      }
+    })
+    res.json({ matchedTicketIds })
   })
 )
 

--- a/api/rule/automation/automation.js
+++ b/api/rule/automation/automation.js
@@ -1,0 +1,52 @@
+const { Conditions } = require('../condition')
+const { Actions } = require('../action')
+const fields = require('./condition/fields')
+const types = require('./action/types')
+
+class Automation {
+  constructor({ objectId, conditions, actions }) {
+    this.id = objectId
+    this.rawConditions = conditions
+    this.conditions = Automation.parseConditions(conditions)
+    this.rawActions = actions
+    this.actions = Automation.parseActions(actions)
+  }
+
+  static parseConditions(conditions) {
+    return new Conditions(conditions, fields)
+  }
+
+  static parseActions(actions) {
+    return new Actions(actions, types)
+  }
+
+  test(ctx) {
+    return this.conditions.test(ctx)
+  }
+
+  exec(ctx) {
+    this.actions.exec(ctx)
+  }
+}
+
+class Automations {
+  /**
+   * @param {array} automations
+   */
+  constructor(automations) {
+    if (!Array.isArray(automations)) {
+      throw new Error('Automations must be an array')
+    }
+    this.automations = automations.map((a) => new Automation(a))
+  }
+
+  exec(ctx) {
+    this.automations.forEach((automation) => {
+      if (automation.test(ctx)) {
+        automation.exec(ctx)
+      }
+    })
+  }
+}
+
+module.exports = { Automation, Automations }

--- a/api/rule/automation/condition/createdAt.js
+++ b/api/rule/automation/condition/createdAt.js
@@ -1,0 +1,50 @@
+const moment = require('moment')
+
+class CreatedAtIs {
+  /**
+   * @param {number} value
+   */
+  constructor(value) {
+    if (typeof value !== 'number') {
+      throw new Error('Invalid number')
+    }
+    if (value < 0) {
+      throw new Error('Value must be a postive number')
+    }
+    this.value = value
+  }
+
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  _nowDiff(ctx) {
+    return moment().diff(ctx.getCreatedAt(), 'hours')
+  }
+
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) === this.value
+  }
+}
+
+class CreatedAtLessThan extends CreatedAtIs {
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) < this.value
+  }
+}
+
+class CreatedAtGreaterThan extends CreatedAtIs {
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) > this.value
+  }
+}
+
+module.exports = { CreatedAtIs, CreatedAtLessThan, CreatedAtGreaterThan }

--- a/api/rule/automation/condition/fields.js
+++ b/api/rule/automation/condition/fields.js
@@ -1,0 +1,20 @@
+const { assigneeId, status, title, content } = require('../../condition/fields')
+const { CreatedAtIs, CreatedAtLessThan, CreatedAtGreaterThan } = require('./createdAt')
+const { UpdatedAtIs, UpdatedAtLessThan, UpdatedAtGreaterThan } = require('./updatedAt')
+
+module.exports = {
+  assigneeId,
+  status,
+  title,
+  content,
+  createdAt: {
+    is: (value) => new CreatedAtIs(value),
+    lessThan: (value) => new CreatedAtLessThan(value),
+    greaterThan: (value) => new CreatedAtGreaterThan(value),
+  },
+  updatedAt: {
+    is: (value) => new UpdatedAtIs(value),
+    lessThan: (value) => new UpdatedAtLessThan(value),
+    greaterThan: (value) => new UpdatedAtGreaterThan(value),
+  },
+}

--- a/api/rule/automation/condition/updatedAt.js
+++ b/api/rule/automation/condition/updatedAt.js
@@ -1,0 +1,50 @@
+const moment = require('moment')
+
+class UpdatedAtIs {
+  /**
+   * @param {number} value
+   */
+  constructor(value) {
+    if (typeof value !== 'number') {
+      throw new Error('Invalid number')
+    }
+    if (value < 0) {
+      throw new Error('Value must be a postive number')
+    }
+    this.value = value
+  }
+
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  _nowDiff(ctx) {
+    return moment().diff(ctx.getUpdatedAt(), 'hours')
+  }
+
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) === this.value
+  }
+}
+
+class UpdatedAtLessThan extends UpdatedAtIs {
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) < this.value
+  }
+}
+
+class UpdatedAtGreaterThan extends UpdatedAtIs {
+  /**
+   * @param {import('../../context').Context} ctx
+   */
+  test(ctx) {
+    return this._nowDiff(ctx) > this.value
+  }
+}
+
+module.exports = { UpdatedAtIs, UpdatedAtLessThan, UpdatedAtGreaterThan }

--- a/api/rule/automation/index.js
+++ b/api/rule/automation/index.js
@@ -1,0 +1,14 @@
+const AV = require('leanengine')
+
+const { Automations } = require('./automation')
+
+async function getActiveAutomations() {
+  const query = new AV.Query('Automation')
+    .equalTo('active', true)
+    .addAscending('position')
+    .addAscending('createdAt')
+  const objects = await query.find({ useMasterKey: true })
+  return new Automations(objects.map((o) => o.toJSON()))
+}
+
+module.exports = { getActiveAutomations }

--- a/api/rule/condition/status.js
+++ b/api/rule/condition/status.js
@@ -4,6 +4,9 @@ const { TICKET_STATUS } = require('../../../lib/common')
 
 class StatusIs {
   constructor(value) {
+    if (typeof value !== 'number') {
+      throw new Error('Status must be a number')
+    }
     if (!(value in _.invert(TICKET_STATUS))) {
       throw new Error('Invalid status')
     }

--- a/api/rule/trigger/index.js
+++ b/api/rule/trigger/index.js
@@ -31,4 +31,24 @@ async function validateTriggers() {
   return result
 }
 
-module.exports = { getActiveTriggers, validateTriggers }
+/**
+ * @param {Triggers} triggers
+ * @param {string} ticketId
+ */
+async function recordTriggerLog(triggers, ticketId) {
+  const firedTriggers = triggers.getFiredTriggers()
+  if (firedTriggers.length) {
+    const logs = firedTriggers.map((trigger) =>
+      AV.Object('TriggerLog', {
+        ACL: {},
+        ticket: AV.Object.createWithoutData('Ticket', ticketId),
+        trigger: AV.Object.createWithoutData('Trigger', trigger.id),
+        actions: trigger.rawActions,
+        conditions: trigger.rawConditions,
+      })
+    )
+    await AV.Object.saveAll(logs, { useMasterKey: true })
+  }
+}
+
+module.exports = { getActiveTriggers, validateTriggers, recordTriggerLog }

--- a/modules/Settings/Rule/Automation/condition/fields/index.js
+++ b/modules/Settings/Rule/Automation/condition/fields/index.js
@@ -1,0 +1,67 @@
+export { assigneeId, status, title, content } from '../../../Condition/fields'
+
+export const createdAt = {
+  title: 'Hours since created',
+  operators: {
+    lessThan: {
+      title: 'Less than',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+    greaterThan: {
+      title: 'Greater than',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+    is: {
+      title: 'Is',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+  },
+}
+
+export const updatedAt = {
+  title: 'Hours since updated',
+  operators: {
+    lessThan: {
+      title: 'Less than',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+    greaterThan: {
+      title: 'Greater than',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+    is: {
+      title: 'Is',
+      component: {
+        type: 'number',
+        props: {
+          min: 0,
+        },
+      },
+    },
+  },
+}

--- a/modules/Settings/Rule/Automation/condition/fields/index.js
+++ b/modules/Settings/Rule/Automation/condition/fields/index.js
@@ -7,27 +7,21 @@ export const createdAt = {
       title: 'Less than',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
     greaterThan: {
       title: 'Greater than',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
     is: {
       title: 'Is',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
   },
@@ -40,27 +34,21 @@ export const updatedAt = {
       title: 'Less than',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
     greaterThan: {
       title: 'Greater than',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
     is: {
       title: 'Is',
       component: {
         type: 'number',
-        props: {
-          min: 0,
-        },
+        min: 0,
       },
     },
   },

--- a/modules/Settings/Rule/Automation/condition/index.js
+++ b/modules/Settings/Rule/Automation/condition/index.js
@@ -1,0 +1,4 @@
+import { useConditions as useBasicConditions } from '../../Condition'
+import * as fields from './fields'
+
+export const useConditions = () => useBasicConditions({ fields })

--- a/modules/Settings/Rule/Condition/fields/index.js
+++ b/modules/Settings/Rule/Condition/fields/index.js
@@ -1,105 +1,111 @@
 import { AssigneeSelect } from '../../components/AssigneeSelect'
 import { TICKET_STATUS } from '../../../../../lib/common'
 
-export default {
-  updateType: {
-    title: 'Ticket',
-    operators: {
-      is: {
-        title: 'Is',
-        component: {
-          type: 'select',
-          options: [
-            {
-              title: 'Created',
-              value: 'create',
-            },
-            {
-              title: 'Updated',
-              value: 'update',
-            },
-          ],
-        },
+export const updateType = {
+  title: 'Ticket',
+  operators: {
+    is: {
+      title: 'Is',
+      component: {
+        type: 'select',
+        options: [
+          {
+            title: 'Created',
+            value: 'create',
+          },
+          {
+            title: 'Updated',
+            value: 'update',
+          },
+        ],
       },
     },
   },
-  assigneeId: {
-    title: 'Assignee',
-    operators: {
-      is: {
-        title: 'Is',
-        component: AssigneeSelect,
+}
+
+export const assigneeId = {
+  title: 'Assignee',
+  operators: {
+    is: {
+      title: 'Is',
+      component: AssigneeSelect,
+    },
+    isNot: {
+      title: 'Is not',
+      component: AssigneeSelect,
+    },
+  },
+}
+
+export const status = {
+  title: 'Status',
+  operators: {
+    is: {
+      title: 'Is',
+      component: {
+        type: 'select',
+        options: [
+          {
+            title: 'New',
+            value: TICKET_STATUS.NEW,
+          },
+          {
+            title: 'Waiting on staff reply',
+            value: TICKET_STATUS.WAITING_CUSTOMER_SERVICE,
+          },
+          {
+            title: 'Waiting on customer reply',
+            value: TICKET_STATUS.WAITING_CUSTOMER,
+          },
+          {
+            title: 'Waiting on confirming resolved',
+            value: TICKET_STATUS.PRE_FULFILLED,
+          },
+          {
+            title: 'Resolved',
+            value: TICKET_STATUS.FULFILLED,
+          },
+          {
+            title: 'Closed',
+            value: TICKET_STATUS.CLOSED,
+          },
+        ],
       },
     },
   },
-  status: {
-    title: 'Status',
-    operators: {
-      is: {
-        title: 'Is',
-        component: {
-          type: 'select',
-          options: [
-            {
-              title: 'New',
-              value: TICKET_STATUS.NEW,
-            },
-            {
-              title: 'Waiting on staff reply',
-              value: TICKET_STATUS.WAITING_CUSTOMER_SERVICE,
-            },
-            {
-              title: 'Waiting on customer reply',
-              value: TICKET_STATUS.WAITING_CUSTOMER,
-            },
-            {
-              title: 'Waiting on confirming resolved',
-              value: TICKET_STATUS.PRE_FULFILLED,
-            },
-            {
-              title: 'Resolved',
-              value: TICKET_STATUS.FULFILLED,
-            },
-            {
-              title: 'Closed',
-              value: TICKET_STATUS.CLOSED,
-            },
-          ],
-        },
+}
+
+export const title = {
+  title: 'Title',
+  operators: {
+    contains: {
+      title: 'Contains',
+      component: {
+        type: 'text',
+      },
+    },
+    notContains: {
+      title: 'Does not contain',
+      component: {
+        type: 'text',
       },
     },
   },
-  title: {
-    title: 'Title',
-    operators: {
-      contains: {
-        title: 'Contains',
-        component: {
-          type: 'text',
-        },
-      },
-      notContains: {
-        title: 'Does not contain',
-        component: {
-          type: 'text',
-        },
+}
+
+export const content = {
+  title: 'Content',
+  operators: {
+    contains: {
+      title: 'Contains',
+      component: {
+        type: 'text',
       },
     },
-  },
-  content: {
-    title: 'Content',
-    operators: {
-      contains: {
-        title: 'Contains',
-        component: {
-          type: 'text',
-        },
-      },
-      notContains: {
-        title: 'Does not contain',
-        component: {
-          type: 'text',
-        },
+    notContains: {
+      title: 'Does not contain',
+      component: {
+        type: 'text',
       },
     },
   },

--- a/modules/Settings/Rule/Condition/fields/index.js
+++ b/modules/Settings/Rule/Condition/fields/index.js
@@ -70,6 +70,7 @@ export const status = {
             value: TICKET_STATUS.CLOSED,
           },
         ],
+        reducer: (value) => parseInt(value),
       },
     },
   },

--- a/modules/Settings/Rule/Condition/index.js
+++ b/modules/Settings/Rule/Condition/index.js
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import { CardContainer } from '../components/CardContainer'
 import { MapSelect } from '../components/MapSelect'
 import { Value } from '../components/Value'
-import basicFields from './fields'
+import * as basicFields from './fields'
 
 function Condition({ fields, initData, onChange }) {
   const [field, setField] = useState(initData?.field || '')

--- a/modules/Settings/Rule/components/NumberInput.js
+++ b/modules/Settings/Rule/components/NumberInput.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react'
+import { Form } from 'react-bootstrap'
+import PropTypes from 'prop-types'
+
+export function NumberInput({ initValue, onChange, props }) {
+  const [value, setValue] = useState(initValue || 0)
+  useEffect(() => {
+    onChange(value)
+  }, [value])
+  return (
+    <Form.Control
+      {...props}
+      type="number"
+      value={value}
+      onChange={(e) => setValue(Number(e.target.value))}
+    />
+  )
+}
+NumberInput.propTypes = {
+  initValue: PropTypes.number,
+  onChange: PropTypes.func.isRequired,
+  props: PropTypes.object,
+}

--- a/modules/Settings/Rule/components/NumberInput.js
+++ b/modules/Settings/Rule/components/NumberInput.js
@@ -2,15 +2,15 @@ import React, { useEffect, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 
-export function NumberInput({ initValue, onChange, props }) {
+export function NumberInput({ initValue, onChange, min }) {
   const [value, setValue] = useState(initValue || 0)
   useEffect(() => {
     onChange(value)
   }, [value])
   return (
     <Form.Control
-      {...props}
       type="number"
+      min={min}
       value={value}
       onChange={(e) => setValue(Number(e.target.value))}
     />
@@ -19,5 +19,5 @@ export function NumberInput({ initValue, onChange, props }) {
 NumberInput.propTypes = {
   initValue: PropTypes.number,
   onChange: PropTypes.func.isRequired,
-  props: PropTypes.object,
+  min: PropTypes.number,
 }

--- a/modules/Settings/Rule/components/Select.js
+++ b/modules/Settings/Rule/components/Select.js
@@ -8,11 +8,12 @@ import PropTypes from 'prop-types'
  * @param {Array<{title: string, value: string | number}>} props.options
  * @param {Function} props.onChange
  * @param {string | number} [props.initValue]
+ * @param {Function} [props.reducer]
  */
-export function Select({ options, initValue, onChange }) {
+export function Select({ options, initValue, onChange, reducer }) {
   const [value, setValue] = useState(initValue || options[0].value)
   useEffect(() => {
-    onChange(value)
+    onChange(reducer ? reducer(value) : value)
   }, [value])
   return (
     <Form.Control as="select" value={value} onChange={(e) => setValue(e.target.value)}>
@@ -33,4 +34,5 @@ Select.propTypes = {
   ).isRequired,
   initValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func.isRequired,
+  reducer: PropTypes.func,
 }

--- a/modules/Settings/Rule/components/Select.js
+++ b/modules/Settings/Rule/components/Select.js
@@ -28,9 +28,9 @@ Select.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,
-      value: PropTypes.oneOf(PropTypes.string, PropTypes.number),
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     })
   ).isRequired,
-  initValue: PropTypes.oneOf(PropTypes.string, PropTypes.number),
+  initValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func.isRequired,
 }

--- a/modules/Settings/Rule/components/Value.js
+++ b/modules/Settings/Rule/components/Value.js
@@ -9,11 +9,18 @@ export function Value({ component, initValue, onChange }) {
   const { type } = component
   switch (type) {
     case 'select':
-      return <Select options={component.options} initValue={initValue} onChange={onChange} />
+      return (
+        <Select
+          options={component.options}
+          initValue={initValue}
+          onChange={onChange}
+          reducer={component.reducer}
+        />
+      )
     case 'text':
       return <TextInput initValue={initValue} onChange={onChange} />
     case 'number':
-      return <NumberInput initValue={initValue} onChange={onChange} props={component.props} />
+      return <NumberInput initValue={initValue} onChange={onChange} min={component.min} />
   }
   return null
 }

--- a/modules/Settings/Rule/components/Value.js
+++ b/modules/Settings/Rule/components/Value.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { Select } from './Select'
 import { TextInput } from './TextInput'
+import { NumberInput } from './NumberInput'
 
 export function Value({ component, initValue, onChange }) {
   const { type } = component
@@ -11,6 +12,8 @@ export function Value({ component, initValue, onChange }) {
       return <Select options={component.options} initValue={initValue} onChange={onChange} />
     case 'text':
       return <TextInput initValue={initValue} onChange={onChange} />
+    case 'number':
+      return <NumberInput initValue={initValue} onChange={onChange} props={component.props} />
   }
   return null
 }

--- a/modules/Settings/index.js
+++ b/modules/Settings/index.js
@@ -19,6 +19,7 @@ import Category from './Category'
 import CategorySort from './CategorySort'
 import DynamicContent from './DynamicContent'
 import Trigger from './Rule/Trigger'
+import Automation from './Rule/Automation'
 
 export default function Settings(props) {
   const { path } = useRouteMatch()
@@ -70,6 +71,9 @@ export default function Settings(props) {
               <ListGroup.Item>
                 <Link to="/settings/triggers">Trigger</Link>
               </ListGroup.Item>
+              <ListGroup.Item>
+                <Link to="/settings/automations">Automation</Link>
+              </ListGroup.Item>
             </ListGroup>
           </Card>
         )}
@@ -120,6 +124,9 @@ export default function Settings(props) {
           </Route>
           <Route path={`${path}/triggers`}>
             <Trigger />
+          </Route>
+          <Route path={`${path}/automations`}>
+            <Automation />
           </Route>
         </Switch>
       </Col>

--- a/resources/schema/Automation.json
+++ b/resources/schema/Automation.json
@@ -1,0 +1,79 @@
+{
+  "schema": {
+    "updatedAt": {
+      "type": "Date"
+    },
+    "ACL": {
+      "type": "ACL"
+    },
+    "objectId": {
+      "type": "String"
+    },
+    "createdAt": {
+      "type": "Date"
+    },
+    "actions": {
+      "type": "Array",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "title": {
+      "type": "String",
+      "v": 2,
+      "required": true,
+      "hidden": false,
+      "read_only": false
+    },
+    "conditions": {
+      "type": "Object",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "active": {
+      "type": "Boolean",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "position": {
+      "type": "Number",
+      "v": 2,
+      "required": false,
+      "auto_increment": false,
+      "hidden": false,
+      "read_only": false
+    }
+  },
+  "permissions": {
+    "create": {
+      "roles": [],
+      "users": []
+    },
+    "find": {
+      "roles": [],
+      "users": []
+    },
+    "get": {
+      "roles": [],
+      "users": []
+    },
+    "update": {
+      "roles": [],
+      "users": []
+    },
+    "delete": {
+      "roles": [],
+      "users": []
+    },
+    "add_fields": {
+      "roles": [],
+      "users": []
+    }
+  },
+  "indexes": []
+}


### PR DESCRIPTION
Automation 和 Trigger 类似，也是由一系列「条件」和「操作」组成。不同的是 Automation 每小时执行一次。
Zendesk 最多处理 1000 条满足 Automation 条件的工单，而目前的实现是每次执行最多检测 1000 条处于开启状态的工单。

Automation 的执行由云引擎的定时任务管理，每小时 (`0 * * * *`) 执行一次 `tickAutomation` 函数。

已部署到 sdjdd-ticket 的生产环境。