### PR TITLE
refactor: process up to 1000 tickets in one automation cycle

### DIFF
--- a/api/rule/automation/index.js
+++ b/api/rule/automation/index.js
@@ -1,6 +1,5 @@
 const AV = require('leancloud-storage')
 
-const cache = require('../../utils/cache')
 const { Conditions } = require('../condition')
 const { Actions } = require('../action')
 const conditions = require('./conditions')
@@ -56,20 +55,9 @@ class Automations {
   /**
    * @param {boolean} [includeInactive]
    */
-  static async fetch(includeInactive) {
+  static async get(includeInactive) {
     const objects = await this.fetchRaw(includeInactive)
     return new Automations(objects.map((o) => o.toJSON()))
-  }
-
-  /**
-   * @param {boolean} [includeInactive]
-   */
-  static get(includeInactive) {
-    return cache.get(
-      ['automations', { active: !!includeInactive }],
-      () => this.fetch(includeInactive),
-      1000 * 60 * 10
-    )
   }
 
   exec(ctx) {


### PR DESCRIPTION
Zendesk 是最多处理 1000 个满足条件的工单，当时为了实现简单做成了最多获取 1000 个未关闭的工单来做判断。实际测试发现这个数量可能不够，就也改成和 Zendesk 一样了。

因为不想把 Automation 条件和查询条件绑到一起，就保留获取后再判断的逻辑了。之前还给 Automation 设置了个 10 分支的缓存，但一小时执行一次也不需要缓存，就把缓存也去掉了。