### PR TITLE
feat: support to config metadata value renderer

### DIFF
--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -250,6 +250,7 @@ CategorySection.propTypes = {
 function CustomMetadata({ metadata }) {
   const { t } = useTranslation()
   const comments = getConfig('ticket.metadata.customMetadata.comments', {})
+  const valueRenderers = getConfig('ticket.metadata.customMetadata.valueRenderers', {})
   const filteredMetadata = useMemo(() => {
     return Object.entries(metadata).reduce((arr, [key, value]) => {
       if (typeof value === 'string' || typeof value === 'number') {
@@ -266,7 +267,7 @@ function CustomMetadata({ metadata }) {
         {filteredMetadata.map(([key, value]) => (
           <div className={css.customMetadata} key={key}>
             <span className={css.key}>{comments[key] || key}: </span>
-            {value}
+            {typeof valueRenderers[key] === 'function' ? valueRenderers[key](value) : value}
           </div>
         ))}
       </Form.Group>


### PR DESCRIPTION
用了最简单的方式来支持 metadata 值显示的自定义。

配置示例： https://github.com/leeyeh/ticket/commit/9fed2953e8577b5b3be6a94f2816010974c4aa14