### PR TITLE
feat: internal comment

### DIFF
--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -381,21 +381,33 @@ router.get(
   query('created_at_gt').isISO8601().optional(),
   catchError(async (req, res) => {
     const { created_at_gt } = req.query
-    const query = new AV.Query('Reply')
-      .equalTo('ticket', req.ticket)
-      .ascending('createdAt')
-      .include('author', 'files')
-      .limit(500)
+    const isCS = await isCSInTicket(req.user, req.ticket.get('author'))
+
+    let query = new AV.Query('Reply').equalTo('ticket', req.ticket)
     if (created_at_gt) {
       query.greaterThan('createdAt', new Date(created_at_gt))
     }
-    const replies = await query.find({ useMasterKey: true })
+    if (!isCS) {
+      const internalQuery = AV.Query.or(
+        new AV.Query('Reply').doesNotExist('internal'),
+        new AV.Query('Reply').equalTo('internal', false)
+      )
+      query = AV.Query.and(query, internalQuery)
+    }
+
+    const replies = await query
+      .ascending('createdAt')
+      .include('author', 'files')
+      .limit(500)
+      .find({ useMasterKey: true })
+
     res.json(
       replies.map((reply) => {
         return {
           ...encodeReplyObject(reply),
           author: encodeUserObject(reply.get('author')),
           files: reply.get('files')?.map(encodeFileObject) || [],
+          internal: isCS ? !!reply.get('internal') : undefined,
         }
       })
     )
@@ -407,13 +419,16 @@ router.post(
   check('content').isString(),
   check('file_ids').default([]).isArray(),
   check('file_ids.*').isString(),
+  check('internal').isBoolean().optional(),
   catchError(async (req, res) => {
     const ticket = new Ticket(req.ticket)
     const author = req.user
+    const { content, file_ids, internal } = req.body
     const reply = await ticket.reply({
       author,
-      content: req.body.content,
-      file_ids: req.body.file_ids,
+      content,
+      file_ids,
+      internal,
       isCustomerService: await isCSInTicket(req.user, ticket.author_id),
     })
     res.json(encodeReplyObject(reply))

--- a/api/ticket/model.js
+++ b/api/ticket/model.js
@@ -654,9 +654,9 @@ class Ticket {
 
       this.save().catch(captureException)
 
-      // notification 需要 assignee 的信息
       Promise.all([this.getAuthorInfo(), this.getAssigneeInfo()])
         .then(([authorInfo, assigneeInfo]) => {
+          // 适配 notification 使用的数据结构
           const author = AV.Object.createWithoutData('_User', this.author_id)
           author.attributes = authorInfo
           const assignee = AV.Object.createWithoutData('_User', this.assignee_id)

--- a/modules/Ticket/ReplyCard.js
+++ b/modules/Ticket/ReplyCard.js
@@ -138,14 +138,23 @@ export function ReplyCard({ data }) {
   const [translationEnabled, setTranslationEnabled] = useState(false)
 
   return (
-    <Card id={data.id} className={classNames({ [css.panelModerator]: data.is_customer_service })}>
+    <Card
+      id={data.id}
+      className={classNames({
+        [css.staff]: data.is_customer_service,
+        [css.internal]: data.internal,
+      })}
+    >
       <Card.Header className={classNames(css.heading, 'd-flex', 'justify-content-between')}>
         <div>
           <UserLabel user={data.author} /> {t('submittedAt')}{' '}
           <Time value={data.created_at} href={'#' + data.id} />
         </div>
         <div className="d-flex align-items-center">
-          {data.is_customer_service && <i className={css.badge}>{t('staff')}</i>}
+          {data.is_customer_service && (
+            <i className={css.badge}>{data.internal ? 'Internal' : t('staff')}</i>
+          )}
+
           {isCustomerService && (
             <Dropdown className="ml-2">
               <Dropdown.Toggle className="d-flex" as={MenuIcon} />

--- a/modules/Ticket/index.css
+++ b/modules/Ticket/index.css
@@ -12,13 +12,22 @@
   font-weight: 600;
 }
 
-.panelModerator {
+.staff {
   border-color: #c1d5e4;
 }
 
-.panelModerator .heading {
+.staff .heading {
   background: #e3edf7;
   border-color: #c1d5e4;
+}
+
+.internal {
+  border-color: #ff9800bf;
+}
+
+.internal .heading {
+  background: #ffc10733;
+  border-color: #ff9800bf;
 }
 
 .content {
@@ -51,7 +60,14 @@
   padding: 4px 6px;
   border-radius: 4px;
   line-height: 1;
+}
+
+.staff .badge {
   color: #779bbf;
+}
+
+.internal .badge {
+  color: #ff9800bf;
 }
 
 .replyMenuIcon {

--- a/resources/schema/Reply.json
+++ b/resources/schema/Reply.json
@@ -38,6 +38,13 @@
     },
     "isCustomerService": {
       "type": "Boolean"
+    },
+    "internal": {
+      "type": "Boolean",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
     }
   },
   "permissions": {


### PR DESCRIPTION
## 内部注释功能

通过给 Reply 表添加一列 `internal` 来区分普通回复和内部注释。

内部注释对用户不可见，且不会更新 Ticket 的 `latestReply` 、`status` 、`replyCount` 和 `unreadCount` ，不会触发 notification 。

为了让其他客服能实时感知到内部注释的创建，改回监听 Ticket 、Reply 和 OpsLog 这三个表的 LiveQuery ，不过以后要改 Ticket 的 ACL 的话就又要头疼了 😑 