### PR TITLE
refactor: REST API for ticket management

### DIFF
--- a/api/Reply.js
+++ b/api/Reply.js
@@ -52,3 +52,5 @@ const getReplyAcl = (ticket, author) => {
   acl.setRoleReadAccess(new AV.Role('customerService'), true)
   return acl
 }
+
+module.exports = { getReplyAcl }

--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -15,7 +15,7 @@ const {
   TICKET_STATUS,
   getTicketAcl,
   ticketStatus,
-  ticketOpenedStatuses,
+  TICKET_OPENED_STATUSES,
 } = require('../lib/common')
 const errorHandler = require('./errorHandler')
 const { invokeWebhooks } = require('./webhook')
@@ -290,7 +290,7 @@ const getTargetStatus = (action, isCustomerService) => {
   }
 }
 
-exports.replyTicket = (ticket, reply, replyAuthor) => {
+const replyTicket = (ticket, reply, replyAuthor) => {
   return Promise.all([
     ticket.fetch({ include: 'author,assignee' }, { user: replyAuthor }),
     getTinyReplyInfo(reply),
@@ -356,7 +356,7 @@ const getVacationers = () => {
 
 async function tickAutomation() {
   const query = new AV.Query('Ticket')
-  query.containedIn('status', ticketOpenedStatuses())
+  query.containedIn('status', TICKET_OPENED_STATUSES)
   query.addAscending('createdAt')
   query.limit(1000)
   const [tickets, automations] = await Promise.all([
@@ -376,3 +376,5 @@ async function tickAutomation() {
   }
 }
 AV.Cloud.define('tickAutomation', { fetchUser: false, internal: true }, tickAutomation)
+
+module.exports = { replyTicket, selectAssignee }

--- a/api/index.js
+++ b/api/index.js
@@ -33,6 +33,7 @@ router.use('/api/1/dynamic-contents', require('./DynamicContent'))
 router.use('/api/1/triggers', require('./rule/trigger/api'))
 router.use('/api/1/automations', require('./rule/automation/api'))
 router.use('/api/1/ticket-fields', require('./TicketField'))
+router.use('/api/1/tickets', require('./ticket/api'))
 
 const { integrations } = require('../config')
 console.log(`Using plugins: ${integrations.map((integration) => integration.name).join(', ')}`)

--- a/api/middleware/index.js
+++ b/api/middleware/index.js
@@ -14,7 +14,7 @@ exports.requireAuth = async (req, res, next) => {
     if (error.code === 211) {
       return res.sendStatus(403)
     }
-    throw error
+    next(error)
   }
 }
 
@@ -33,13 +33,15 @@ exports.customerServiceOnly = async (req, res, next) => {
   }
 }
 
+function throwError(status = 500, message = 'Internal Error') {
+  const error = new Error(message)
+  error.status = status
+  throw error
+}
+
 exports.catchError = (handler) => {
   return async (req, res, next, ...args) => {
-    res.throw = (status = 500, message = 'Internal Error') => {
-      const error = new Error(message)
-      error.status = status
-      throw error
-    }
+    res.throw = throwError
     try {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {

--- a/api/rule/automation/api.js
+++ b/api/rule/automation/api.js
@@ -3,7 +3,7 @@ const { check } = require('express-validator')
 const { Router } = require('express')
 
 const { requireAuth, customerServiceOnly, catchError } = require('../../middleware')
-const { ticketOpenedStatuses } = require('../../../lib/common')
+const { TICKET_OPENED_STATUSES } = require('../../../lib/common')
 const { Context } = require('../context')
 const { Automation } = require('./automation')
 
@@ -117,7 +117,7 @@ router.post(
   check('conditions').isObject(),
   catchError(async (req, res) => {
     const query = new AV.Query('Ticket')
-    query.containedIn('status', ticketOpenedStatuses())
+    query.containedIn('status', TICKET_OPENED_STATUSES)
     query.limit(1000)
     query.addAscending('createdAt')
     const tickets = await query.find({ useMasterKey: true })

--- a/api/stats.js
+++ b/api/stats.js
@@ -5,12 +5,12 @@ const AV = require('leanengine')
 
 const forEachAVObject = require('./common').forEachAVObject
 
-const { TICKET_STATUS, ticketOpenedStatuses } = require('../lib/common')
+const { TICKET_STATUS, TICKET_OPENED_STATUSES } = require('../lib/common')
 
 AV.Cloud.define('statsOpenedTicket', (req, res) => {
   res.success()
   forEachAVObject(
-    new AV.Query('Ticket').containedIn('status', ticketOpenedStatuses()),
+    new AV.Query('Ticket').containedIn('status', TICKET_OPENED_STATUSES),
     (ticket) => {
       return AV.Cloud.run('statsTicket', { ticketId: ticket.id }).catch((err) => {
         console.log('err >>', ticket.id, err)

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -3,7 +3,7 @@ const { Router } = require('express')
 const { check, query } = require('express-validator')
 
 const { checkPermission } = require('../oauth')
-const { requireAuth, catchError } = require('../middleware')
+const { requireAuth, catchError, customerServiceOnly } = require('../middleware')
 const {
   selectAssignee,
   getVacationerIds,
@@ -278,6 +278,9 @@ router.put(
      * @type {AV.Object}
      */
     const ticket = req.ticket
+    if (req.user.id !== ticket.get('author').id) {
+      res.throw(403)
+    }
     if (ticket.has('evaluation')) {
       res.throw(409, 'Evaluation already exists')
     }
@@ -340,6 +343,7 @@ router.patch(
 
 router.post(
   '/:id/subscription',
+  customerServiceOnly,
   catchError(async (req, res) => {
     const { user, ticket } = req
     const watch = await getWatchObject(user, ticket)
@@ -356,6 +360,7 @@ router.post(
 
 router.delete(
   '/:id/subscription',
+  customerServiceOnly,
   catchError(async (req, res) => {
     const { user, ticket } = req
     const watch = await getWatchObject(user, ticket)

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -1,0 +1,418 @@
+const AV = require('leanengine')
+const { Router } = require('express')
+const { check, query } = require('express-validator')
+
+const { checkPermission } = require('../oauth')
+const { requireAuth, catchError } = require('../middleware')
+const {
+  selectAssignee,
+  getVacationerIds,
+  getTinyCategoryInfo,
+  saveWithoutHooks,
+  getActionStatus,
+} = require('./utils')
+const { isCustomerService, getTinyUserInfo, htmlify, getTinyReplyInfo } = require('../common')
+const { TICKET_ACTION, TICKET_STATUS, ticketStatus, getTicketAcl } = require('../../lib/common')
+const { afterSaveTicketHandler, afterUpdateTicketHandler } = require('./hook-handler')
+const { getReplyAcl } = require('../Reply')
+const notification = require('../notification')
+const { invokeWebhooks } = require('../webhook')
+
+const router = Router().use(requireAuth)
+
+function getWatchObject(user, ticket) {
+  return new AV.Query('Watch')
+    .select('objectId')
+    .equalTo('user', user)
+    .equalTo('ticket', ticket)
+    .first({ useMasterKey: true })
+}
+
+router.post(
+  '/',
+  check('title').isString().trim().isLength({ min: 1 }),
+  check('categoryId').isString(),
+  check('content').isString(),
+  check('organizationId').isString().optional(),
+  check('files').isArray().optional(),
+  check('files.*.__type').custom((value) => value === 'Pointer'),
+  check('files.*.className').custom((value) => value === '_File'),
+  check('files.*.objectId').isString(),
+  catchError(async (req, res) => {
+    if (!(await checkPermission(req.user))) {
+      res.throw(403, 'Your account is not qualified to create ticket.')
+    }
+
+    const { title, categoryId, content, organizationId, files = [] } = req.body
+    const author = req.user
+    const organization = organizationId
+      ? AV.Object.createWithoutData('Organization', organizationId)
+      : undefined
+    const [assignee, categoryInfo] = await Promise.all([
+      selectAssignee(categoryId),
+      getTinyCategoryInfo(categoryId),
+    ])
+
+    const ticket = new AV.Object('Ticket')
+    ticket.setACL(new AV.ACL(getTicketAcl(author, organization)))
+    ticket.set('status', TICKET_STATUS.NEW)
+    ticket.set('title', title)
+    ticket.set('author', author)
+    ticket.set('assignee', assignee)
+    ticket.set('category', categoryInfo)
+    ticket.set('content', content)
+    ticket.set('content_HTML', htmlify(content))
+    ticket.set('files', files)
+    if (organization) {
+      ticket.set('organization', organization)
+    }
+
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      ignoreAfterHook: true,
+    })
+    afterSaveTicketHandler(ticket, { skipFetchAuthorAndAssignee: true })
+
+    res.json({ objectId: ticket.id })
+  })
+)
+
+router.param(
+  'id',
+  catchError(async (req, res, next, id) => {
+    if (!/^\d+$/.test(id)) {
+      res.throw(400, 'Invalid nid')
+    }
+    const query = new AV.Query('Ticket').equalTo('nid', parseInt(id))
+    req.ticket = await query.first({ user: req.user })
+    if (!req.ticket) {
+      res.throw(404, 'Ticket not found')
+    }
+    next()
+  })
+)
+
+router.get(
+  '/:id',
+  catchError(async (req, res) => {
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    const [isCS, watch] = await Promise.all([
+      isCustomerService(req.user),
+      getWatchObject(req.user, ticket),
+      ticket.fetch(
+        { include: ['author', 'assignee', 'files', 'organization'] },
+        { useMasterKey: true }
+      ),
+    ])
+
+    res.json({
+      ticket: {
+        objectId: ticket.id,
+        nid: ticket.get('nid'),
+        title: ticket.get('title'),
+        author: ticket.get('author'),
+        organization: ticket.get('organization'),
+        assignee: ticket.get('assignee'),
+        category: ticket.get('category'),
+        content: ticket.get('content'),
+        content_HTML: ticket.get('content_HTML'),
+        files: ticket.get('files') || [],
+        evaluation: ticket.get('evaluation') || null,
+        joinedCustomerService: ticket.get('joinedCustomerService') || [],
+        status: ticket.get('status'),
+        tags: ticket.get('tags') || [],
+        privateTags: isCS ? ticket.get('privateTags') || [] : undefined,
+        metaData: ticket.get('metaData'),
+        createdAt: ticket.createdAt,
+        updatedAt: ticket.updatedAt,
+      },
+      subscribed: !!watch,
+    })
+
+    try {
+      const messages = await new AV.Query('Message')
+        .equalTo('ticket', ticket)
+        .equalTo('to', req.user)
+        .lessThanOrEqualTo('createdAt', new Date())
+        .limit(1000)
+        .find({ user: req.user })
+      if (messages.length) {
+        messages.forEach((message) => message.set('isRead', true))
+        await AV.Object.saveAll(messages, { user: req.user })
+      }
+    } catch {
+      // ignore errors
+    }
+  })
+)
+
+router.get(
+  '/:id/replies',
+  query('page.after').isString().optional(),
+  catchError(async (req, res) => {
+    const { page } = req.query
+    const query = new AV.Query('Reply')
+      .equalTo('ticket', req.ticket)
+      .include('author', 'files')
+      .ascending('objectId')
+      .limit(500)
+    if (page?.after) {
+      query.greaterThan('objectId', page.after)
+    }
+    const replies = await query.find({ useMasterKey: true })
+    res.json({
+      replies: replies.map((reply) => ({
+        objectId: reply.id,
+        nid: reply.get('nid'),
+        author: reply.get('author'),
+        content: reply.get('content'),
+        content_HTML: reply.get('content_HTML'),
+        files: reply.get('files') || [],
+        isCustomerService: reply.get('isCustomerService'),
+        createdAt: reply.createdAt,
+      })),
+    })
+  })
+)
+
+router.post(
+  '/:id/replies',
+  check('content').isString(),
+  check('files').isArray().optional(),
+  check('files.*.__type').custom((value) => value === 'Pointer'),
+  check('files.*.className').custom((value) => value === '_File'),
+  check('files.*.objectId').isString(),
+  catchError(async (req, res) => {
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    const { content, files = [] } = req.body
+    const author = req.user
+    const reply = new AV.Object('Reply')
+    const isCS = await isCustomerService(author, ticket.get('author'))
+    reply.setACL(getReplyAcl(ticket, author))
+    reply.set('author', author)
+    reply.set('content', content)
+    reply.set('content_HTML', htmlify(content))
+    reply.set('files', files)
+    reply.set('isCustomerService', isCS)
+
+    await saveWithoutHooks(reply, {
+      ignoreBeforeHook: true,
+      ignoreAfterHook: true,
+    })
+    res.json({})
+
+    const [replyInfo, authorInfo] = await Promise.all([
+      getTinyReplyInfo(reply),
+      getTinyUserInfo(author),
+      ticket.fetch({ include: ['author', 'assignee'] }, { useMasterKey: true }),
+    ])
+    ticket.set('latestReply', replyInfo)
+    ticket.increment('replyCount', 1)
+    ticket.updatedKeys = ['latestReply', 'replyCount']
+
+    if (isCS) {
+      ticket.addUnique('joinedCustomerService', authorInfo)
+      ticket.set('status', TICKET_STATUS.WAITING_CUSTOMER)
+      ticket.increment('unreadCount')
+      ticket.updatedKeys.push('joinedCustomerServices', 'status', 'unreadCount')
+    } else {
+      ticket.set('status', TICKET_STATUS.WAITING_CUSTOMER_SERVICE)
+      ticket.updatedKeys.push('status')
+    }
+
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      ignoreAfterHook: true,
+      useMasterKey: true,
+    })
+    afterUpdateTicketHandler(ticket, {
+      user: author,
+    })
+    notification.replyTicket(ticket, reply, author)
+    invokeWebhooks('reply.create', { reply: reply.toJSON() })
+  })
+)
+
+router.get(
+  '/:id/ops-logs',
+  query('page.after').isString().optional(),
+  catchError(async (req, res) => {
+    const { page } = req.query
+    const query = new AV.Query('OpsLog')
+      .equalTo('ticket', req.ticket)
+      .ascending('objectId')
+      .limit(500)
+    if (page?.after) {
+      query.greaterThan('objectId', page.after)
+    }
+    const opsLogs = await query.find({ useMasterKey: true })
+    res.json({
+      opsLogs: opsLogs.map((opsLog) => ({
+        objectId: opsLog.id,
+        action: opsLog.get('action'),
+        data: opsLog.get('data'),
+        createdAt: opsLog.createdAt,
+      })),
+    })
+  })
+)
+
+router.put(
+  '/:id/evaluation',
+  check('evaluation.star').isInt().isIn([0, 1]),
+  check('evaluation.content').isString(),
+  catchError(async (req, res) => {
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    if (ticket.has('evaluation')) {
+      res.throw(409, 'Evaluation already exists')
+    }
+
+    const { evaluation } = req.body
+    ticket.set('evaluation', evaluation)
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      useMasterKey: true,
+    })
+    res.json({})
+  })
+)
+
+router.patch(
+  '/:id',
+  check('assigneeId').isString().optional(),
+  check('categoryId').isString().optional(),
+  catchError(async (req, res) => {
+    const { assigneeId, categoryId } = req.body
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    ticket.updatedKeys = []
+
+    const isCS = await isCustomerService(req.user)
+    if (!isCS) {
+      res.throw(403, 'Forbidden')
+    }
+
+    if (assigneeId) {
+      const vacationerIds = await getVacationerIds()
+      if (vacationerIds.includes(assigneeId)) {
+        res.throw(400, 'Sorry, this customer service is in vacation.')
+      }
+      const assignee = await new AV.Query('_User').get(assigneeId)
+      ticket.set('assignee', assignee)
+      ticket.updatedKeys.push('assignee')
+    }
+
+    if (categoryId) {
+      const categoryInfo = await getTinyCategoryInfo(categoryId)
+      ticket.set('category', categoryInfo)
+      ticket.updatedKeys.push('category')
+    }
+
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      ignoreAfterHook: true,
+      useMasterKey: true,
+    })
+    afterUpdateTicketHandler(ticket, {
+      user: req.user,
+      skipFetchAssignee: !!assigneeId,
+    })
+    res.json({})
+  })
+)
+
+router.post(
+  '/:id/subscription',
+  catchError(async (req, res) => {
+    const { user, ticket } = req
+    const watch = await getWatchObject(user, ticket)
+    if (!watch) {
+      await new AV.Object('Watch', {
+        ACL: { [user.id]: { read: true, write: true } },
+        user,
+        ticket,
+      }).save()
+    }
+    res.json({})
+  })
+)
+
+router.delete(
+  '/:id/subscription',
+  catchError(async (req, res) => {
+    const { user, ticket } = req
+    const watch = await getWatchObject(user, ticket)
+    if (!watch) {
+      return res.throw(404)
+    }
+    await watch.destroy({ useMasterKey: true })
+    res.json({})
+  })
+)
+
+router.put(
+  '/:id/tags',
+  check('tags').isArray(),
+  check('tags.*.key').isString().isLength({ min: 1 }),
+  check('tags.*.value').isString(),
+  check('isPrivate').isBoolean().optional(),
+  catchError(async (req, res) => {
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    const { tags, isPrivate } = req.body
+    ticket.set(isPrivate ? 'privateTags' : 'tags', tags)
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      useMasterKey: true,
+    })
+    res.json({})
+  })
+)
+
+router.post(
+  '/:id/operate',
+  check('action')
+    .isString()
+    .custom((action) => Object.values(TICKET_ACTION).includes(action)),
+  catchError(async (req, res) => {
+    /**
+     * @type {AV.Object}
+     */
+    const ticket = req.ticket
+    const { action } = req.body
+    const [isCS, operatorInfo] = await Promise.all([
+      isCustomerService(req.user, ticket.get('author')),
+      getTinyUserInfo(req.user),
+    ])
+
+    const status = getActionStatus(action, isCS)
+    if (isCS) {
+      ticket.addUnique('joinedCustomerServices', operatorInfo)
+      if (ticketStatus.isOpened(status) !== ticketStatus.isOpened(ticket.get('status'))) {
+        ticket.increment('unreadCount')
+      }
+    }
+
+    ticket.set('status', status)
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      useMasterKey: true,
+    })
+    res.json({})
+  })
+)
+
+module.exports = router

--- a/api/ticket/hook-handler.js
+++ b/api/ticket/hook-handler.js
@@ -1,0 +1,107 @@
+const AV = require('leancloud-storage')
+
+const { addOpsLog } = require('./utils')
+const notification = require('../notification')
+const { getTinyUserInfo, systemUser } = require('../common')
+const { ticketStatus } = require('../../lib/common')
+const { invokeWebhooks } = require('../webhook')
+const { getActiveTriggers, recordTriggerLog } = require('../rule/trigger')
+const { Context } = require('../rule/context')
+
+/**
+ * @param {AV.Object} ticket
+ * @param {'create' | 'update'} updateType
+ */
+async function invokeTriggers(ticket, updateType) {
+  // Triggers do not run or fire on tickets after they are closed.
+  // However, triggers can fire when a ticket is being set to closed.
+  if (ticketStatus.isClosed(ticket.get('status')) && !ticket.updatedKeys?.includes('status')) {
+    return
+  }
+
+  const ctx = new Context(ticket.toJSON(), updateType, ticket.updatedKeys)
+  const triggers = await getActiveTriggers()
+  triggers.exec(ctx)
+  if (ctx.isUpdated()) {
+    const updatedData = ctx.getUpdatedData()
+    const ticketToUpdate = AV.Object.createWithoutData('Ticket', ticket.id)
+    ticketToUpdate.disableAfterHook()
+    await ticketToUpdate.save(updatedData, { useMasterKey: true })
+
+    const ticketToInvokeHook = AV.Object.createWithoutData('Ticket', ticket.id)
+    Object.entries(ctx.data).forEach(([key, value]) => (ticketToInvokeHook.attributes[key] = value))
+    ticketToInvokeHook.updatedKeys = Object.keys(updatedData)
+    afterUpdateTicketHandler(ticketToInvokeHook, { skipTriggers: updateType === 'update' })
+  }
+
+  recordTriggerLog(triggers, ticket.id)
+}
+
+/**
+ * @param {AV.Object} ticket
+ * @param {object} [options]
+ * @param {boolean} [options.skipFetchAuthorAndAssignee]
+ */
+async function afterSaveTicketHandler(ticket, options) {
+  if (!options?.skipFetchAuthorAndAssignee) {
+    await ticket.fetch({ include: ['author', 'assignee'] }, { useMasterKey: true })
+  }
+  const author = ticket.get('author')
+  const assignee = ticket.get('assignee')
+  addOpsLog(ticket, 'selectAssignee', { assignee: await getTinyUserInfo(assignee) })
+  notification.newTicket(ticket, author, assignee)
+  invokeWebhooks('ticket.create', { ticket: ticket.toJSON() })
+  invokeTriggers(ticket, 'create')
+}
+
+/**
+ * @param {AV.Object} ticket
+ * @param {object} [options]
+ * @param {AV.User} [options.user]
+ * @param {boolean} [options.skipTriggers]
+ * @param {boolean} [options.skipFetchAssignee]
+ */
+async function afterUpdateTicketHandler(ticket, options) {
+  if (!options?.skipFetchAssignee) {
+    await ticket.fetch({ include: ['assignee'] }, { useMasterKey: true })
+  }
+  const user = options?.user || systemUser
+  const userInfo = await getTinyUserInfo(user)
+
+  if (ticket.updatedKeys?.includes('category')) {
+    addOpsLog(ticket, 'changeCategory', {
+      category: ticket.get('category'),
+      operator: userInfo,
+    })
+  }
+
+  if (ticket.updatedKeys?.includes('assignee')) {
+    const assigneeInfo = await getTinyUserInfo(ticket.get('assignee'))
+    addOpsLog(ticket, 'changeAssignee', {
+      assignee: assigneeInfo,
+      operator: userInfo,
+    })
+    notification.changeAssignee(ticket, user, ticket.get('assignee'))
+  }
+
+  if (ticket.updatedKeys?.includes('status')) {
+    if (ticketStatus.isClosed(ticket.get('status'))) {
+      AV.Cloud.run('statsTicket', { ticketId: ticket.id })
+    }
+  }
+
+  if (ticket.updatedKeys?.includes('evaluation') && options?.user) {
+    notification.ticketEvaluation(ticket, options.user, ticket.get('assignee'))
+  }
+
+  invokeWebhooks('ticket.update', {
+    ticket: ticket.toJSON(),
+    updatedKeys: ticket.updatedKeys,
+  })
+
+  if (!options?.skipTriggers) {
+    invokeTriggers(ticket, 'update')
+  }
+}
+
+module.exports = { afterSaveTicketHandler, afterUpdateTicketHandler }

--- a/api/ticket/utils.js
+++ b/api/ticket/utils.js
@@ -1,0 +1,112 @@
+const AV = require('leancloud-storage')
+const _ = require('lodash')
+
+const { TICKET_ACTION, TICKET_STATUS } = require('../../lib/common')
+const { captureException } = require('../errorHandler')
+
+/**
+ * @param {string} categoryId
+ * @returns {Promise<{ objectId: string; name: string }>}
+ */
+async function getTinyCategoryInfo(categoryId) {
+  const category = await new AV.Query('Category').get(categoryId)
+  return {
+    objectId: category.id,
+    name: category.get('name'),
+  }
+}
+
+/**
+ * @returns {Promise<string[]>}
+ */
+async function getVacationerIds() {
+  const now = new Date()
+  const vacations = await new AV.Query('Vacation')
+    .lessThan('startDate', now)
+    .greaterThan('endDate', now)
+    .find({ useMasterKey: true })
+  return vacations.map((v) => v.get('vacationer').id)
+}
+
+/**
+ * @param {string} categoryId
+ * @returns {Promise<AV.User>}
+ */
+async function selectAssignee(categoryId) {
+  const [role, vacationerIds] = await Promise.all([
+    new AV.Query(AV.Role).equalTo('name', 'customerService').first(),
+    getVacationerIds(),
+  ])
+  const query = role.getUsers().query()
+  if (vacationerIds.length) {
+    query.notContainedIn('objectId', vacationerIds)
+  }
+  const users = await query.find({ useMasterKey: true })
+
+  const assignees = users.filter((user) => {
+    /**
+     * @type {Array<{objectId: string}>}
+     */
+    const categories = user.get('categories') || []
+    return categories.findIndex((c) => c.objectId === categoryId) !== -1
+  })
+
+  return assignees.length ? _.sample(assignees) : _.sample(users)
+}
+
+function addOpsLog(ticket, action, data) {
+  return new AV.Object('OpsLog')
+    .save({ ticket, action, data }, { useMasterKey: true })
+    .catch(captureException)
+}
+
+function getActionStatus(action, isCustomerService) {
+  switch (action) {
+    case TICKET_ACTION.REPLY_WITH_NO_CONTENT:
+      return TICKET_STATUS.WAITING_CUSTOMER
+    case TICKET_ACTION.REPLY_SOON:
+      return TICKET_STATUS.WAITING_CUSTOMER_SERVICE
+    case TICKET_ACTION.RESOLVE:
+      return isCustomerService ? TICKET_STATUS.PRE_FULFILLED : TICKET_STATUS.FULFILLED
+    case TICKET_ACTION.CLOSE:
+    // 向前兼容
+    // eslint-disable-next-line no-fallthrough
+    case TICKET_ACTION.REJECT:
+      return TICKET_STATUS.CLOSED
+    case TICKET_ACTION.REOPEN:
+      return TICKET_STATUS.WAITING_CUSTOMER
+    default:
+      throw new Error('invalid action')
+  }
+}
+
+/**
+ * @param {AV.Object} object
+ * @param {object} [options]
+ * @param {boolean} [options.ignoreBeforeHook]
+ * @param {boolean} [options.ignoreAfterHook]
+ * @param {boolean} [options.useMasterKey]
+ */
+async function saveWithoutHooks(object, options) {
+  const ignoredHooks = _.clone(object._flags.__ignore_hooks)
+  if (options?.ignoreBeforeHook) {
+    object.disableBeforeHook()
+  }
+  if (options?.ignoreAfterHook) {
+    object.disableAfterHook()
+  }
+  try {
+    await object.save(null, { useMasterKey: options?.useMasterKey })
+  } finally {
+    object._flags.__ignore_hooks = ignoredHooks
+  }
+}
+
+module.exports = {
+  getVacationerIds,
+  getTinyCategoryInfo,
+  addOpsLog,
+  saveWithoutHooks,
+  getActionStatus,
+  selectAssignee,
+}

--- a/lib/common.js
+++ b/lib/common.js
@@ -54,29 +54,20 @@ exports.TICKET_STATUS_MSG = {
   [exports.TICKET_STATUS.CLOSED]: 'statusClosed',
 }
 
-exports.ticketOpenedStatuses = () => {
-  return [
-    exports.TICKET_STATUS.NEW,
-    exports.TICKET_STATUS.WAITING_CUSTOMER_SERVICE,
-    exports.TICKET_STATUS.WAITING_CUSTOMER,
-  ]
-}
+exports.TICKET_OPENED_STATUSES = [
+  exports.TICKET_STATUS.NEW,
+  exports.TICKET_STATUS.WAITING_CUSTOMER_SERVICE,
+  exports.TICKET_STATUS.WAITING_CUSTOMER,
+]
 
-exports.ticketClosedStatuses = () => {
-  return [
-    exports.TICKET_STATUS.PRE_FULFILLED,
-    exports.TICKET_STATUS.FULFILLED,
-    exports.TICKET_STATUS.CLOSED,
-  ]
-}
-
+exports.TICKET_CLOSED_STATUSES = [
+  exports.TICKET_STATUS.PRE_FULFILLED,
+  exports.TICKET_STATUS.FULFILLED,
+  exports.TICKET_STATUS.CLOSED,
+]
 exports.ticketStatus = {
-  isOpened: (status) => exports.ticketOpenedStatuses().includes(status),
-  isClosed: (status) => exports.ticketClosedStatuses().includes(status),
-}
-exports.isTicketOpen = (ticket) => {
-  // 前后端都使用了这个函数，必须通过 get 方法获取属性
-  return exports.ticketStatus.isOpened(ticket.get('status'))
+  isOpened: (status) => exports.TICKET_OPENED_STATUSES.includes(status),
+  isClosed: (status) => exports.TICKET_CLOSED_STATUSES.includes(status),
 }
 
 exports.getGravatarHash = (email = '') => md5(email.trim().toLocaleLowerCase())

--- a/lib/leancloud.js
+++ b/lib/leancloud.js
@@ -49,12 +49,22 @@ LC.use({
 })
 
 /**
+ * @typedef {Record<string, string | number | boolean} QueryParams
+ */
+
+/**
  *
- * @param {RequestInfo} input
- * @param {RequestInit} [init]
- * @returns {Promise<Response>}
+ * @param {string} input
+ * @param {RequestInit & { query?: QueryParams }} [init]
+ * @returns {Promise}
  */
 export async function fetch(input, init) {
+  if (init?.query) {
+    const query = Object.entries(init.query).filter(([, value]) => value !== undefined)
+    if (Object.keys(query).length) {
+      input += '?' + query.map(([key, value]) => encodeURIComponent(`${key}=${value}`)).join('&')
+    }
+  }
   const res = await window.fetch(input, {
     ...init,
     headers: {

--- a/lib/leancloud.js
+++ b/lib/leancloud.js
@@ -62,7 +62,7 @@ export async function fetch(input, init) {
   if (init?.query) {
     const query = Object.entries(init.query).filter(([, value]) => value !== undefined)
     if (Object.keys(query).length) {
-      input += '?' + query.map(([key, value]) => encodeURIComponent(`${key}=${value}`)).join('&')
+      input += '?' + query.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&')
     }
   }
   const res = await window.fetch(input, {

--- a/modules/App.js
+++ b/modules/App.js
@@ -4,6 +4,7 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import { Container } from 'react-bootstrap'
 import { Route, Switch, withRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from 'react-query'
 import PropTypes from 'prop-types'
 import NotificationSystem from 'react-notification-system'
 import Raven from 'raven-js'
@@ -35,6 +36,14 @@ import Settings from './Settings'
 if (SENTRY_DSN_PUBLIC !== '') {
   Raven.config(SENTRY_DSN_PUBLIC).install()
 }
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 class App extends Component {
   constructor(props) {
@@ -188,52 +197,57 @@ class App extends Component {
     return (
       <>
         {!this.state.loading && (
-          <AppContext.Provider
-            value={{
-              isCustomerService: props.isCustomerService,
-              tagMetadatas: props.tagMetadatas,
-              addNotification: this.getChildContext().addNotification,
-            }}
-          >
-            <GlobalNav user={this.state.currentUser?.toJSON()} onLogout={this.logout.bind(this)} />
-            <Container className={`${css.main} py-2`}>
-              <Switch>
-                <Route path="/" exact>
-                  <Home {...props} />
-                </Route>
-                <Route path="/about" component={About} />
-                <Route path="/login">
-                  <Login {...props} />
-                </Route>
-                <AuthRoute path="/tickets" exact>
-                  <Tickets {...props} />
-                </AuthRoute>
-                <AuthRoute path="/tickets/new">
-                  <NewTicket {...props} />
-                </AuthRoute>
-                <AuthRoute path="/tickets/:nid">
-                  <Ticket {...props} />
-                </AuthRoute>
-                <AuthRoute path="/messages">
-                  <Messages {...props} />
-                </AuthRoute>
-                <AuthRoute path="/notifications">
-                  <Notifications {...props} />
-                </AuthRoute>
-                <AuthRoute mustCustomerService path="/customerService">
-                  <CustomerService />
-                </AuthRoute>
-                <AuthRoute path="/users/:username">
-                  <User {...props} />
-                </AuthRoute>
-                <AuthRoute path="/settings">
-                  <Settings {...props} />
-                </AuthRoute>
-                <Route path="/error" component={ErrorPage} />
-                <Route path="*" component={NotFound} />
-              </Switch>
-            </Container>
-          </AppContext.Provider>
+          <QueryClientProvider client={queryClient}>
+            <AppContext.Provider
+              value={{
+                isCustomerService: props.isCustomerService,
+                tagMetadatas: props.tagMetadatas,
+                addNotification: this.getChildContext().addNotification,
+              }}
+            >
+              <GlobalNav
+                user={this.state.currentUser?.toJSON()}
+                onLogout={this.logout.bind(this)}
+              />
+              <Container className={`${css.main} py-2`}>
+                <Switch>
+                  <Route path="/" exact>
+                    <Home {...props} />
+                  </Route>
+                  <Route path="/about" component={About} />
+                  <Route path="/login">
+                    <Login {...props} />
+                  </Route>
+                  <AuthRoute path="/tickets" exact>
+                    <Tickets {...props} />
+                  </AuthRoute>
+                  <AuthRoute path="/tickets/new">
+                    <NewTicket {...props} />
+                  </AuthRoute>
+                  <AuthRoute path="/tickets/:nid">
+                    <Ticket {...props} />
+                  </AuthRoute>
+                  <AuthRoute path="/messages">
+                    <Messages {...props} />
+                  </AuthRoute>
+                  <AuthRoute path="/notifications">
+                    <Notifications {...props} />
+                  </AuthRoute>
+                  <AuthRoute mustCustomerService path="/customerService">
+                    <CustomerService />
+                  </AuthRoute>
+                  <AuthRoute path="/users/:username">
+                    <User {...props} />
+                  </AuthRoute>
+                  <AuthRoute path="/settings">
+                    <Settings {...props} />
+                  </AuthRoute>
+                  <Route path="/error" component={ErrorPage} />
+                  <Route path="*" component={NotFound} />
+                </Switch>
+              </Container>
+            </AppContext.Provider>
+          </QueryClientProvider>
         )}
         <ServerNotification currentUser={this.state.currentUser} />
         <NotificationSystem ref="notificationSystem" />

--- a/modules/CategoriesSelect.js
+++ b/modules/CategoriesSelect.js
@@ -9,8 +9,8 @@ import { depthFirstSearchMap } from '../lib/common'
 export default function CategoriesSelect({
   categoriesTree,
   selected,
-  onChange,
   hiddenDisable = true,
+  ...props
 }) {
   const options = _.compact(
     depthFirstSearchMap(categoriesTree, (c) => {
@@ -21,7 +21,7 @@ export default function CategoriesSelect({
         <option
           key={c.id}
           value={c.id}
-          disabled={selected && (selected.id || selected.objectId) == c.id}
+          disabled={selected && (selected.id || selected.objectId) === c.id}
         >
           {getNodeIndentString(c) + getCategoryName(c)}
         </option>
@@ -29,22 +29,14 @@ export default function CategoriesSelect({
     })
   )
   return (
-    <FormControl
-      as="select"
-      value={selected ? selected.id || selected.objectId : ''}
-      onChange={onChange}
-    >
+    <FormControl {...props} as="select" value={selected ? selected.id || selected.objectId : ''}>
       <option value=""></option>
       {options}
     </FormControl>
   )
 }
-
-CategoriesSelect.displayName = 'CategoriesSelect'
-
 CategoriesSelect.propTypes = {
   categoriesTree: PropTypes.array.isRequired,
   selected: PropTypes.object,
-  onChange: PropTypes.func,
   hiddenDisable: PropTypes.bool,
 }

--- a/modules/CustomerService/Tickets.js
+++ b/modules/CustomerService/Tickets.js
@@ -16,8 +16,8 @@ import {
   TICKET_STATUS_MSG,
   TIME_RANGE_MAP,
   getUserDisplayName,
-  ticketOpenedStatuses,
-  ticketClosedStatuses,
+  TICKET_OPENED_STATUSES,
+  TICKET_CLOSED_STATUSES,
   ticketStatus,
 } from '../../lib/common'
 import { TicketStatusLabel } from '../components/TicketStatusLabel'
@@ -536,9 +536,9 @@ export function useTickets() {
     }
 
     if (isOpen === 'true') {
-      query = query.where('status', 'in', ticketOpenedStatuses()).orderBy('status')
+      query = query.where('status', 'in', TICKET_OPENED_STATUSES).orderBy('status')
     } else if (isOpen === 'false') {
-      query = query.where('status', 'in', ticketClosedStatuses())
+      query = query.where('status', 'in', TICKET_CLOSED_STATUSES)
     } else if (status) {
       query = query.where('status', '==', parseInt(status))
     }

--- a/modules/CustomerService/hooks.js
+++ b/modules/CustomerService/hooks.js
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query'
+
+import { auth } from '../../lib/leancloud'
+
+/**
+ * @returns {Promise<any[]>}
+ */
+export async function fetchCustomerServices() {
+  const role = await auth.queryRole().where('name', '==', 'customerService').first()
+  const customerServices = await role.queryUser().orderBy('username').find()
+  return customerServices.map((u) => u.toJSON())
+}
+
+export function useCustomerServices() {
+  return useQuery('customerServices', fetchCustomerServices)
+}

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -212,10 +212,11 @@ class NewTicket extends React.Component {
     this.setState({ isCommitting: true })
     try {
       const organization = this.props.selectedOrgId ? { id: this.props.selectedOrgId } : undefined
+      const uploadedFiles = await uploadFiles(document.getElementById('ticketFile').files)
       const ticketId = await createTicket({
         title: ticket.title,
         content: ticket.content,
-        files: await uploadFiles(document.getElementById('ticketFile').files),
+        files: uploadedFiles.map((file) => ({ objectId: file.id })),
         categoryId: _.last(this.state.categoryPath).id,
         organizationId: organization?.id,
       })

--- a/modules/Settings/Rule/Automation/index.js
+++ b/modules/Settings/Rule/Automation/index.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react'
 import { Button, ButtonGroup, Form, Table } from 'react-bootstrap'
 import { Link, Route, Switch, useHistory, useRouteMatch } from 'react-router-dom'
 import { createResourceHook } from '@leancloud/use-resource'
+import * as Icon from 'react-bootstrap-icons'
 
 import { AppContext } from '../../../context'
 import { fetch } from '../../../../lib/leancloud'
@@ -149,7 +150,7 @@ function AutomationList() {
                       disabled={index === 0}
                       onClick={() => moveUp(index)}
                     >
-                      <i className="bi bi-caret-up-fill"></i>
+                      <Icon.CaretUpFill />
                     </Button>
                     <Button
                       className="py-0"
@@ -157,7 +158,7 @@ function AutomationList() {
                       disabled={index === localAutomations.length - 1}
                       onClick={() => moveDown(index)}
                     >
-                      <i className="bi bi-caret-down-fill"></i>
+                      <Icon.CaretDownFill />
                     </Button>
                   </ButtonGroup>
                 </td>

--- a/modules/TagForm.js
+++ b/modules/TagForm.js
@@ -14,40 +14,40 @@ class TagForm extends React.Component {
     }
   }
 
-  handleChange(e) {
+  async handleChange(e) {
     const tagMetadata = this.props.tagMetadata
-    if (tagMetadata.get('type') == 'select') {
-      return this.props
-        .changeTagValue(tagMetadata.get('key'), e.target.value, tagMetadata.get('isPrivate'))
-        .then(() => {
-          this.setState({ isUpdate: false })
-          return
-        })
+    if (tagMetadata.get('type') === 'select') {
+      await this.props.changeTagValue(
+        tagMetadata.get('key'),
+        e.target.value,
+        tagMetadata.get('isPrivate')
+      )
+      this.setState({ isUpdate: false })
+      return
     }
-
     this.setState({ value: e.target.value })
   }
 
-  handleCommit() {
+  async handleCommit() {
     const tagMetadata = this.props.tagMetadata
-    return this.props
-      .changeTagValue(tagMetadata.get('key'), this.state.value, tagMetadata.get('isPrivate'))
-      .then(() => {
-        this.setState({ isUpdate: false })
-        return
-      })
+    await this.props.changeTagValue(
+      tagMetadata.get('key'),
+      this.state.value,
+      tagMetadata.get('isPrivate')
+    )
+    this.setState({ isUpdate: false })
   }
 
   render() {
     const { t, tagMetadata, tag, isCustomerService } = this.props
     const isPrivate = tagMetadata.get('isPrivate')
     if (isPrivate && !isCustomerService) {
-      return <div></div>
+      return null
     }
 
     // 如果标签不存在，说明标签还没设置过。对于非客服来说则什么都不显示
     if (!tag && !isCustomerService) {
-      return <div></div>
+      return null
     }
 
     return (

--- a/modules/Ticket/Evaluation.js
+++ b/modules/Ticket/Evaluation.js
@@ -1,112 +1,81 @@
-import React, { Component } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { Alert, Button, Form } from 'react-bootstrap'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
 import * as Icon from 'react-bootstrap-icons'
 
-class Evaluation extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isAlreadyEvaluation: false,
-      star: 1,
-      content: localStorage.getItem(`ticket:${this.props.ticket.objectId}:evaluation`) || '',
-    }
-  }
+import { AppContext } from '../context'
+import { fetch } from '../../lib/leancloud'
 
-  handleStarChange(e) {
-    this.setState({ star: parseInt(e.target.value) })
-  }
+export default function Evaluation({ ticket, isCustomerService }) {
+  const { t } = useTranslation()
+  const { addNotification } = useContext(AppContext)
+  const [star, setStar] = useState(ticket.evaluation?.star ?? 1)
+  const [content, setContent] = useState(ticket.evaluation?.content ?? '')
+  useEffect(() => {
+    localStorage.setItem(`ticket:${ticket.nid}:evaluation`, content)
+  }, [ticket.nid, content])
 
-  handleContentChange(e) {
-    localStorage.setItem(`ticket:${this.props.ticket.objectId}:evaluation`, e.target.value)
-    this.setState({ content: e.target.value })
-  }
-
-  handleSubmit(e) {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    this.props
-      .saveEvaluation({
-        star: this.state.star,
-        content: this.state.content,
+    try {
+      await fetch(`/api/1/tickets/${ticket.nid}/evaluation`, {
+        method: 'PUT',
+        body: { star, content },
       })
-      .then(() => {
-        localStorage.removeItem(`ticket:${this.props.ticket.objectId}:evaluation`)
-        return
-      })
-      .catch(this.context.addNotification)
+      localStorage.removeItem(`ticket:${ticket.nid}:evaluation`)
+    } catch (error) {
+      addNotification(error)
+    }
   }
 
-  render() {
-    const { t } = this.props
-    const { evaluation } = this.props.ticket
-    if (evaluation) {
-      return (
-        <Alert variant="warning">
-          {t('feedback')}
-          <Form.Group>
-            <Form.Check
-              type="radio"
-              inline
-              disabled
-              defaultChecked={evaluation.star === 1}
-              label={<Icon.HandThumbsUp />}
-            />
-            <Form.Check
-              type="radio"
-              inline
-              disabled
-              defaultChecked={evaluation.star === 0}
-              label={<Icon.HandThumbsDown />}
-            />
-          </Form.Group>
-          <Form.Group>
-            <Form.Control as="textarea" rows="8" value={evaluation.content} disabled />
-          </Form.Group>
-        </Alert>
-      )
-    }
-
-    if (!this.props.isCustomerService) {
-      return (
-        <Alert variant="warning">
-          {t('satisfiedOrNot')}
-          <Form onSubmit={this.handleSubmit.bind(this)}>
-            <Form.Group>
-              <Form.Check
-                type="radio"
-                inline
-                value="1"
-                onClick={this.handleStarChange.bind(this)}
-                label={<Icon.HandThumbsUp />}
-              />
-              <Form.Check
-                type="radio"
-                inline
-                value="0"
-                onClick={this.handleStarChange.bind(this)}
-                label={<Icon.HandThumbsDown />}
-              />
-            </Form.Group>
-            <Form.Group>
-              <Form.Control
-                as="textarea"
-                placeholder={t('haveSomethingToSay')}
-                rows="8"
-                value={this.state.content}
-                onChange={this.handleContentChange.bind(this)}
-              />
-            </Form.Group>
-            <Button type="submit" variant="light">
-              {t('submit')}
-            </Button>
-          </Form>
-        </Alert>
-      )
-    }
-
+  if (!ticket.evaluation && isCustomerService) {
     return null
   }
+  return (
+    <Alert variant="warning">
+      {ticket.evaluation ? t('feedback') : t('satisfiedOrNot')}
+      <Form onSubmit={handleSubmit}>
+        <Form.Group>
+          <Form.Check
+            id="evaluation-good"
+            label={<Icon.HandThumbsUp />}
+            type="radio"
+            inline
+            disabled={!!ticket.evaluation}
+            checked={star === 1}
+            value={1}
+            onChange={() => setStar(1)}
+          />
+          <Form.Check
+            id="evaluation-bad"
+            label={<Icon.HandThumbsDown />}
+            type="radio"
+            inline
+            disabled={!!ticket.evaluation}
+            checked={star === 0}
+            value={0}
+            onChange={() => setStar(0)}
+          />
+        </Form.Group>
+        <Form.Group>
+          <Form.Control
+            as="textarea"
+            rows={8}
+            placeholder={ticket.evaluation ? '' : t('haveSomethingToSay')}
+            value={content}
+            disabled={!!ticket.evaluation}
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </Form.Group>
+        {!ticket.evaluation && (
+          <Button type="submit" variant="light">
+            {t('submit')}
+          </Button>
+        )}
+      </Form>
+    </Alert>
+  )
 }
 
 Evaluation.propTypes = {
@@ -118,12 +87,4 @@ Evaluation.propTypes = {
     }),
   }).isRequired,
   isCustomerService: PropTypes.bool,
-  saveEvaluation: PropTypes.func.isRequired,
-  t: PropTypes.func,
 }
-
-Evaluation.contextTypes = {
-  addNotification: PropTypes.func.isRequired,
-}
-
-export default withTranslation()(Evaluation)

--- a/modules/Ticket/Evaluation.js
+++ b/modules/Ticket/Evaluation.js
@@ -3,7 +3,6 @@ import { Alert, Button, Form } from 'react-bootstrap'
 import { withTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
 import * as Icon from 'react-bootstrap-icons'
-import LC from '../lib/leancloud'
 
 class Evaluation extends Component {
   constructor(props) {
@@ -11,7 +10,7 @@ class Evaluation extends Component {
     this.state = {
       isAlreadyEvaluation: false,
       star: 1,
-      content: localStorage.getItem(`ticket:${this.props.ticket.id}:evaluation`) || '',
+      content: localStorage.getItem(`ticket:${this.props.ticket.objectId}:evaluation`) || '',
     }
   }
 
@@ -20,7 +19,7 @@ class Evaluation extends Component {
   }
 
   handleContentChange(e) {
-    localStorage.setItem(`ticket:${this.props.ticket.id}:evaluation`, e.target.value)
+    localStorage.setItem(`ticket:${this.props.ticket.objectId}:evaluation`, e.target.value)
     this.setState({ content: e.target.value })
   }
 
@@ -32,7 +31,7 @@ class Evaluation extends Component {
         content: this.state.content,
       })
       .then(() => {
-        localStorage.removeItem(`ticket:${this.props.ticket.id}:evaluation`)
+        localStorage.removeItem(`ticket:${this.props.ticket.objectId}:evaluation`)
         return
       })
       .catch(this.context.addNotification)
@@ -40,7 +39,7 @@ class Evaluation extends Component {
 
   render() {
     const { t } = this.props
-    const evaluation = this.props.ticket.get('evaluation')
+    const { evaluation } = this.props.ticket
     if (evaluation) {
       return (
         <Alert variant="warning">
@@ -111,7 +110,13 @@ class Evaluation extends Component {
 }
 
 Evaluation.propTypes = {
-  ticket: PropTypes.instanceOf(LC.LCObject),
+  ticket: PropTypes.shape({
+    objectId: PropTypes.string.isRequired,
+    evaluation: PropTypes.shape({
+      star: PropTypes.number.isRequired,
+      content: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
   isCustomerService: PropTypes.bool,
   saveEvaluation: PropTypes.func.isRequired,
   t: PropTypes.func,

--- a/modules/Ticket/OpsLog.js
+++ b/modules/Ticket/OpsLog.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
 import moment from 'moment'
+import * as Icon from 'react-bootstrap-icons'
 
 import css from './index.css'
 import csCss from '../CustomerServiceTickets.css'
@@ -52,7 +53,7 @@ export function OpsLog({ opsLog }) {
     case 'selectAssignee':
       content = [
         <span className="icon-wrap">
-          <i className="bi bi-arrow-left-right"></i>
+          <Icon.ArrowLeftRight />
         </span>,
         <>
           {t('system')} {t('assignedTicketTo')} <UserLabel user={opsLog.data.assignee} />
@@ -62,7 +63,7 @@ export function OpsLog({ opsLog }) {
     case 'changeCategory':
       content = [
         <span className="icon-wrap">
-          <i className="bi bi-arrow-left-right"></i>
+          <Icon.ArrowLeftRight />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('changedTicketCategoryTo')}{' '}
@@ -77,7 +78,7 @@ export function OpsLog({ opsLog }) {
     case 'changeAssignee':
       content = [
         <span className="icon-wrap">
-          <i className="bi bi-arrow-left-right"></i>
+          <Icon.ArrowLeftRight />
         </span>,
         <>
           <Operator operator={opsLog.data.operator} /> {t('changedTicketAssigneeTo')}{' '}
@@ -88,7 +89,7 @@ export function OpsLog({ opsLog }) {
     case 'replyWithNoContent':
       content = [
         <span className="icon-wrap">
-          <i className="bi bi-chat-left-fill"></i>
+          <Icon.ChatLeftFill />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('thoughtNoNeedToReply')}
@@ -98,7 +99,7 @@ export function OpsLog({ opsLog }) {
     case 'replySoon':
       content = [
         <span className="icon-wrap awaiting">
-          <i className="bi bi-hourglass"></i>
+          <Icon.Hourglass />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('thoughtNeedTime')}
@@ -108,7 +109,7 @@ export function OpsLog({ opsLog }) {
     case 'resolve':
       content = [
         <span className="icon-wrap resolved">
-          <i className="bi bi-check-circle"></i>
+          <Icon.CheckCircle />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('thoughtResolved')}
@@ -119,7 +120,7 @@ export function OpsLog({ opsLog }) {
     case 'reject': // 向前兼容
       content = [
         <span className="icon-wrap closed">
-          <i className="bi bi-slash-circle"></i>
+          <Icon.SlashCircle />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('closedTicket')}
@@ -129,7 +130,7 @@ export function OpsLog({ opsLog }) {
     case 'reopen':
       content = [
         <span className="icon-wrap reopened">
-          <i className="bi bi-record-circle"></i>
+          <Icon.RecordCircle />
         </span>,
         <>
           <UserLabel user={opsLog.data.operator} /> {t('reopenedTicket')}

--- a/modules/Ticket/OpsLog.js
+++ b/modules/Ticket/OpsLog.js
@@ -1,0 +1,151 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+
+import css from './index.css'
+import csCss from '../CustomerServiceTickets.css'
+import { UserLabel } from '../UserLabel'
+import { getCategoryPathName } from '../common'
+import { useCategoriesTree } from '../category/hooks'
+
+export function Operator({ operator }) {
+  const { t } = useTranslation()
+  if (!operator || operator.objectId === 'system') {
+    return t('system')
+  }
+  return <UserLabel user={operator} />
+}
+Operator.propTypes = {
+  operator: PropTypes.object,
+}
+
+export function Time({ value, hash }) {
+  if (!moment.isMoment(value)) {
+    value = moment(value)
+  }
+  if (moment().diff(value) > 86400000) {
+    return (
+      <a className="timestamp" href={'#' + hash} title={value.format()}>
+        {value.calendar()}
+      </a>
+    )
+  } else {
+    return (
+      <a className="timestamp" href={'#' + hash} title={value.format()}>
+        {value.fromNow()}
+      </a>
+    )
+  }
+}
+Time.propTypes = {
+  value: PropTypes.any.isRequired,
+  hash: PropTypes.string.isRequired,
+}
+
+export function OpsLog({ opsLog }) {
+  const { t } = useTranslation()
+  const { data: categoriesTree, isLoading: isLoadingCategoriesTree } = useCategoriesTree()
+
+  let content = [null, null]
+  switch (opsLog.action) {
+    case 'selectAssignee':
+      content = [
+        <span className="icon-wrap">
+          <i className="bi bi-arrow-left-right"></i>
+        </span>,
+        <>
+          {t('system')} {t('assignedTicketTo')} <UserLabel user={opsLog.data.assignee} />
+        </>,
+      ]
+      break
+    case 'changeCategory':
+      content = [
+        <span className="icon-wrap">
+          <i className="bi bi-arrow-left-right"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('changedTicketCategoryTo')}{' '}
+          <span className={csCss.category + ' ' + css.category}>
+            {isLoadingCategoriesTree
+              ? 'Loading...'
+              : getCategoryPathName(opsLog.data.category, categoriesTree)}
+          </span>
+        </>,
+      ]
+      break
+    case 'changeAssignee':
+      content = [
+        <span className="icon-wrap">
+          <i className="bi bi-arrow-left-right"></i>
+        </span>,
+        <>
+          <Operator operator={opsLog.data.operator} /> {t('changedTicketAssigneeTo')}{' '}
+          <UserLabel user={opsLog.data.assignee} />
+        </>,
+      ]
+      break
+    case 'replyWithNoContent':
+      content = [
+        <span className="icon-wrap">
+          <i className="bi bi-chat-left-fill"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('thoughtNoNeedToReply')}
+        </>,
+      ]
+      break
+    case 'replySoon':
+      content = [
+        <span className="icon-wrap awaiting">
+          <i className="bi bi-hourglass"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('thoughtNeedTime')}
+        </>,
+      ]
+      break
+    case 'resolve':
+      content = [
+        <span className="icon-wrap resolved">
+          <i className="bi bi-check-circle"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('thoughtResolved')}
+        </>,
+      ]
+      break
+    case 'close':
+    case 'reject': // 向前兼容
+      content = [
+        <span className="icon-wrap closed">
+          <i className="bi bi-slash-circle"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('closedTicket')}
+        </>,
+      ]
+      break
+    case 'reopen':
+      content = [
+        <span className="icon-wrap reopened">
+          <i className="bi bi-record-circle"></i>
+        </span>,
+        <>
+          <UserLabel user={opsLog.data.operator} /> {t('reopenedTicket')}
+        </>,
+      ]
+  }
+
+  return (
+    <div className="ticket-status" id={opsLog.objectId}>
+      <div className="ticket-status-left">{content[0]}</div>
+      <div className="ticket-status-right">
+        {content[1]} <Time value={opsLog.createdAt} hash={opsLog.objectId} />
+      </div>
+    </div>
+  )
+}
+OpsLog.propTypes = {
+  opsLog: PropTypes.object.isRequired,
+}

--- a/modules/Ticket/Tag.js
+++ b/modules/Ticket/Tag.js
@@ -1,9 +1,8 @@
-/* global ENABLE_LEANCLOUD_INTEGRATION */
 import React, { useEffect, useState } from 'react'
 import { Badge, Button, Form } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
-import LC, { cloud } from '../lib/leancloud'
+import { cloud } from '../../lib/leancloud'
 
 export default function Tag({ tag, ticket, isCustomerService }) {
   const { t } = useTranslation()
@@ -12,14 +11,14 @@ export default function Tag({ tag, ticket, isCustomerService }) {
   // TODO: fix race condition
   useEffect(() => {
     ;(async () => {
-      if (ENABLE_LEANCLOUD_INTEGRATION && tag.data.key === 'appId') {
-        const appId = tag.data.value
+      if (window.ENABLE_LEANCLOUD_INTEGRATION && tag.key === 'appId') {
+        const appId = tag.value
         if (!appId) {
           return
         }
         const app = await cloud.run('getLeanCloudApp', {
           appId,
-          username: ticket.data.author.data.username,
+          username: ticket.author.username,
         })
         setData({ key: 'application', value: app.app_name })
         if (isCustomerService) {
@@ -33,13 +32,13 @@ export default function Tag({ tag, ticket, isCustomerService }) {
         }
       }
     })()
-  }, [tag, ticket, isCustomerService])
+  }, [tag.key, tag.value, ticket.author.username, isCustomerService])
 
   if (!data) {
     return (
       <div className="form-group">
         <Badge variant="secondary">
-          {tag.data.key}: {tag.data.value}
+          {tag.key}: {tag.value}
         </Badge>
       </div>
     )
@@ -63,11 +62,10 @@ export default function Tag({ tag, ticket, isCustomerService }) {
 }
 
 Tag.propTypes = {
-  tag: PropTypes.instanceOf(LC.LCObject).isRequired,
+  tag: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  }).isRequired,
   ticket: PropTypes.object.isRequired,
   isCustomerService: PropTypes.bool,
-}
-
-Tag.contextTypes = {
-  addNotification: PropTypes.func.isRequired,
 }

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -101,7 +101,7 @@ export default function TicketMetadata({ ticket, isCustomerService }) {
             <UserLabel user={assignee} />
             {isCustomerService && (
               <Button variant="link" onClick={() => setUpdatingAssignee(true)}>
-                <i className="bi bi-pencil-fill"></i>
+                <Icon.PencilFill />
               </Button>
             )}
           </Form.Group>
@@ -126,7 +126,7 @@ export default function TicketMetadata({ ticket, isCustomerService }) {
             </span>
             {isCustomerService && !isLoadingCategoriesTree && (
               <Button variant="link" onClick={() => setUpdatingCategory(true)}>
-                <i className="bi bi-pencil-fill"></i>
+                <Icon.PencilFill />
               </Button>
             )}
           </div>

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -1,12 +1,10 @@
-import React, { Component } from 'react'
+import React, { useContext, useState } from 'react'
 import { Button, Form } from 'react-bootstrap'
-import { withTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
-import _ from 'lodash'
 import * as Icon from 'react-bootstrap-icons'
-import LC from '../../lib/leancloud'
 
-import { getCustomerServices, getCategoryPathName } from '../common'
+import { getCategoryPathName } from '../common'
 import { UserLabel } from '../UserLabel'
 import TagForm from '../TagForm'
 import css from './index.css'
@@ -15,166 +13,166 @@ import { depthFirstSearchFind } from '../../lib/common'
 import CategoriesSelect from '../CategoriesSelect'
 import { getConfig } from '../config'
 import { MountCustomElement } from '../custom/element'
+import { AppContext } from '../context'
+import { useUpdateAssignee, useUpdateCategory, useSaveTicketTag } from './hooks'
+import { useCustomerServices } from '../CustomerService/hooks'
+import { useCategoriesTree } from '../category/hooks'
 
-class TicketMetadata extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isUpdateAssignee: false,
-      isUpdateCategory: false,
-      assignees: [],
+export default function TicketMetadata({ ticket, isCustomerService }) {
+  const { t } = useTranslation()
+  const { tagMetadatas, addNotification } = useContext(AppContext)
+  const { data: categoriesTree, isLoading: isLoadingCategoriesTree } = useCategoriesTree()
+  const { data: customerServices } = useCustomerServices()
+  const [updatingAssignee, setUpdatingAssignee] = useState(false)
+  const [updatingCategory, setUpdatingCategory] = useState(false)
+
+  const { mutate: updateAssignee, setLocalAssignee } = useUpdateAssignee(ticket.nid)
+  const { mutate: updateCateogry, setLocalCategory } = useUpdateCategory(ticket.nid)
+  const { mutate: saveTags, setLocalTags } = useSaveTicketTag(ticket.nid)
+
+  const handleChangeAssignee = (e) => {
+    const assigneeId = e.target.value
+    const assignee = customerServices.find(({ objectId }) => objectId === assigneeId)
+    updateAssignee(assigneeId, {
+      onSuccess: () => {
+        setLocalAssignee(assignee)
+        setUpdatingAssignee(false)
+      },
+      onError: addNotification,
+    })
+  }
+
+  const handleChangeCategory = (e) => {
+    const categoryId = e.target.value
+    const category = depthFirstSearchFind(categoriesTree, (c) => c.id === categoryId)
+    updateCateogry(categoryId, {
+      onSuccess: () => {
+        setLocalCategory(category.toJSON())
+        setUpdatingCategory(false)
+      },
+      onError: addNotification,
+    })
+  }
+
+  const handleSaveTag = (key, value, isPrivate) => {
+    const tags = [...ticket[isPrivate ? 'privateTags' : 'tags']]
+    const index = tags.findIndex((tag) => tag.key === key)
+    if (index === -1) {
+      if (!value) {
+        return
+      }
+      tags.push({ key, value })
+    } else {
+      if (value) {
+        tags[index] = { ...tags[index], value }
+      } else {
+        tags.splice(index, 1)
+      }
     }
-  }
-
-  componentDidMount() {
-    this.fetchDatas()
-  }
-
-  fetchDatas() {
-    getCustomerServices()
-      .then((assignees) => {
-        this.setState({ assignees })
-        return
-      })
-      .catch(this.context.addNotification)
-  }
-
-  handleAssigneeChange(e) {
-    const customerService = _.find(this.state.assignees, { id: e.target.value })
-    this.props
-      .updateTicketAssignee(customerService)
-      .then(() => {
-        this.setState({ isUpdateAssignee: false })
-        return
-      })
-      .then(this.context.addNotification)
-      .catch(this.context.addNotification)
-  }
-
-  handleCategoryChange(e) {
-    this.props
-      .updateTicketCategory(
-        depthFirstSearchFind(this.props.categoriesTree, (c) => c.id == e.target.value)
-      )
-      .then(() => {
-        this.setState({ isUpdateCategory: false })
-        return
-      })
-      .then(this.context.addNotification)
-      .catch(this.context.addNotification)
-  }
-
-  handleTagChange(key, value, isPrivate) {
-    return this.props.saveTag(key, value, isPrivate)
-  }
-
-  render() {
-    const { t } = this.props
-    const { ticket, isCustomerService } = this.props
-    const assignee = ticket.data.assignee
-
-    return (
-      <>
-        <Form.Group>
-          <Form.Label>{t('assignee')}</Form.Label>
-          {this.state.isUpdateAssignee ? (
-            <Form.Control
-              as="select"
-              value={assignee.id}
-              onChange={this.handleAssigneeChange.bind(this)}
-            >
-              {this.state.assignees.map((cs) => (
-                <option key={cs.id} value={cs.id}>
-                  {cs.data.username}
-                </option>
-              ))}
-            </Form.Control>
-          ) : (
-            <Form.Group>
-              <UserLabel user={ticket.data.assignee.data} />
-              {isCustomerService && (
-                <Button variant="link" onClick={() => this.setState({ isUpdateAssignee: true })}>
-                  <Icon.PencilFill />
-                </Button>
-              )}
-            </Form.Group>
-          )}
-        </Form.Group>
-
-        <Form.Group>
-          <Form.Label>{t('category')}</Form.Label>
-          {this.state.isUpdateCategory ? (
-            <CategoriesSelect
-              categoriesTree={this.props.categoriesTree}
-              selected={ticket.get('category')}
-              onChange={this.handleCategoryChange.bind(this)}
-            />
-          ) : (
-            <div>
-              <span className={csCss.category + ' ' + css.categoryBlock}>
-                {getCategoryPathName(ticket.get('category'), this.props.categoriesTree)}
-              </span>
-              {isCustomerService && (
-                <Button variant="link" onClick={() => this.setState({ isUpdateCategory: true })}>
-                  <Icon.PencilFill />
-                </Button>
-              )}
-            </div>
-          )}
-        </Form.Group>
-
-        {isCustomerService && ticket.data.metaData && (
-          <Form.Group>
-            <Form.Label>{t('details')}</Form.Label>
-            {Object.entries(ticket.data.metaData)
-              .filter(([, v]) => v && (typeof v === 'string' || typeof v === 'number'))
-              .map(([key, value]) => {
-                const comments = getConfig('ticket.metadata.customMetadata.comments', {})
-                return (
-                  <div className={css.customMetadata} key={key}>
-                    <span className={css.key}>{comments[key] || key}: </span>
-                    {value}
-                  </div>
-                )
-              })}
-          </Form.Group>
-        )}
-
-        <MountCustomElement
-          point="ticket.metadata"
-          props={{ isCustomerService, ticket: ticket.toJSON() }}
-        />
-
-        {this.context.tagMetadatas.map((tagMetadata) => {
-          const tags = ticket.get(tagMetadata.get('isPrivate') ? 'privateTags' : 'tags')
-          const tag = _.find(tags, (t) => t.key == tagMetadata.get('key'))
-          return (
-            <TagForm
-              key={tagMetadata.id}
-              tagMetadata={tagMetadata}
-              tag={tag}
-              changeTagValue={this.handleTagChange.bind(this)}
-              isCustomerService={isCustomerService}
-            />
-          )
-        })}
-      </>
+    saveTags(
+      { tags, isPrivate },
+      {
+        onSuccess: () => setLocalTags({ tags, isPrivate }),
+        onError: addNotification,
+      }
     )
   }
+
+  const { assignee } = ticket
+  return (
+    <>
+      <Form.Group>
+        <Form.Label>{t('assignee')}</Form.Label>
+        {updatingAssignee ? (
+          <Form.Control
+            as="select"
+            value={assignee.objectId}
+            onChange={handleChangeAssignee}
+            onBlur={() => setUpdatingAssignee(false)}
+          >
+            {customerServices.map(({ objectId, username }) => (
+              <option key={objectId} value={objectId}>
+                {username}
+              </option>
+            ))}
+          </Form.Control>
+        ) : (
+          <Form.Group>
+            <UserLabel user={assignee} />
+            {isCustomerService && (
+              <Button variant="link" onClick={() => setUpdatingAssignee(true)}>
+                <i className="bi bi-pencil-fill"></i>
+              </Button>
+            )}
+          </Form.Group>
+        )}
+      </Form.Group>
+
+      <Form.Group>
+        <Form.Label>{t('category')}</Form.Label>
+        {updatingCategory ? (
+          <CategoriesSelect
+            categoriesTree={categoriesTree}
+            selected={ticket.category}
+            onChange={handleChangeCategory}
+            onBlur={() => setUpdatingCategory(false)}
+          />
+        ) : (
+          <div>
+            <span className={csCss.category + ' ' + css.categoryBlock}>
+              {isLoadingCategoriesTree
+                ? 'Loading...'
+                : getCategoryPathName(ticket.category, categoriesTree)}
+            </span>
+            {isCustomerService && !isLoadingCategoriesTree && (
+              <Button variant="link" onClick={() => setUpdatingCategory(true)}>
+                <i className="bi bi-pencil-fill"></i>
+              </Button>
+            )}
+          </div>
+        )}
+      </Form.Group>
+
+      {isCustomerService && ticket.metaData && (
+        <Form.Group>
+          <Form.Label>{t('details')}</Form.Label>
+          {Object.entries(ticket.metaData)
+            .filter(([, v]) => v && (typeof v === 'string' || typeof v === 'number'))
+            .map(([key, value]) => {
+              const comments = getConfig('ticket.metadata.customMetadata.comments', {})
+              return (
+                <div className={css.customMetadata} key={key}>
+                  <span className={css.key}>{comments[key] || key}: </span>
+                  {value}
+                </div>
+              )
+            })}
+        </Form.Group>
+      )}
+
+      <MountCustomElement point="ticket.metadata" props={{ isCustomerService, ticket }} />
+
+      {tagMetadatas.map((tagMetadata) => {
+        const tags = ticket[tagMetadata.get('isPrivate') ? 'privateTags' : 'tags']
+        const tag = tags.find((tag) => tag.key === tagMetadata.get('key'))
+        return (
+          <TagForm
+            key={tagMetadata.id}
+            tagMetadata={tagMetadata}
+            tag={tag}
+            changeTagValue={handleSaveTag}
+            isCustomerService={isCustomerService}
+          />
+        )
+      })}
+    </>
+  )
 }
 
 TicketMetadata.propTypes = {
   isCustomerService: PropTypes.bool.isRequired,
-  ticket: PropTypes.instanceOf(LC.LCObject),
-  categoriesTree: PropTypes.array.isRequired,
-  updateTicketAssignee: PropTypes.func.isRequired,
-  updateTicketCategory: PropTypes.func.isRequired,
-  saveTag: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired,
+  ticket: PropTypes.shape({
+    assignee: PropTypes.object.isRequired,
+    category: PropTypes.object.isRequired,
+  }).isRequired,
 }
-
-TicketMetadata.contextTypes = {
-  tagMetadatas: PropTypes.array,
-}
-
-export default withTranslation()(TicketMetadata)

--- a/modules/Ticket/TicketOperation.js
+++ b/modules/Ticket/TicketOperation.js
@@ -1,22 +1,33 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Alert, Button, Form } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
 
 import { TICKET_STATUS, ticketStatus } from '../../lib/common'
+import { operateTicket } from './hooks'
+import { AppContext } from '../context'
 
-export function TicketOperation({ ticket, isCustomerService, onOperate }) {
+export function TicketOperation({ ticket, isCustomerService }) {
   const { t } = useTranslation()
+  const { addNotification } = useContext(AppContext)
+
+  const handleOperateTicket = async (action) => {
+    try {
+      await operateTicket(ticket.nid, action)
+    } catch (error) {
+      addNotification(error)
+    }
+  }
 
   if (ticketStatus.isOpened(ticket.status)) {
     return (
       <Form.Group>
         <Form.Label>{t('ticketOperation')}</Form.Label>
         <div>
-          <Button variant="light" onClick={() => onOperate('resolve')}>
+          <Button variant="light" onClick={() => handleOperateTicket('resolve')}>
             {t('resolved')}
           </Button>{' '}
-          <Button variant="light" onClick={() => onOperate('close')}>
+          <Button variant="light" onClick={() => handleOperateTicket('close')}>
             {t('close')}
           </Button>
         </div>
@@ -28,8 +39,8 @@ export function TicketOperation({ ticket, isCustomerService, onOperate }) {
       <Alert variant="warning">
         <Form.Label>{t('confirmResolved')}</Form.Label>
         <div>
-          <Button onClick={() => onOperate('resolve')}>{t('resolutionConfirmed')}</Button>{' '}
-          <Button variant="light" onClick={() => onOperate('reopen')}>
+          <Button onClick={() => handleOperateTicket('resolve')}>{t('resolutionConfirmed')}</Button>{' '}
+          <Button variant="light" onClick={() => handleOperateTicket('reopen')}>
             {t('unresolved')}
           </Button>
         </div>
@@ -41,7 +52,7 @@ export function TicketOperation({ ticket, isCustomerService, onOperate }) {
       <Form.Group>
         <Form.Label>{t('ticketOperation')}</Form.Label>
         <div>
-          <Button variant="light" onClick={() => onOperate('reopen')}>
+          <Button variant="light" onClick={() => handleOperateTicket('reopen')}>
             {t('reopen')}
           </Button>
         </div>
@@ -53,6 +64,5 @@ export function TicketOperation({ ticket, isCustomerService, onOperate }) {
 
 TicketOperation.propTypes = {
   ticket: PropTypes.object.isRequired,
-  onOperate: PropTypes.func.isRequired,
   isCustomerService: PropTypes.bool,
 }

--- a/modules/Ticket/TicketReply.js
+++ b/modules/Ticket/TicketReply.js
@@ -42,10 +42,11 @@ export default function TicketReply({ ticket, isCustomerService }) {
     }
     try {
       setCommitting(true)
+      const uploadedFiles = await uploadFiles(files)
       commitReply({
         nid: ticket.nid,
         content: trimedContent,
-        files: await uploadFiles(files),
+        files: uploadedFiles.map((file) => ({ objectId: file.id })),
       })
     } catch (error) {
       addNotification(error)

--- a/modules/Ticket/TicketReply.js
+++ b/modules/Ticket/TicketReply.js
@@ -186,7 +186,7 @@ export default function TicketReply({ ticket, isCustomerService }) {
       <Form.Group className="d-block d-md-flex">
         <div className="flex-fill">
           <p className={css.markdownTip}>
-            <i className="bi bi-markdown"></i>{' '}
+            <Icon.Markdown />{' '}
             <a href="https://forum.leancloud.cn/t/topic/15412" target="_blank" rel="noopener">
               {t('supportMarkdown')}
             </a>

--- a/modules/Ticket/hooks.js
+++ b/modules/Ticket/hooks.js
@@ -1,0 +1,162 @@
+import { useInfiniteQuery, useMutation, useQueryClient } from 'react-query'
+import _ from 'lodash'
+
+import { fetch } from '../../lib/leancloud'
+
+/**
+ * @param {number} nid
+ * @returns {Promise<{ ticket: object; subscribed: boolean; }>}
+ */
+export function fetchTicket(nid) {
+  return fetch(`/api/1/tickets/${nid}`)
+}
+
+/**
+ * @typedef {{
+ *   objectId: string;
+ * }} Reply
+ */
+
+/**
+ *
+ * @param {number} nid
+ * @param {string} [after] objectId of reply
+ * @returns {Promise<{ replies: Reply[] }>}
+ */
+export function fetchReplies(nid, after) {
+  return fetch(`/api/1/tickets/${nid}/replies`, {
+    query: {
+      'page[after]': after,
+    },
+  })
+}
+
+/**
+ * @param {number} nid
+ */
+export function useReplies(nid) {
+  return useInfiniteQuery(['ticketReplies', nid], ({ pageParam }) => fetchReplies(nid, pageParam), {
+    getNextPageParam: (lastPage) => _.last(lastPage.replies)?.objectId,
+  })
+}
+
+/**
+ * @typedef {{
+ *   objectId: string;
+ * }} OpsLog
+ */
+
+/**
+ * @param {number} nid
+ * @param {string} [after]
+ * @returns {Promise<{ opsLogs: OpsLog[] }>}
+ */
+export function fetchOpsLogs(nid, after) {
+  return fetch(`/api/1/tickets/${nid}/ops-logs`, {
+    query: {
+      'page[after]': after,
+    },
+  })
+}
+
+/**
+ * @param {number} nid
+ */
+export function useOpsLogs(nid) {
+  return useInfiniteQuery(['ticketOpsLogs', nid], ({ pageParam }) => fetchOpsLogs(nid, pageParam), {
+    getNextPageParam: (lastPage) => _.last(lastPage.opsLogs)?.objectId,
+  })
+}
+
+/**
+ * @param {number} nid
+ * @param {object} data
+ */
+export function updateTicket(nid, data) {
+  return fetch(`/api/1/tickets/${nid}`, { method: 'PATCH', body: data })
+}
+
+/**
+ * @param {number} nid
+ * @param {import('react-query').UseMutationOptions} [options]
+ */
+export function useUpdateAssignee(nid, options) {
+  const queryClient = useQueryClient()
+  return {
+    ...useMutation((assigneeId) => updateTicket(nid, { assigneeId }), options),
+    setLocalAssignee: (assignee) => {
+      queryClient.setQueryData(['ticket', nid], (current) => ({
+        ...current,
+        ticket: { ...current.ticket, assignee },
+      }))
+    },
+  }
+}
+
+/**
+ * @param {number} nid
+ * @param {import('react-query').UseMutationOptions} [options]
+ */
+export function useUpdateCategory(nid, options) {
+  const queryClient = useQueryClient()
+  return {
+    ...useMutation((categoryId) => updateTicket(nid, { categoryId }), options),
+    setLocalCategory: (category) => {
+      queryClient.setQueryData(['ticket', nid], (current) => ({
+        ...current,
+        ticket: { ...current.ticket, category },
+      }))
+    },
+  }
+}
+
+/**
+ * @param {number} nid
+ * @param {array} tags
+ * @param {boolean} [isPrivate]
+ */
+export function saveTicketTag(nid, tags, isPrivate) {
+  return fetch(`/api/1/tickets/${nid}/tags`, {
+    method: 'PUT',
+    body: { tags, isPrivate },
+  })
+}
+
+/**
+ * @param {number} nid
+ * @param {import('react-query').UseMutationOptions} [options]
+ */
+export function useSaveTicketTag(nid, options) {
+  const queryClient = useQueryClient()
+  return {
+    ...useMutation(({ tags, isPrivate }) => saveTicketTag(nid, tags, isPrivate), options),
+    setLocalTags: ({ tags, isPrivate }) => {
+      queryClient.setQueryData(['ticket', nid], (current) => ({
+        ...current,
+        ticket: {
+          ...current.ticket,
+          [isPrivate ? 'privateTags' : 'tags']: tags,
+        },
+      }))
+    },
+  }
+}
+
+/**
+ * @param {number | string} nid
+ * @param {string} content
+ * @param {array} [files]
+ */
+export function commitTicketReply(nid, content, files) {
+  return fetch(`/api/1/tickets/${nid}/replies`, {
+    method: 'POST',
+    body: { content, files },
+  })
+}
+
+export function operateTicket(nid, action) {
+  return fetch(`/api/1/tickets/${nid}/operate`, {
+    method: 'POST',
+    body: { action },
+  })
+}

--- a/modules/Ticket/hooks.js
+++ b/modules/Ticket/hooks.js
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from 'react-query'
+import { useInfiniteQuery } from 'react-query'
 import _ from 'lodash'
 
 import { fetch } from '../../lib/leancloud'
@@ -74,72 +74,6 @@ export function useOpsLogs(nid) {
  */
 export function updateTicket(nid, data) {
   return fetch(`/api/1/tickets/${nid}`, { method: 'PATCH', body: data })
-}
-
-/**
- * @param {number} nid
- * @param {import('react-query').UseMutationOptions} [options]
- */
-export function useUpdateAssignee(nid, options) {
-  const queryClient = useQueryClient()
-  return {
-    ...useMutation((assigneeId) => updateTicket(nid, { assigneeId }), options),
-    setLocalAssignee: (assignee) => {
-      queryClient.setQueryData(['ticket', nid], (current) => ({
-        ...current,
-        ticket: { ...current.ticket, assignee },
-      }))
-    },
-  }
-}
-
-/**
- * @param {number} nid
- * @param {import('react-query').UseMutationOptions} [options]
- */
-export function useUpdateCategory(nid, options) {
-  const queryClient = useQueryClient()
-  return {
-    ...useMutation((categoryId) => updateTicket(nid, { categoryId }), options),
-    setLocalCategory: (category) => {
-      queryClient.setQueryData(['ticket', nid], (current) => ({
-        ...current,
-        ticket: { ...current.ticket, category },
-      }))
-    },
-  }
-}
-
-/**
- * @param {number} nid
- * @param {array} tags
- * @param {boolean} [isPrivate]
- */
-export function saveTicketTag(nid, tags, isPrivate) {
-  return fetch(`/api/1/tickets/${nid}/tags`, {
-    method: 'PUT',
-    body: { tags, isPrivate },
-  })
-}
-
-/**
- * @param {number} nid
- * @param {import('react-query').UseMutationOptions} [options]
- */
-export function useSaveTicketTag(nid, options) {
-  const queryClient = useQueryClient()
-  return {
-    ...useMutation(({ tags, isPrivate }) => saveTicketTag(nid, tags, isPrivate), options),
-    setLocalTags: ({ tags, isPrivate }) => {
-      queryClient.setQueryData(['ticket', nid], (current) => ({
-        ...current,
-        ticket: {
-          ...current.ticket,
-          [isPrivate ? 'privateTags' : 'tags']: tags,
-        },
-      }))
-    },
-  }
 }
 
 /**

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -1,26 +1,29 @@
-import React, { Component } from 'react'
+import React, { Component, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { Button, Card, Col, OverlayTrigger, Row, Tooltip } from 'react-bootstrap'
-import { useTranslation, withTranslation } from 'react-i18next'
-import { withRouter } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useHistory, useRouteMatch } from 'react-router-dom'
 import moment from 'moment'
 import _ from 'lodash'
 import xss from 'xss'
 import PropTypes from 'prop-types'
 import * as Icon from 'react-bootstrap-icons'
 import css from './index.css'
-import { auth, cloud, db } from '../../lib/leancloud'
-import { uploadFiles, getCategoryPathName, getCategoriesTree } from '../common'
+import { auth, cloud, db, fetch } from '../../lib/leancloud'
+import { uploadFiles } from '../common'
 import csCss from '../CustomerServiceTickets.css'
-import { ticketStatus, getTinyCategoryInfo } from '../../lib/common'
-import Evaluation from '../Evaluation'
-import TicketMetadata from './TicketMetadata'
+import { ticketStatus } from '../../lib/common'
 import TicketReply from './TicketReply'
+import Evaluation from './Evaluation'
+import TicketMetadata from './TicketMetadata'
 import { TicketStatusLabel } from '../components/TicketStatusLabel'
-import Tag from '../Tag'
+import Tag from './Tag'
 import { WeekendWarning } from '../components/WeekendWarning'
 import { UserLabel } from '../UserLabel'
 import { DocumentTitle } from '../utils/DocumentTitle'
 import { TicketOperation } from './TicketOperation'
+import { OpsLog, Time } from './OpsLog'
+import { AppContext } from '../context'
+import { useOpsLogs, useReplies, useTicket } from './hooks'
 
 // get a copy of default whiteList
 const whiteList = xss.getDefaultWhiteList()
@@ -35,22 +38,71 @@ const myxss = new xss.FilterXSS({
   css: false,
 })
 
-function UserOrSystem({ operator }) {
-  const { t } = useTranslation(0)
-  if (!operator || operator.objectId === 'system') {
-    return t('system')
-  }
-  return <UserLabel user={operator} />
+const IMAGE_MIMES = ['image/png', 'image/jpeg', 'image/gif']
+
+function ReplyCard({ reply }) {
+  const { t } = useTranslation()
+  const { objectId, author, content_HTML, createdAt, files, isCustomerService } = reply
+  const imageFiles = []
+  const otherFiles = []
+  files?.forEach((file) => {
+    if (IMAGE_MIMES.includes(file.mime_type)) {
+      imageFiles.push(file)
+    } else {
+      otherFiles.push(file)
+    }
+  })
+
+  return (
+    <Card
+      id={objectId}
+      key={objectId}
+      className={isCustomerService ? css.panelModerator : undefined}
+    >
+      <Card.Header className={css.heading}>
+        <UserLabel user={author} /> {t('submittedAt')} <Time value={createdAt} hash={objectId} />
+        {isCustomerService && <i className={css.badge}>{t('staff')}</i>}
+      </Card.Header>
+      <Card.Body className={css.content}>
+        <div
+          className="markdown-body"
+          dangerouslySetInnerHTML={{ __html: myxss.process(content_HTML) }}
+        />
+        {imageFiles.map(({ objectId, name, url }) => (
+          <a key={objectId} href={url} target="_blank">
+            <img src={url} alt={name} />
+          </a>
+        ))}
+      </Card.Body>
+      {otherFiles.length > 0 && (
+        <Card.Footer>
+          {otherFiles.map(({ objectId, name, url }) => (
+            <div key={objectId}>
+              <a href={url + '?attname=' + encodeURIComponent(name)} target="_blank">
+                <i className="bi bi-paperclip"></i> {name}
+              </a>
+            </div>
+          ))}
+        </Card.Footer>
+      )}
+    </Card>
+  )
 }
-UserOrSystem.propTypes = {
-  operator: PropTypes.object,
+ReplyCard.propTypes = {
+  reply: PropTypes.shape({
+    objectId: PropTypes.string.isRequired,
+    author: PropTypes.object.isRequired,
+    content_HTML: PropTypes.string.isRequired,
+    createdAt: PropTypes.string.isRequired,
+    files: PropTypes.array,
+    isCustomerService: PropTypes.bool,
+  }),
 }
 
 class Ticket extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      categoriesTree: [],
       ticket: null,
       replies: [],
       opsLogs: [],
@@ -63,33 +115,18 @@ class Ticket extends Component {
     this.getTicketQuery(parseInt(nid))
       .first()
       .then((ticket) => {
-        if (!ticket) {
-          return this.props.history.replace({
-            pathname: '/error',
-            state: { code: 'Unauthorized' },
-          })
-        }
-
         return Promise.all([
-          cloud.run('getPrivateTags', { ticketId: ticket.id }),
-          getCategoriesTree(false),
           this.getReplyQuery(ticket).find(),
-          db.class('Tag').where('ticket', '==', ticket).find(),
           this.getOpsLogQuery(ticket).find(),
           db
             .class('Watch')
             .where('ticket', '==', ticket)
             .where('user', '==', auth.currentUser)
             .first(),
-        ]).then(([privateTags, categoriesTree, replies, tags, opsLogs, watch]) => {
-          if (privateTags) {
-            ticket.set('privateTags', privateTags.privateTags)
-          }
+        ]).then(([replies, opsLogs, watch]) => {
           this.setState({
-            categoriesTree,
             ticket,
             replies,
-            tags,
             opsLogs,
             watch,
           })
@@ -217,23 +254,9 @@ class Ticket extends Component {
     return this.operateTicket('replySoon')
   }
 
-  operateTicket(action) {
-    const ticket = this.state.ticket
-    return cloud
-      .run('operateTicket', { ticketId: ticket.id, action })
-      .then(() => {
-        return ticket.get({ include: ['author', 'organization', 'assignee', 'files'] })
-      })
-      .then((ticket) => {
-        this.setState({ ticket })
-        return
-      })
-      .catch(this.context.addNotification)
-  }
-
   updateTicketCategory(category) {
     const ticket = this.state.ticket
-    return ticket.update({ category: getTinyCategoryInfo(category) }).then(() => {
+    return updateTicket(ticket.id, { categoryId: category.id }).then(() => {
       ticket.data.category = category
       this.setState({ ticket })
       return
@@ -242,38 +265,12 @@ class Ticket extends Component {
 
   updateTicketAssignee(assignee) {
     const ticket = this.state.ticket
-    return ticket
-      .update({ assignee })
+    return updateTicket(ticket.id, { assigneeId: assignee.id })
       .then(() => {
         ticket.data.assignee = assignee
         return
       })
       .catch(this.context.addNotification)
-  }
-
-  saveTag(key, value, isPrivate) {
-    const ticket = this.state.ticket
-    let tags = ticket.get(isPrivate ? 'privateTags' : 'tags')
-    if (!tags) {
-      tags = []
-    }
-    const tag = _.find(tags, { key })
-    if (!tag) {
-      if (value == '') {
-        return
-      }
-      tags.push({ key, value })
-    } else {
-      if (value == '') {
-        tags = _.reject(tags, { key })
-      } else {
-        tag.value = value
-      }
-    }
-    return ticket.update({ [isPrivate ? 'privateTags' : 'tags']: tags }).then(() => {
-      this.setState({ ticket })
-      return
-    })
   }
 
   saveEvaluation(evaluation) {
@@ -285,263 +282,17 @@ class Ticket extends Component {
     })
   }
 
-  handleAddWatch() {
-    return db
-      .class('Watch')
-      .add({
-        ticket: this.state.ticket,
-        user: auth.currentUser,
-        ACL: {
-          [auth.currentUser.id]: { write: true, read: true },
-        },
-      })
-      .then((watch) => {
-        this.setState({ watch })
-        return
-      })
-      .catch(this.context.addNotification)
-  }
-
-  handleRemoveWatch() {
-    return this.state.watch
-      .delete()
-      .then(() => {
-        this.setState({ watch: undefined })
-        return
-      })
-      .catch(this.context.addNotification)
-  }
-
-  contentView(content) {
-    return <div dangerouslySetInnerHTML={{ __html: myxss.process(content) }} />
-  }
-
-  getTime(avObj) {
-    if (new Date() - avObj.get('createdAt') > 86400000) {
-      return (
-        <a
-          href={'#' + avObj.id}
-          className="timestamp"
-          title={moment(avObj.get('createdAt')).format()}
-        >
-          {moment(avObj.get('createdAt')).calendar()}
-        </a>
-      )
-    } else {
-      return (
-        <a
-          href={'#' + avObj.id}
-          className="timestamp"
-          title={moment(avObj.get('createdAt')).format()}
-        >
-          {moment(avObj.get('createdAt')).fromNow()}
-        </a>
-      )
-    }
-  }
-
-  ticketTimeline(avObj) {
-    const { t } = this.props
-    if (avObj.className === 'OpsLog') {
-      switch (avObj.get('action')) {
-        case 'selectAssignee':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap">
-                  <Icon.ArrowLeftRight />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                {t('system')} {t('assignedTicketTo')}{' '}
-                <UserLabel user={avObj.get('data').assignee} /> ({this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'changeCategory':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap">
-                  <Icon.ArrowLeftRight />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('changedTicketCategoryTo')}{' '}
-                <span className={csCss.category + ' ' + css.category}>
-                  {getCategoryPathName(avObj.get('data').category, this.state.categoriesTree)}
-                </span>{' '}
-                ({this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'changeAssignee':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap">
-                  <Icon.ArrowLeftRight />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserOrSystem operator={avObj.get('data').operator} />{' '}
-                {t('changedTicketAssigneeTo')} <UserLabel user={avObj.get('data').assignee} /> (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'replyWithNoContent':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap">
-                  <Icon.ChatLeftFill />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('thoughtNoNeedToReply')} (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'replySoon':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap awaiting">
-                  <Icon.Hourglass />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('thoughtNeedTime')} (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'resolve':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap resolved">
-                  <Icon.CheckCircle />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('thoughtResolved')} (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'close':
-        case 'reject': // 向前兼容
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap closed">
-                  <Icon.SlashCircle />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('closedTicket')} (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-        case 'reopen':
-          return (
-            <div className="ticket-status" id={avObj.id} key={avObj.id}>
-              <div className="ticket-status-left">
-                <span className="icon-wrap reopened">
-                  <Icon.RecordCircle />
-                </span>
-              </div>
-              <div className="ticket-status-right">
-                <UserLabel user={avObj.get('data').operator} /> {t('reopenedTicket')} (
-                {this.getTime(avObj)})
-              </div>
-            </div>
-          )
-      }
-    } else {
-      let panelFooter = null
-      let imgBody = <div></div>
-      const files = avObj.get('files')
-      if (files && files.length !== 0) {
-        const imgFiles = []
-        const otherFiles = []
-        files.forEach((f) => {
-          const mimeType = f.get('mime_type')
-          if (['image/png', 'image/jpeg', 'image/gif'].indexOf(mimeType) != -1) {
-            imgFiles.push(f)
-          } else {
-            otherFiles.push(f)
-          }
-        })
-
-        if (imgFiles.length > 0) {
-          imgBody = imgFiles.map((f) => {
-            return (
-              <a href={f.data.url} target="_blank" key={f.id}>
-                <img src={f.data.url} alt={f.get('name')} />
-              </a>
-            )
-          })
-        }
-
-        if (otherFiles.length > 0) {
-          const fileLinks = otherFiles.map((f) => {
-            return (
-              <span key={f.id}>
-                <a
-                  href={f.data.url + '?attname=' + encodeURIComponent(f.get('name'))}
-                  target="_blank"
-                >
-                  <Icon.Paperclip /> {f.get('name')}
-                </a>{' '}
-              </span>
-            )
-          })
-          panelFooter = <Card.Footer className={css.footer}>{fileLinks}</Card.Footer>
-        }
-      }
-      const userLabel = avObj.get('isCustomerService') ? (
-        <span>
-          <UserLabel user={avObj.get('author').data} />
-          <i className={css.badge}>{t('staff')}</i>
-        </span>
-      ) : (
-        <UserLabel user={avObj.get('author').data} />
-      )
-      return (
-        <Card
-          id={avObj.id}
-          key={avObj.id}
-          className={avObj.get('isCustomerService') ? css.panelModerator : undefined}
-        >
-          <Card.Header className={css.heading}>
-            {userLabel} {t('submittedAt')} {this.getTime(avObj)}
-          </Card.Header>
-          <Card.Body className={`${css.content} markdown-body`}>
-            {this.contentView(avObj.get('content_HTML'))}
-            {imgBody}
-          </Card.Body>
-          {panelFooter}
-        </Card>
-      )
-    }
-  }
-
   render() {
     const { t } = this.props
     const ticket = this.state.ticket
-    if (ticket === null) {
-      return <div>{t('loading')}……</div>
+    if (!ticket) {
+      return t('loading') + '...'
     }
 
     // 如果是客服自己提交工单，则当前客服在该工单中认为是用户，
     // 这是为了方便工单作为内部工作协调使用。
     const isCustomerService =
-      this.props.isCustomerService && ticket.get('author').id !== this.props.currentUser.id
+      this.props.isCustomerService && ticket.author.objectId !== this.props.currentUser.id
     const timeline = _.chain(this.state.replies)
       .concat(this.state.opsLogs)
       .sortBy((data) => data.createdAt)
@@ -550,26 +301,24 @@ class Ticket extends Component {
 
     return (
       <>
-        <DocumentTitle title={ticket.get('title') + ' - LeanTicket' || 'LeanTicket'} />
+        <DocumentTitle title={ticket.title + ' - LeanTicket' || 'LeanTicket'} />
         <Row className="mt-3">
           <Col sm={12}>
             {!isCustomerService && <WeekendWarning />}
-            <h1>{ticket.get('title')}</h1>
+            <h1>{ticket.title}</h1>
             <div className={css.meta}>
-              <span className={csCss.nid}>#{ticket.get('nid')}</span>
-              <TicketStatusLabel status={ticket.get('status')} />{' '}
+              <span className={csCss.nid}>#{ticket.nid}</span>
+              <TicketStatusLabel status={ticket.status} />{' '}
               <span>
-                <UserLabel user={ticket.data.author.data} displayTags={isCustomerService} />{' '}
-                {t('createdAt')}{' '}
-                <span title={moment(ticket.get('createdAt')).format()}>
-                  {moment(ticket.get('createdAt')).fromNow()}
+                <UserLabel user={ticket.author} displayTags={isCustomerService} /> {t('createdAt')}{' '}
+                <span title={moment(ticket.createdAt).format()}>
+                  {moment(ticket.createdAt).fromNow()}
                 </span>
-                {moment(ticket.get('createdAt')).fromNow() ===
-                  moment(ticket.get('updatedAt')).fromNow() || (
+                {moment(ticket.createdAt).fromNow() !== moment(ticket.updatedAt).fromNow() && (
                   <span>
                     , {t('updatedAt')}{' '}
-                    <span title={moment(ticket.get('updatedAt')).format()}>
-                      {moment(ticket.get('updatedAt')).fromNow()}
+                    <span title={moment(ticket.updatedAt).format()}>
+                      {moment(ticket.updatedAt).fromNow()}
                     </span>
                   </span>
                 )}
@@ -605,7 +354,7 @@ class Ticket extends Component {
         <Row className="row">
           <Col sm={8}>
             <div className="tickets">
-              {this.ticketTimeline(ticket)}
+              {React.createElement(ReplyCard, ticket)}
               <div>{timeline}</div>
             </div>
 
@@ -667,4 +416,327 @@ Ticket.contextTypes = {
   addNotification: PropTypes.func.isRequired,
 }
 
-export default withTranslation()(withRouter(Ticket))
+function Timeline({ data }) {
+  switch (data.type) {
+    case 'reply':
+      return <ReplyCard reply={data} />
+    case 'opsLog':
+      return <OpsLog opsLog={data} />
+    default:
+      return null
+  }
+}
+Timeline.propTypes = {
+  data: PropTypes.shape({
+    type: PropTypes.oneOf(['reply', 'opsLog']),
+  }),
+}
+
+/**
+ * @param {number} nid
+ */
+function useTicket__(nid) {
+  const { addNotification } = useContext(AppContext)
+  const [ticket, setTicket] = useState()
+  const [subscribed, setSubscribed] = useState(false)
+  const [error, setError] = useState()
+
+  const reload = useCallback(async () => {
+    setError(undefined)
+    try {
+      const { ticket, subscribed } = await fetch(`/api/1/tickets/${nid}`)
+      setTicket(ticket)
+      setSubscribed(subscribed)
+    } catch (error) {
+      setError(error)
+    }
+  }, [nid])
+
+  useEffect(() => {
+    reload()
+    let subscription
+    const query = db.class('Ticket').where('nid', '==', nid)
+    query
+      .subscribe()
+      .then((s) => {
+        subscription = s
+        s.on('update', reload)
+        return
+      })
+      .catch(addNotification)
+    return () => {
+      subscription?.unsubscribe()
+    }
+  }, [nid, addNotification])
+
+  const subscribe = useCallback(async () => {
+    try {
+      await fetch(`/api/1/tickets/${nid}/subscription`, {
+        method: 'POST',
+      })
+      setSubscribed(true)
+    } catch (error) {
+      addNotification(error)
+    }
+  }, [nid, addNotification])
+
+  const unsubscribe = useCallback(async () => {
+    try {
+      await fetch(`/api/1/tickets/${nid}/subscription`, {
+        method: 'DELETE',
+      })
+      setSubscribed(false)
+    } catch (error) {
+      addNotification(error)
+    }
+  }, [nid, addNotification])
+
+  const updateTicket = useCallback(
+    async (data) => {
+      try {
+        await fetch(`/api/1/tickets/${nid}`, { method: 'PATCH', body: data })
+      } catch (error) {
+        addNotification(error)
+      }
+    },
+    [nid, addNotification]
+  )
+
+  const updateAssignee = useCallback(
+    async (assignee) => {
+      await updateTicket({ assigneeId: assignee.id })
+      setTicket((current) => ({ ...current, assignee: assignee.toJSON() }))
+    },
+    [updateTicket]
+  )
+
+  const updateCategory = useCallback(
+    async (category) => {
+      await updateTicket({ categoryId: category.id })
+      setTicket((current) => ({ ...current, category: category.toJSON() }))
+    },
+    [updateTicket]
+  )
+
+  const saveTag = async (key, value, isPrivate) => {
+    const tags = [...ticket[isPrivate ? 'privateTags' : 'tags']]
+    const index = tags.findIndex((tag) => tag.key === key)
+    if (index === -1) {
+      if (!value) {
+        return
+      }
+      tags.push({ key, value })
+    } else {
+      if (value) {
+        tags[index] = { ...tags[index], value }
+      } else {
+        tags.splice(index, 1)
+      }
+    }
+    try {
+      await fetch(`/api/1/tickets/${nid}/tags`, {
+        method: 'PUT',
+        body: { tags, isPrivate },
+      })
+      setTicket((current) => ({ ...current, [isPrivate ? 'privateTags' : 'tags']: tags }))
+    } catch (error) {
+      addNotification(error)
+    }
+  }
+
+  const evaluate = useCallback(
+    async (evaluation) => {
+      try {
+        await fetch(`/api/1/tickets/${nid}/evaluation`, {
+          method: 'PUT',
+          body: { evaluation },
+        })
+      } catch (error) {
+        addNotification(error)
+      }
+    },
+    [nid, addNotification]
+  )
+
+  const operate = useCallback(
+    async (action) => {
+      try {
+        await fetch(`/api/1/tickets/${nid}/operate`, {
+          method: 'POST',
+          body: { action },
+        })
+      } catch (error) {
+        addNotification(error)
+      }
+    },
+    [nid]
+  )
+
+  return {
+    ticket,
+    subscribed,
+    error,
+    subscribe,
+    unsubscribe,
+    updateAssignee,
+    updateCategory,
+    saveTag,
+    evaluate,
+    operate,
+  }
+}
+
+export default function _Ticket({ isCustomerService, currentUser }) {
+  const { t } = useTranslation()
+  const { params } = useRouteMatch()
+  const history = useHistory()
+  const nid = parseInt(params.nid)
+  const { addNotification } = useContext(AppContext)
+  const { data, isError, isLoading } = useTicket(nid)
+  const ticket = data?.ticket
+  const subscribed = data?.subscribed
+  const { data: repliesData } = useReplies(nid)
+  const { data: opsLogsData } = useOpsLogs(nid)
+
+  useEffect(() => {
+    if (isError) {
+      history.replace({
+        pathname: '/error',
+        state: { code: 'Unauthorized' },
+      })
+    }
+  }, [isError])
+
+  const isCS = useMemo(() => {
+    if (!ticket) {
+      return isCustomerService
+    }
+    return isCustomerService && ticket.author.objectId !== currentUser.id
+  }, [isCustomerService, currentUser, ticket])
+
+  const replies = useMemo(() => {
+    return repliesData?.pages.map((page) => page.replies).flat() || []
+  }, [repliesData])
+
+  const opsLogs = useMemo(() => {
+    return opsLogsData?.pages.map((page) => page.opsLogs).flat() || []
+  }, [opsLogsData])
+
+  const timeline = useMemo(() => {
+    return [
+      ...replies.map((data) => ({ ...data, type: 'reply' })),
+      ...opsLogs.map((data) => ({ ...data, type: 'opsLog' })),
+    ].sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))
+  }, [replies, opsLogs])
+
+  const [tags, setTags] = useState([])
+  const ticketId = ticket?.objectId
+  useEffect(() => {
+    if (ticketId) {
+      db.class('Tag')
+        .where('ticket', '==', db.class('Ticket').object(ticketId))
+        .find()
+        .then((tags) => setTags(tags.map((tag) => tag.toJSON())))
+        .catch(addNotification)
+    }
+  }, [ticketId])
+
+  if (isLoading) {
+    return t('loading') + '...'
+  }
+  return (
+    <>
+      <DocumentTitle title={ticket.title + ' - LeanTicket' || 'LeanTicket'} />
+      <Row className="mt-3">
+        <Col sm={12}>
+          {!isCS && <WeekendWarning />}
+          <h1>{ticket.title}</h1>
+          <div className={css.meta}>
+            <span className={csCss.nid}>#{ticket.nid}</span>
+            <TicketStatusLabel status={ticket.status} />{' '}
+            <span>
+              <UserLabel user={ticket.author} displayTags={isCS} /> {t('createdAt')}{' '}
+              <span title={moment(ticket.createdAt).format()}>
+                {moment(ticket.createdAt).fromNow()}
+              </span>
+              {moment(ticket.createdAt).fromNow() !== moment(ticket.updatedAt).fromNow() && (
+                <span>
+                  , {t('updatedAt')}{' '}
+                  <span title={moment(ticket.updatedAt).format()}>
+                    {moment(ticket.updatedAt).fromNow()}
+                  </span>
+                </span>
+              )}
+            </span>{' '}
+            {isCS &&
+              (subscribed ? (
+                <OverlayTrigger
+                  placement="right"
+                  overlay={<Tooltip id="tooltip">{t('clickToUnsubscribe')}</Tooltip>}
+                >
+                  <Button variant="link" active onClick={() => console.log('unsubscribe')}>
+                    <i className="bi bi-eye-slash"></i>
+                  </Button>
+                </OverlayTrigger>
+              ) : (
+                <OverlayTrigger
+                  placement="right"
+                  overlay={<Tooltip id="tooltip">{t('clickToSubscribe')}</Tooltip>}
+                >
+                  <Button variant="link" onClick={() => console.log('subscribe')}>
+                    <i className="bi bi-eye"></i>
+                  </Button>
+                </OverlayTrigger>
+              ))}
+          </div>
+          <hr />
+        </Col>
+      </Row>
+
+      <Row className="row">
+        <Col sm={8}>
+          <div className="tickets">
+            <ReplyCard reply={ticket} />
+            <div>
+              {timeline.map((data) => (
+                <Timeline key={data.objectId} data={data} />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <hr />
+            {ticketStatus.isOpened(ticket.status) ? (
+              <TicketReply ticket={ticket} isCustomerService={isCustomerService} />
+            ) : (
+              <Evaluation
+                ticket={ticket}
+                isCustomerService={isCustomerService}
+                saveEvaluation={console.log}
+              />
+            )}
+          </div>
+        </Col>
+
+        <Col className={css.sidebar} sm={4}>
+          {tags.map((tag) => (
+            <Tag
+              key={tag.objectId}
+              tag={tag}
+              ticket={ticket}
+              isCustomerService={isCustomerService}
+            />
+          ))}
+
+          <TicketMetadata ticket={ticket} isCustomerService={isCustomerService} />
+
+          {/* <TicketOperation
+            ticket={ticket}
+            isCustomerService={isCustomerService}
+            onOperate={console.log}
+          /> */}
+        </Col>
+      </Row>
+    </>
+  )
+}

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -79,7 +79,7 @@ function ReplyCard({ reply }) {
           {otherFiles.map(({ objectId, name, url }) => (
             <div key={objectId}>
               <a href={url + '?attname=' + encodeURIComponent(name)} target="_blank">
-                <i className="bi bi-paperclip"></i> {name}
+                <Icon.Paperclip /> {name}
               </a>
             </div>
           ))}
@@ -675,7 +675,7 @@ export default function _Ticket({ isCustomerService, currentUser }) {
                   overlay={<Tooltip id="tooltip">{t('clickToUnsubscribe')}</Tooltip>}
                 >
                   <Button variant="link" active onClick={() => console.log('unsubscribe')}>
-                    <i className="bi bi-eye-slash"></i>
+                    <Icon.EyeSlash />
                   </Button>
                 </OverlayTrigger>
               ) : (
@@ -684,7 +684,7 @@ export default function _Ticket({ isCustomerService, currentUser }) {
                   overlay={<Tooltip id="tooltip">{t('clickToSubscribe')}</Tooltip>}
                 >
                   <Button variant="link" onClick={() => console.log('subscribe')}>
-                    <i className="bi bi-eye"></i>
+                    <Icon.Eye />
                   </Button>
                 </OverlayTrigger>
               ))}

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -11,7 +11,7 @@ import css from './index.css'
 import { auth, cloud, db } from '../../lib/leancloud'
 import { uploadFiles, getCategoryPathName, getCategoriesTree } from '../common'
 import csCss from '../CustomerServiceTickets.css'
-import { isTicketOpen, getTinyCategoryInfo } from '../../lib/common'
+import { ticketStatus, getTinyCategoryInfo } from '../../lib/common'
 import Evaluation from '../Evaluation'
 import TicketMetadata from './TicketMetadata'
 import TicketReply from './TicketReply'
@@ -609,10 +609,9 @@ class Ticket extends Component {
               <div>{timeline}</div>
             </div>
 
-            {isTicketOpen(ticket) && (
-              <div>
-                <hr />
-
+            <div>
+              <hr />
+              {ticketStatus.isOpened(ticket.data.status) ? (
                 <TicketReply
                   ticket={ticket}
                   commitReply={this.commitReply.bind(this)}
@@ -620,19 +619,14 @@ class Ticket extends Component {
                   operateTicket={this.operateTicket.bind(this)}
                   isCustomerService={isCustomerService}
                 />
-              </div>
-            )}
-            {!isTicketOpen(ticket) && (
-              <div>
-                <hr />
-
+              ) : (
                 <Evaluation
                   saveEvaluation={this.saveEvaluation.bind(this)}
                   ticket={ticket}
                   isCustomerService={isCustomerService}
                 />
-              </div>
-            )}
+              )}
+            </div>
           </Col>
 
           <Col className={css.sidebar} sm={4}>

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -323,9 +323,6 @@ export default function Ticket({ isCustomerService, currentUser }) {
 }
 
 Ticket.propTypes = {
-  history: PropTypes.object.isRequired,
-  match: PropTypes.object.isRequired,
   currentUser: PropTypes.object,
   isCustomerService: PropTypes.bool,
-  t: PropTypes.func.isRequired,
 }

--- a/modules/Tickets/index.js
+++ b/modules/Tickets/index.js
@@ -158,7 +158,7 @@ class Tickets extends Component {
                   selectedOrgId={this.props.selectedOrgId}
                   onOrgChange={this.props.handleOrgChange}
                 />
-                <DropdownButton id="tickets-ops" className="ml-1" variant="light">
+                <DropdownButton id="tickets-ops" className="ml-1" variant="light" title="">
                   <Dropdown.Item onClick={() => this.handleBatchOps(true)}>
                     {t('batchOperation')}
                   </Dropdown.Item>

--- a/modules/category/hooks.js
+++ b/modules/category/hooks.js
@@ -1,0 +1,7 @@
+import { useQuery } from 'react-query'
+
+import { getCategoriesTree } from '../common'
+
+export function useCategoriesTree(hideDisabled) {
+  return useQuery(['categoriesTree', hideDisabled], () => getCategoriesTree(hideDisabled))
+}

--- a/modules/common.js
+++ b/modules/common.js
@@ -54,9 +54,7 @@ export const getCategoriesTree = (hiddenDisable = true) => {
   return query
     .orderBy('createdAt', 'desc')
     .find()
-    .then((categories) => {
-      return makeTree(categories)
-    })
+    .then(makeTree)
     .catch((err) => {
       // 如果还没有被停用的分类，deletedAt 属性可能不存在
       if (err.code == 700 && err.message.includes('deletedAt')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2671,6 +2671,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2896,6 +2901,43 @@
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.5.3.tgz",
+      "integrity": "sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.0.4",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -4707,8 +4749,7 @@
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-      "dev": true
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "digest-header": {
       "version": "0.0.1",
@@ -7666,6 +7707,11 @@
         }
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -8123,6 +8169,30 @@
         "object-visit": "^1.0.0"
       }
     },
+    "match-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -8221,6 +8291,11 @@
           "dev": true
         }
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "migrate": {
       "version": "1.6.2",
@@ -8463,6 +8538,14 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.1.22",
@@ -12713,6 +12796,31 @@
         }
       }
     },
+    "react-query": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.15.1.tgz",
+      "integrity": "sha512-F17OuiL7CS9HDbNt1vUN5Opk0Ua+r2y2liDGLlZh3mbdc3ANob0mgaWB6TOBdlyMewbgg+qf1keS2aCV1qVWOg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
     "react-router": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
@@ -13263,6 +13371,11 @@
         "argparse": "^1.0.10",
         "autolinker": "~0.28.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -15307,6 +15420,30 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-dom": "^16.14.0",
     "react-i18next": "^11.8.7",
     "react-notification-system": "^0.2.14",
+    "react-query": "^3.15.1",
     "react-router-dom": "^5.2.0",
     "remarkable": "^1.7.2",
     "request": "^2.87.0",


### PR DESCRIPTION
把工单相关的操作从 SDK 切换到 REST API ，并把相关的 Class 组件重构成函数组件 + react hook 。
工单列表没改，想等重写关键词搜索的时候一起改。

改的时候尽可能和之前的行为保持一致。不过之前的行为有点分散，可能有漏的地方，这个改动最好在预备环境充分测试后再发布。
已经部署到 sdjdd-ticket 上并测试了一遍，没发现啥问题。如果真的存在问题也应该是遗漏了 hook 中的某些操作，只影响统计和触发器。

由于使用了 react-query 这个库，添加了一些重复的功能，再单开一个 PR 整理一下吧 🏃 