### PR TITLE
refactor: create ticket by REST API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,6 +33,7 @@ router.use('/api/1/dynamic-contents', require('./DynamicContent'))
 router.use('/api/1/triggers', require('./rule/trigger/api'))
 router.use('/api/1/automations', require('./rule/automation/api'))
 router.use('/api/1/ticket-fields', require('./TicketField'))
+router.use('/api/1/tickets', require('./ticket/api'))
 
 const { integrations } = require('../config')
 console.log(`Using plugins: ${integrations.map((integration) => integration.name).join(', ')}`)

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -1,0 +1,68 @@
+const AV = require('leanengine')
+const { Router } = require('express')
+const { check } = require('express-validator')
+
+const { checkPermission } = require('../oauth')
+const { requireAuth, catchError } = require('../middleware')
+const { selectAssignee, getTinyCategoryInfo, saveWithoutHooks } = require('./utils')
+const { htmlify } = require('../common')
+const { TICKET_STATUS, getTicketAcl } = require('../../lib/common')
+const { afterSaveTicketHandler } = require('./hook-handler')
+
+const router = Router().use(requireAuth)
+
+router.post(
+  '/',
+  check('title').isString().trim().isLength({ min: 1 }),
+  check('category_id').isString(),
+  check('content').isString(),
+  check('organization_id').isString().optional(),
+  check('file_ids').default([]).isArray(),
+  check('file_ids.*').isString(),
+  catchError(async (req, res) => {
+    if (!(await checkPermission(req.user))) {
+      res.throw(403, 'Your account is not qualified to create ticket.')
+    }
+
+    const { title, category_id, content, organization_id, file_ids } = req.body
+    const author = req.user
+    const organization = organization_id
+      ? AV.Object.createWithoutData('Organization', organization_id)
+      : undefined
+    const [assignee, categoryInfo] = await Promise.all([
+      selectAssignee(category_id),
+      getTinyCategoryInfo(category_id),
+    ])
+
+    const ticket = new AV.Object('Ticket')
+    ticket.setACL(new AV.ACL(getTicketAcl(author, organization)))
+    ticket.set('status', TICKET_STATUS.NEW)
+    ticket.set('title', title)
+    ticket.set('author', author)
+    ticket.set('assignee', assignee)
+    ticket.set('category', categoryInfo)
+    ticket.set('content', content)
+    ticket.set('content_HTML', htmlify(content))
+    ticket.set(
+      'files',
+      file_ids.map((id) => ({
+        __type: 'Pointer',
+        className: '_File',
+        objectId: id,
+      }))
+    )
+    if (organization) {
+      ticket.set('organization', organization)
+    }
+
+    await saveWithoutHooks(ticket, {
+      ignoreBeforeHook: true,
+      ignoreAfterHook: true,
+    })
+    afterSaveTicketHandler(ticket, { skipFetchAuthorAndAssignee: true })
+
+    res.json({ id: ticket.id })
+  })
+)
+
+module.exports = router

--- a/api/ticket/hook-handler.js
+++ b/api/ticket/hook-handler.js
@@ -1,0 +1,109 @@
+const AV = require('leancloud-storage')
+
+const { addOpsLog } = require('./utils')
+const notification = require('../notification')
+const { getTinyUserInfo, systemUser } = require('../common')
+const { ticketStatus } = require('../../lib/common')
+const { invokeWebhooks } = require('../webhook')
+const { getActiveTriggers, recordTriggerLog } = require('../rule/trigger')
+const { Context } = require('../rule/context')
+
+/**
+ * @param {AV.Object} ticket
+ * @param {'create' | 'update'} updateType
+ */
+async function invokeTriggers(ticket, updateType) {
+  // Triggers do not run or fire on tickets after they are closed.
+  // However, triggers can fire when a ticket is being set to closed.
+  if (ticketStatus.isClosed(ticket.get('status')) && !ticket.updatedKeys?.includes('status')) {
+    return
+  }
+
+  const ctx = new Context(ticket.toJSON(), updateType, ticket.updatedKeys)
+  const triggers = await getActiveTriggers()
+  triggers.exec(ctx)
+  if (ctx.isUpdated()) {
+    const updatedData = ctx.getUpdatedData()
+    const ticketToUpdate = AV.Object.createWithoutData('Ticket', ticket.id)
+    ticketToUpdate.disableAfterHook()
+    await ticketToUpdate.save(updatedData, { useMasterKey: true })
+
+    const ticketToInvokeHook = AV.Object.createWithoutData('Ticket', ticket.id)
+    Object.entries(ctx.data).forEach(([key, value]) => (ticketToInvokeHook.attributes[key] = value))
+    ticketToInvokeHook.updatedKeys = Object.keys(updatedData)
+    afterUpdateTicketHandler(ticketToInvokeHook, { skipTriggers: updateType === 'update' })
+  }
+
+  recordTriggerLog(triggers, ticket.id)
+}
+
+/**
+ * @param {AV.Object} ticket
+ * @param {object} [options]
+ * @param {boolean} [options.skipFetchAuthorAndAssignee]
+ */
+async function afterSaveTicketHandler(ticket, options) {
+  if (!options?.skipFetchAuthorAndAssignee) {
+    await ticket.fetch({ include: ['author', 'assignee'] }, { useMasterKey: true })
+  }
+  const author = ticket.get('author')
+  const assignee = ticket.get('assignee')
+  addOpsLog(ticket, 'selectAssignee', {
+    assignee: await getTinyUserInfo(assignee),
+  })
+  notification.newTicket(ticket, author, assignee)
+  invokeWebhooks('ticket.create', { ticket: ticket.toJSON() })
+  invokeTriggers(ticket, 'create')
+}
+
+/**
+ * @param {AV.Object} ticket
+ * @param {object} [options]
+ * @param {AV.User} [options.user]
+ * @param {boolean} [options.skipTriggers]
+ * @param {boolean} [options.skipFetchAssignee]
+ */
+async function afterUpdateTicketHandler(ticket, options) {
+  if (!options?.skipFetchAssignee) {
+    await ticket.fetch({ include: ['assignee'] }, { useMasterKey: true })
+  }
+  const user = options?.user || systemUser
+  const userInfo = await getTinyUserInfo(user)
+
+  if (ticket.updatedKeys?.includes('category')) {
+    addOpsLog(ticket, 'changeCategory', {
+      category: ticket.get('category'),
+      operator: userInfo,
+    })
+  }
+
+  if (ticket.updatedKeys?.includes('assignee')) {
+    const assigneeInfo = await getTinyUserInfo(ticket.get('assignee'))
+    addOpsLog(ticket, 'changeAssignee', {
+      assignee: assigneeInfo,
+      operator: userInfo,
+    })
+    notification.changeAssignee(ticket, user, ticket.get('assignee'))
+  }
+
+  if (ticket.updatedKeys?.includes('status')) {
+    if (ticketStatus.isClosed(ticket.get('status'))) {
+      AV.Cloud.run('statsTicket', { ticketId: ticket.id })
+    }
+  }
+
+  if (ticket.updatedKeys?.includes('evaluation') && options?.user) {
+    notification.ticketEvaluation(ticket, options.user, ticket.get('assignee'))
+  }
+
+  invokeWebhooks('ticket.update', {
+    ticket: ticket.toJSON(),
+    updatedKeys: ticket.updatedKeys,
+  })
+
+  if (!options?.skipTriggers) {
+    invokeTriggers(ticket, 'update')
+  }
+}
+
+module.exports = { afterSaveTicketHandler, afterUpdateTicketHandler }

--- a/api/ticket/utils.js
+++ b/api/ticket/utils.js
@@ -1,0 +1,90 @@
+const AV = require('leancloud-storage')
+const _ = require('lodash')
+
+const { captureException } = require('../errorHandler')
+
+/**
+ * @param {string} categoryId
+ * @returns {Promise<{ objectId: string; name: string }>}
+ */
+async function getTinyCategoryInfo(categoryId) {
+  const category = await new AV.Query('Category').get(categoryId)
+  return {
+    objectId: category.id,
+    name: category.get('name'),
+  }
+}
+
+/**
+ * @returns {Promise<string[]>}
+ */
+async function getVacationerIds() {
+  const now = new Date()
+  const vacations = await new AV.Query('Vacation')
+    .lessThan('startDate', now)
+    .greaterThan('endDate', now)
+    .find({ useMasterKey: true })
+  return vacations.map((v) => v.get('vacationer').id)
+}
+
+/**
+ * @param {string} categoryId
+ * @returns {Promise<AV.User>}
+ */
+async function selectAssignee(categoryId) {
+  const [role, vacationerIds] = await Promise.all([
+    new AV.Query(AV.Role).equalTo('name', 'customerService').first(),
+    getVacationerIds(),
+  ])
+  const query = role.getUsers().query()
+  if (vacationerIds.length) {
+    query.notContainedIn('objectId', vacationerIds)
+  }
+  const users = await query.find({ useMasterKey: true })
+
+  const assignees = users.filter((user) => {
+    /**
+     * @type {Array<{objectId: string}>}
+     */
+    const categories = user.get('categories') || []
+    return categories.findIndex((c) => c.objectId === categoryId) !== -1
+  })
+
+  return assignees.length ? _.sample(assignees) : _.sample(users)
+}
+
+function addOpsLog(ticket, action, data) {
+  return new AV.Object('OpsLog')
+    .save({ ticket, action, data }, { useMasterKey: true })
+    .catch(captureException)
+}
+
+/**
+ * @param {AV.Object} object
+ * @param {object} [options]
+ * @param {boolean} [options.ignoreBeforeHook]
+ * @param {boolean} [options.ignoreAfterHook]
+ * @param {boolean} [options.useMasterKey]
+ */
+async function saveWithoutHooks(object, options) {
+  const ignoredHooks = _.clone(object._flags.__ignore_hooks)
+  if (options?.ignoreBeforeHook) {
+    object.disableBeforeHook()
+  }
+  if (options?.ignoreAfterHook) {
+    object.disableAfterHook()
+  }
+  try {
+    await object.save(null, { useMasterKey: options?.useMasterKey })
+  } finally {
+    object._flags.__ignore_hooks = ignoredHooks
+  }
+}
+
+module.exports = {
+  getVacationerIds,
+  getTinyCategoryInfo,
+  addOpsLog,
+  saveWithoutHooks,
+  selectAssignee,
+}

--- a/lib/leancloud.js
+++ b/lib/leancloud.js
@@ -49,12 +49,22 @@ LC.use({
 })
 
 /**
+ * @typedef {Record<string, string | number | boolean} QueryParams
+ */
+
+/**
  *
- * @param {RequestInfo} input
- * @param {RequestInit} [init]
- * @returns {Promise<Response>}
+ * @param {string} input
+ * @param {RequestInit & { query?: QueryParams }} [init]
+ * @returns {Promise}
  */
 export async function fetch(input, init) {
+  if (init?.query) {
+    const query = Object.entries(init.query).filter(([, value]) => value !== undefined)
+    if (Object.keys(query).length) {
+      input += '?' + query.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&')
+    }
+  }
   const res = await window.fetch(input, {
     ...init,
     headers: {


### PR DESCRIPTION
把 #255 拆小。
分别用 SDK 和 REST API 创建了个工单，没发现啥问题。

---

### `POST /api/1/tickets` 创建工单

Request:
```json
{
  "title": "工单标题",
  "category_id": "分类ID",
  "content": "工单内容",
  "organization_id": "组织ID（可选）",
  "file_ids": ["已上传的文件ID"]
}
```

Response:
```json
{
  "id": "工单ID"
}
```