### PR TITLE
fix(UserLabel): calculate tag by user.created_at

### DIFF
--- a/api/user/utils.js
+++ b/api/user/utils.js
@@ -10,6 +10,7 @@ function encodeUserObject(user) {
     username: user.get('username'),
     name: user.get('name') || '',
     tags: user.get('tags') || [],
+    created_at: user.createdAt,
   }
 }
 

--- a/modules/UserLabel.js
+++ b/modules/UserLabel.js
@@ -24,12 +24,13 @@ const USER_TAG = {
 
 function getUserTags(user) {
   const tags = []
-  if (user.createdAt) {
+  const createdAt = user.createdAt || user.created_at
+  if (createdAt) {
     const now = moment()
-    if (now.diff(user.createdAt, 'month') <= 3) {
+    if (now.diff(createdAt, 'month') <= 3) {
       tags.push('new')
     }
-    if (now.diff(user.createdAt, 'year') >= 2) {
+    if (now.diff(createdAt, 'year') >= 2) {
       tags.push('early')
     }
   }


### PR DESCRIPTION
切换到 REST API 后，由于没返回 `created_at` 导致没法再前端计算 Early / New  两个标签。