### PR TITLE
feat: allow user to reopen tickets

### DIFF
--- a/modules/Ticket/TicketOperation.js
+++ b/modules/Ticket/TicketOperation.js
@@ -36,19 +36,16 @@ export function TicketOperation({ ticket, isCustomerService, onOperate }) {
       </Alert>
     )
   }
-  if (isCustomerService) {
-    return (
-      <Form.Group>
-        <Form.Label>{t('ticketOperation')}</Form.Label>
-        <div>
-          <Button variant="light" onClick={() => onOperate('reopen')}>
-            {t('reopen')}
-          </Button>
-        </div>
-      </Form.Group>
-    )
-  }
-  return null
+  return (
+    <Form.Group>
+      <Form.Label>{t('ticketOperation')}</Form.Label>
+      <div>
+        <Button variant="light" onClick={() => onOperate('reopen')}>
+          {t('reopen')}
+        </Button>
+      </div>
+    </Form.Group>
+  )
 }
 
 TicketOperation.propTypes = {


### PR DESCRIPTION
目前只有客服可以重新打开工单。有时用户错误的关闭了工单，或者关闭了工单之后有又遇到了问题需要继续反馈，此时是会想要「重新打开」的。在引入了对「自动关闭」功能的支持后，这个需求变的更加强烈了。

GitHub issue 的逻辑是如果是用户关闭的工单用户可以重新打开，但如果是 repo owner 关闭的则用户不能打开。但 GitHub 更多的是站在开发者的角度帮助其收集与追踪问题，而工单则是帮助开发者服务客户。并且我也没有想到允许用户重新打开工单之后会有什么问题，所以就直接默认支持打开好了。