### PR TITLE
feat: root category

### DIFF
--- a/api/category/utils.js
+++ b/api/category/utils.js
@@ -46,19 +46,43 @@ async function fetchCategories() {
 }
 
 /**
+ * @returns {Promise<{[key: string]: Category}>}
+ */
+async function fetchCategoryMap() {
+  return (await fetchCategories()).reduce((map, category) => {
+    map[category.id] = category
+    return map
+  }, {})
+}
+
+/**
  * @param {string} categoryId
  * @returns {Promise<{ objectId: string; name: string; }>}
  */
-async function getTinyCategoryInfo(categoryId) {
-  const category = await new AV.Query('Category').get(categoryId)
+async function getTinyCategoryInfo(categoryId, categories) {
+  const category = categories
+    ? categories[categoryId]
+    : encodeCategoryObject(await new AV.Query('Category').get(categoryId))
   return {
     objectId: category.id,
-    name: category.get('name'),
+    name: category.name,
   }
+}
+
+function getCategoryPath(categoryId, categoryById) {
+  let current = categoryById[categoryId]
+  const path = [current.id]
+  while (current.parent_id) {
+    current = categoryById[current.parent_id]
+    path.unshift(current.id)
+  }
+  return path
 }
 
 module.exports = {
   encodeCategoryObject,
   fetchCategories,
+  fetchCategoryMap,
   getTinyCategoryInfo,
+  getCategoryPath,
 }

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -11,7 +11,7 @@ const { TICKET_ACTION, TICKET_STATUS } = require('../../lib/common')
 const { encodeFileObject } = require('../file/utils')
 const { encodeUserObject } = require('../user/utils')
 const { isCustomerService } = require('../customerService/utils')
-const { fetchCategories } = require('../category/utils')
+const { fetchCategoryMap } = require('../category/utils')
 const config = require('../../config')
 const Ticket = require('./model')
 
@@ -29,16 +29,6 @@ function getWatchObject(user, ticket) {
     .equalTo('user', user)
     .equalTo('ticket', ticket)
     .first({ useMasterKey: true })
-}
-
-function getCategoryPath(categoryById, categoryId) {
-  let current = categoryById[categoryId]
-  const path = [{ id: current.id, name: current.name }]
-  while (current.parent_id) {
-    current = categoryById[current.parent_id]
-    path.unshift({ id: current.id, name: current.name })
-  }
-  return path
 }
 
 function encodeLatestReply(latestReply) {
@@ -243,20 +233,14 @@ router.get(
 
     query.include('author', 'assignee')
 
-    const [tickets, totalCount, categories] = await Promise.all([
+    const [tickets, totalCount] = await Promise.all([
       page_size ? query.find({ user: req.user }) : [],
       count ? query.count({ user: req.user }) : 0,
-      fetchCategories(),
     ])
     if (count) {
       res.append('X-Total-Count', totalCount)
       res.append('Access-Control-Expose-Headers', 'X-Total-Count')
     }
-
-    const categoryById = categories.reduce((map, category) => {
-      map[category.id] = category
-      return map
-    }, {})
 
     res.json(
       tickets.map((ticket) => {
@@ -275,7 +259,6 @@ router.get(
           assignee_id: ticket.get('assignee')?.id,
           assignee: ticket.get('assignee') ? encodeUserObject(ticket.get('assignee')) : null,
           category_id: categoryId,
-          category_path: getCategoryPath(categoryById, categoryId),
           content: ticket.get('content'),
           joined_customer_service_ids: Array.from(joinedCustomerServiceIds),
           status: ticket.get('status'),
@@ -306,10 +289,9 @@ router.get(
      * @type {AV.Object}
      */
     const ticket = req.ticket
-    const [isCS, watch, categories] = await Promise.all([
+    const [isCS, watch] = await Promise.all([
       isCSInTicket(req.user, ticket.get('author')),
       getWatchObject(req.user, ticket),
-      fetchCategories(),
     ])
 
     const keys = ['author', 'assignee', 'files', 'group']
@@ -318,11 +300,6 @@ router.get(
       keys.push('privateTags')
     }
     await ticket.fetch({ keys, include }, { user: req.user, useMasterKey: isCS })
-
-    const categoryById = categories.reduce((map, category) => {
-      map[category.id] = category
-      return map
-    }, {})
 
     res.json({
       id: ticket.id,
@@ -335,7 +312,6 @@ router.get(
       assignee: ticket.get('assignee') ? encodeUserObject(ticket.get('assignee')) : null,
       group: encodeGroupObject(ticket.get('group')),
       category_id: ticket.get('category').objectId,
-      category_path: getCategoryPath(categoryById, ticket.get('category').objectId),
       content: ticket.get('content'),
       content_HTML: ticket.get('content_HTML'),
       file_ids: ticket.get('files')?.map((file) => file.id) || [],

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -118,6 +118,8 @@ router.get(
   query('nid').isInt().toInt().optional(),
   query('author_id').trim().isLength({ min: 1 }).optional(),
   query('organization_id').isString().optional(),
+  query('category_id').isString().optional(),
+  query('root_category_id').isString().optional(),
   query(['created_at', 'created_at_gt', 'created_at_gte', 'created_at_lt', 'created_at_lte'])
     .isISO8601()
     .optional(),
@@ -131,7 +133,7 @@ router.get(
   query('evaluation_ne').isIn(['null']).optional(),
   catchError(async (req, res) => {
     const { page, page_size, count } = req.query
-    const { nid, author_id, organization_id, status } = req.query
+    const { nid, author_id, organization_id, category_id, root_category_id, status } = req.query
     const { created_at, created_at_gt, created_at_gte, created_at_lt, created_at_lte } = req.query
     const { reply_count_gt, unread_count_gt } = req.query
 
@@ -161,6 +163,12 @@ router.get(
       } else {
         query.equalTo('organization', AV.Object.createWithoutData('Organization', organization_id))
       }
+    }
+    if (category_id) {
+      query.equalTo('category.objectId', category_id)
+    }
+    if (root_category_id) {
+      query.equalTo('categoryPath', root_category_id)
     }
     if (status) {
       if (status.includes(',')) {

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -119,7 +119,6 @@ router.get(
   query('author_id').trim().isLength({ min: 1 }).optional(),
   query('organization_id').isString().optional(),
   query('category_id').isString().optional(),
-  query('root_category_id').isString().optional(),
   query(['created_at', 'created_at_gt', 'created_at_gte', 'created_at_lt', 'created_at_lte'])
     .isISO8601()
     .optional(),

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -133,7 +133,7 @@ router.get(
   query('evaluation_ne').isIn(['null']).optional(),
   catchError(async (req, res) => {
     const { page, page_size, count } = req.query
-    const { nid, author_id, organization_id, category_id, root_category_id, status } = req.query
+    const { nid, author_id, organization_id, category_id, status } = req.query
     const { created_at, created_at_gt, created_at_gte, created_at_lt, created_at_lte } = req.query
     const { reply_count_gt, unread_count_gt } = req.query
 
@@ -166,9 +166,6 @@ router.get(
     }
     if (category_id) {
       query.equalTo('category.objectId', category_id)
-    }
-    if (root_category_id) {
-      query.equalTo('categoryPath', root_category_id)
     }
     if (status) {
       if (status.includes(',')) {

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -11,7 +11,6 @@ const { TICKET_ACTION, TICKET_STATUS } = require('../../lib/common')
 const { encodeFileObject } = require('../file/utils')
 const { encodeUserObject } = require('../user/utils')
 const { isCustomerService } = require('../customerService/utils')
-const { fetchCategoryMap } = require('../category/utils')
 const config = require('../../config')
 const Ticket = require('./model')
 

--- a/api/ticket/model.js
+++ b/api/ticket/model.js
@@ -11,7 +11,7 @@ const { captureException } = require('../errorHandler')
 const { invokeWebhooks } = require('../webhook')
 const { selectAssignee, getActionStatus, selectGroup } = require('./utils')
 const { Triggers } = require('../rule/trigger')
-const { fetchCategoryMap, getCategoryPath } = require('../category/utils')
+const { fetchCategoryMap } = require('../category/utils')
 
 const KEY_MAP = {
   assignee_id: 'assignee',
@@ -83,12 +83,6 @@ class Ticket {
      * @type {{ objectId: string; name: string; }}
      */
     this._category = object.get('category')
-
-    /**
-     * @private
-     * @type {string[]}
-     */
-    this._categoryPath = object.get('categoryPath')
 
     /**
      * @private
@@ -211,7 +205,6 @@ class Ticket {
     obj.set('status', TICKET_STATUS.NEW)
     obj.set('title', data.title)
     obj.set('category', await getTinyCategoryInfo(data.category_id, categories))
-    obj.set('categoryPath', getCategoryPath(data.category_id, categories))
     obj.set('author', AV.Object.createWithoutData('_User', data.author.id))
     if (assignee) {
       obj.set('assignee', AV.Object.createWithoutData('_User', assignee.id))
@@ -466,7 +459,6 @@ class Ticket {
         throw new Error('The name of category is missing')
       }
       object.set('category', this._category)
-      object.set('categoryPath', this._categoryPath)
     }
 
     if (this.isUpdated('group_id')) {
@@ -552,7 +544,6 @@ class Ticket {
     if (this.isUpdated('category_id')) {
       const categories = await fetchCategoryMap()
       this._category = await getTinyCategoryInfo(this.category_id, categories)
-      this._categoryPath = getCategoryPath(this.category_id, categories)
     }
 
     const object = this._getDirtyAVObject()

--- a/api/ticket/model.js
+++ b/api/ticket/model.js
@@ -11,6 +11,7 @@ const { captureException } = require('../errorHandler')
 const { invokeWebhooks } = require('../webhook')
 const { selectAssignee, getActionStatus, selectGroup } = require('./utils')
 const { Triggers } = require('../rule/trigger')
+const { fetchCategoryMap, getCategoryPath } = require('../category/utils')
 
 const KEY_MAP = {
   assignee_id: 'assignee',
@@ -82,6 +83,12 @@ class Ticket {
      * @type {{ objectId: string; name: string; }}
      */
     this._category = object.get('category')
+
+    /**
+     * @private
+     * @type {string[]}
+     */
+    this._categoryPath = object.get('categoryPath')
 
     /**
      * @private
@@ -198,11 +205,13 @@ class Ticket {
   static async create(data) {
     const assignee = data.assignee || (await selectAssignee(data.category_id))
     const group = await selectGroup(data.category_id)
+    const categories = await fetchCategoryMap()
 
     const obj = new AV.Object('Ticket')
     obj.set('status', TICKET_STATUS.NEW)
     obj.set('title', data.title)
-    obj.set('category', await getTinyCategoryInfo(data.category_id))
+    obj.set('category', await getTinyCategoryInfo(data.category_id, categories))
+    obj.set('categoryPath', getCategoryPath(data.category_id, categories))
     obj.set('author', AV.Object.createWithoutData('_User', data.author.id))
     if (assignee) {
       obj.set('assignee', AV.Object.createWithoutData('_User', assignee.id))
@@ -457,6 +466,7 @@ class Ticket {
         throw new Error('The name of category is missing')
       }
       object.set('category', this._category)
+      object.set('categoryPath', this._categoryPath)
     }
 
     if (this.isUpdated('group_id')) {
@@ -540,7 +550,9 @@ class Ticket {
     }
 
     if (this.isUpdated('category_id')) {
-      this._category = await getTinyCategoryInfo(this.category_id)
+      const categories = await fetchCategoryMap()
+      this._category = await getTinyCategoryInfo(this.category_id, categories)
+      this._categoryPath = getCategoryPath(this.category_id, categories)
     }
 
     const object = this._getDirtyAVObject()

--- a/embed/v1/package-lock.json
+++ b/embed/v1/package-lock.json
@@ -952,6 +952,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1094,6 +1099,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "follow-redirects": {
       "version": "1.14.1",
@@ -1912,6 +1922,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2130,6 +2151,11 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
+    "serialize-query-params": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.5.tgz",
+      "integrity": "sha512-BrLH1RqgzVxm6dco+KP9S6BodeFiUVvKwtY3GSWQlupIdblT19KCGTRkHZ2yIU6Bjy0Prjts0tYe11VpTMbAeQ=="
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -2160,6 +2186,16 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "1.0.2",

--- a/embed/v1/package.json
+++ b/embed/v1/package.json
@@ -23,7 +23,8 @@
     "react-i18next": "^11.11.3",
     "react-intersection-observer": "^8.32.0",
     "react-query": "^3.19.0",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "serialize-query-params": "^1.3.5"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/embed/v1/package.json
+++ b/embed/v1/package.json
@@ -18,6 +18,7 @@
     "i18next": "^20.3.3",
     "i18next-browser-languagedetector": "^6.1.2",
     "open-leancloud-storage": "0.0.35",
+    "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.11.3",

--- a/embed/v1/src/App/Home/index.tsx
+++ b/embed/v1/src/App/Home/index.tsx
@@ -51,7 +51,7 @@ export default function Home() {
       return [];
     }
     return categories
-      .filter((c) => (rootCategory ? c.parent_id === rootCategory : !c.parent_id))
+      .filter((c) => (rootCategory ? c.parentId === rootCategory : !c.parentId))
       .sort((a, b) => a.position - b.position);
   }, [categories]);
   const hasUnreadTickets = useHasUnreadTickets();

--- a/embed/v1/src/App/Home/index.tsx
+++ b/embed/v1/src/App/Home/index.tsx
@@ -8,6 +8,7 @@ import { Page } from 'components/Page';
 import { QueryWrapper } from 'components/QueryWrapper';
 import { useIsMounted } from 'utils/useIsMounted';
 import { CategoryList, useCategories } from '../Categories';
+import { useRootCategory } from '../../App';
 
 interface TicketsLinkProps {
   badge?: boolean;
@@ -43,11 +44,14 @@ export default function Home() {
   const { t } = useTranslation();
   const result = useCategories();
   const categories = result.data;
+  const rootCategory = useRootCategory();
   const topCategories = useMemo(() => {
     if (!categories) {
       return [];
     }
-    return categories.filter((c) => !c.parentId).sort((a, b) => a.position - b.position);
+    return categories
+      .filter((c) => (rootCategory ? c.parent_id === rootCategory : !c.parent_id))
+      .sort((a, b) => a.position - b.position);
   }, [categories]);
   const hasUnreadTickets = useHasUnreadTickets();
 

--- a/embed/v1/src/App/Home/index.tsx
+++ b/embed/v1/src/App/Home/index.tsx
@@ -27,15 +27,17 @@ function TicketsLink({ badge }: TicketsLinkProps) {
 function useHasUnreadTickets() {
   const [hasUnreadTickets, setHasUnreadTickets] = useState(false);
   const isMounted = useIsMounted();
+  const rootCategory = useRootCategory();
   useEffect(() => {
     db.class('Ticket')
       .select('objectId')
       .where('unreadCount', '>', 0)
       .where('author', '==', auth.currentUser)
+      .where('categoryPath', '==', rootCategory)
       .first()
       .then((ticket) => ticket && isMounted() && setHasUnreadTickets(true))
       .catch(console.error);
-  }, []);
+  }, [rootCategory]);
   return hasUnreadTickets;
 }
 

--- a/embed/v1/src/App/Home/index.tsx
+++ b/embed/v1/src/App/Home/index.tsx
@@ -33,7 +33,6 @@ function useHasUnreadTickets() {
       .select('objectId')
       .where('unreadCount', '>', 0)
       .where('author', '==', auth.currentUser)
-      .where('categoryPath', '==', rootCategory)
       .first()
       .then((ticket) => ticket && isMounted() && setHasUnreadTickets(true))
       .catch(console.error);

--- a/embed/v1/src/App/LogIn/index.tsx
+++ b/embed/v1/src/App/LogIn/index.tsx
@@ -16,7 +16,7 @@ function LogInForm() {
     e.preventDefault();
     auth.login(username, password).then((user) => {
       http.defaults.headers['X-LC-Session'] = user.sessionToken;
-      history.push('/home');
+      history.push('/');
     });
   };
 
@@ -48,7 +48,7 @@ export default function LogIn() {
   const { t } = useTranslation();
 
   if (auth.currentUser) {
-    return <Redirect to="/home" />;
+    return <Redirect to="/" />;
   }
   return (
     <Page>

--- a/embed/v1/src/App/Tickets/New/index.tsx
+++ b/embed/v1/src/App/Tickets/New/index.tsx
@@ -16,6 +16,7 @@ import { SpaceChinese } from 'components/SpaceChinese';
 import { useCategory } from '../../Categories';
 import { FieldTemplate, FormGroup, useForm } from './Form';
 import { http } from 'leancloud';
+import { useTicketInfo } from '../..';
 
 const PRESET_FORM_FIELDS_HEAD: FieldTemplate[] = [
   {
@@ -66,6 +67,7 @@ function TicketForm({ categoryId, onCommit }: TicketFormProps) {
   const { t } = useTranslation();
   const { files, upload, remove, isUploading } = useUpload();
   const [isCommitting, setIsCommitting] = useState(false);
+  const { meta, tags } = useTicketInfo();
 
   const { data: fields, isLoading: isLoadingFields } = useCategoryFields(categoryId);
   const formFields = useMemo(() => {
@@ -84,6 +86,8 @@ function TicketForm({ categoryId, onCommit }: TicketFormProps) {
       content: content as string,
       file_ids: files.map((file) => file.id!),
       form_values: Object.entries(fieldValues).map(([id, value]) => ({ field: id, value })),
+      metadata: meta,
+      tags,
     };
     try {
       setIsCommitting(true);

--- a/embed/v1/src/App/Tickets/New/index.tsx
+++ b/embed/v1/src/App/Tickets/New/index.tsx
@@ -152,7 +152,7 @@ export function NewTicket() {
 
   if (!result.data && !result.isLoading && !result.error) {
     // Category is not exists :badbad:
-    return <Redirect to="/home" />;
+    return <>Category is not found</>;
   }
   return (
     <Page title={result.data?.name}>

--- a/embed/v1/src/App/Tickets/Ticket/index.tsx
+++ b/embed/v1/src/App/Tickets/Ticket/index.tsx
@@ -350,7 +350,7 @@ export default function TicketDetail() {
 
   if (!result.isLoading && !result.isError && !result.data) {
     // Ticket is not exists :badbad:
-    return <Redirect to="/home" />;
+    return <>Ticket is not found</>;
   }
   return (
     <Page title={t('ticket.detail')}>

--- a/embed/v1/src/App/Tickets/index.tsx
+++ b/embed/v1/src/App/Tickets/index.tsx
@@ -19,6 +19,7 @@ async function fetchTickets(category_id: string, page: number): Promise<Ticket[]
   const { data } = await http.get<any[]>('/api/1/tickets', {
     params: {
       author_id: auth.currentUser?.id,
+      // TODO: waiting for support in v2 API
       root_category_id: category_id,
       page,
       page_size: TICKETS_PAGE_SIZE,

--- a/embed/v1/src/App/Tickets/index.tsx
+++ b/embed/v1/src/App/Tickets/index.tsx
@@ -11,13 +11,15 @@ import TicketDetail, { TicketStatus } from './Ticket';
 import { NewTicket } from './New';
 import { auth, http } from 'leancloud';
 import { Ticket } from 'types';
+import { useRootCategory } from '../../App';
 
 const TICKETS_PAGE_SIZE = 20;
 
-async function fetchTickets(page: number): Promise<Ticket[]> {
+async function fetchTickets(category_id: string, page: number): Promise<Ticket[]> {
   const { data } = await http.get<any[]>('/api/1/tickets', {
     params: {
       author_id: auth.currentUser?.id,
+      root_category_id: category_id,
       page,
       page_size: TICKETS_PAGE_SIZE,
       q: 'sort:created_at-desc',
@@ -38,9 +40,10 @@ async function fetchTickets(page: number): Promise<Ticket[]> {
 }
 
 export function useTickets() {
+  const category = useRootCategory();
   return useInfiniteQuery<Ticket[], Error>({
     queryKey: 'tickets',
-    queryFn: ({ pageParam = 1 }) => fetchTickets(pageParam),
+    queryFn: ({ pageParam = 1 }) => fetchTickets(category, pageParam),
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length === TICKETS_PAGE_SIZE) {
         return allPages.length + 1;

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -41,7 +41,7 @@ function PrivateRoute(props: PropsWithChildren<{ path: string; exact?: boolean }
 const RootCategoryContext = createContext<string | undefined>(undefined);
 export const useRootCategory = () => useContext(RootCategoryContext);
 
-const ROOT_URL = '/embed/v1/catogeries';
+const ROOT_URL = '/embed/v1/categories';
 
 const NotFound = () => <>NOT FOUND</>;
 

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -1,14 +1,14 @@
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { auth } from 'leancloud';
 import { ControlButton } from 'components/ControlButton';
+import { ErrorBoundary } from 'components/ErrorBoundary';
 import LogIn from './LogIn';
 import Home from './Home';
 import Categories from './Categories';
 import Tickets from './Tickets';
-import { ErrorBoundary } from 'components/ErrorBoundary';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { parse } from 'query-string';
 import { decodeQueryParams, JsonParam } from 'serialize-query-params';
 
@@ -37,7 +37,6 @@ const NotFound = () => <>NOT FOUND</>;
 
 export default function App() {
   const pathname = window.location.pathname;
-  console.log(pathname);
   if (!pathname.startsWith(ROOT_URL)) return <NotFound />;
   const paths = pathname.split('/');
   const rootCategory = paths[4] === '-' ? undefined : paths[4];
@@ -66,8 +65,6 @@ const Routes = () => {
     () => decodeQueryParams({ meta: JsonParam, auth: JsonParam }, parse(window.location.hash)),
     []
   );
-
-  console.log(ticketContext);
 
   return (
     <TicketContext.Provider value={ticketContext}>

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren, useContext, useState } from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 import { auth } from 'leancloud';
 import { ControlButton } from 'components/ControlButton';
@@ -7,18 +7,70 @@ import LogIn from './LogIn';
 import Home from './Home';
 import Categories from './Categories';
 import Tickets from './Tickets';
+import { ErrorBoundary } from 'components/ErrorBoundary';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { parse } from 'query-string';
+import { decodeQueryParams, JsonParam } from 'serialize-query-params';
 
-function PrivateRoute(props: PropsWithChildren<{ path: string }>) {
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
+function PrivateRoute(props: PropsWithChildren<{ path: string; exact?: boolean }>) {
   if (!auth.currentUser) {
     return <Redirect to="/login" />;
   }
   return <Route {...props} />;
 }
 
+const RootCategoryContext = createContext<string | undefined>(undefined);
+export const useRootCategory = () => useContext(RootCategoryContext);
+
+const ROOT_URL = '/embed/v1/catogeries';
+
+const NotFound = () => <>NOT FOUND</>;
+
 export default function App() {
+  const pathname = window.location.pathname;
+  console.log(pathname);
+  if (!pathname.startsWith(ROOT_URL)) return <NotFound />;
+  const paths = pathname.split('/');
+  const rootCategory = paths[4] === '-' ? undefined : paths[4];
+
   return (
-    <div className="h-full p-4 sm:px-24 pt-14 sm:pt-4">
-      <ControlButton />
+    <BrowserRouter basename={`${ROOT_URL}/${paths[4]}`}>
+      <QueryClientProvider client={queryClient}>
+        <ErrorBoundary>
+          <RootCategoryContext.Provider value={rootCategory}>
+            <div className="h-full p-4 sm:px-24 pt-14 sm:pt-4">
+              <ControlButton />
+              <Routes />
+            </div>
+          </RootCategoryContext.Provider>
+        </ErrorBoundary>
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+const TicketContext = createContext<object>({});
+export const useTicketContext = () => useContext(TicketContext);
+
+const Routes = () => {
+  const ticketContext = useMemo(
+    () => decodeQueryParams({ meta: JsonParam, auth: JsonParam }, parse(window.location.hash)),
+    []
+  );
+
+  console.log(ticketContext);
+
+  return (
+    <TicketContext.Provider value={ticketContext}>
       <Switch>
         <Route path="/login">
           <LogIn />
@@ -26,17 +78,19 @@ export default function App() {
         <PrivateRoute path="/tickets">
           <Tickets />
         </PrivateRoute>
-        <PrivateRoute path="/home">
-          <Home />
-        </PrivateRoute>
         <PrivateRoute path="/categories/:id">
           <Categories />
         </PrivateRoute>
         <PrivateRoute path="/tickets">
           <Tickets />
         </PrivateRoute>
-        <Redirect to="/home" />
+        <PrivateRoute path="/" exact>
+          <Home />
+        </PrivateRoute>
+        <Route path="*">
+          <NotFound />
+        </Route>
       </Switch>
-    </div>
+    </TicketContext.Provider>
   );
-}
+};

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -10,7 +10,7 @@ import Home from './Home';
 import Categories from './Categories';
 import Tickets from './Tickets';
 import { parse } from 'query-string';
-import { ArrayParam, decodeQueryParams, JsonParam } from 'serialize-query-params';
+import { ArrayParam, decodeQueryParams, JsonParam, StringParam } from 'serialize-query-params';
 import { User } from 'open-leancloud-storage/auth';
 import { Loading } from 'components/Loading';
 import { APIError } from 'components/APIError';
@@ -64,7 +64,7 @@ export default function App() {
   const params = useMemo(
     () =>
       decodeQueryParams(
-        { meta: JsonParam, tags: ArrayParam, auth: JsonParam },
+        { meta: JsonParam, tags: ArrayParam, auth: JsonParam, 'anonymous-id': StringParam },
         parse(window.location.hash)
       ),
     []
@@ -73,7 +73,12 @@ export default function App() {
 
   const [auth, setAuth] = useState<[User | null, boolean, any]>([null, true, null]);
   useEffect(() => {
-    if (params.auth) {
+    if (params['anonymous-id']) {
+      lcAuth
+        .loginWithAuthData('anonymous', { id: params['anonymous-id'] })
+        .then((user) => setAuth([user, false, null]))
+        .catch((error) => setAuth([null, false, error]));
+    } else if (params.auth) {
       if (!params.auth['platform']) {
         setAuth([null, false, new Error('Malformed auth param: platform is required')]);
         return;

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -2,7 +2,7 @@ import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useSt
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { auth } from 'leancloud';
+import { auth as lcAuth } from 'leancloud';
 import { ControlButton } from 'components/ControlButton';
 import { ErrorBoundary } from 'components/ErrorBoundary';
 import LogIn from './LogIn';
@@ -10,7 +10,10 @@ import Home from './Home';
 import Categories from './Categories';
 import Tickets from './Tickets';
 import { parse } from 'query-string';
-import { decodeQueryParams, JsonParam } from 'serialize-query-params';
+import { ArrayParam, decodeQueryParams, JsonParam } from 'serialize-query-params';
+import { User } from 'open-leancloud-storage/auth';
+import { Loading } from 'components/Loading';
+import { APIError } from 'components/APIError';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,7 +25,14 @@ const queryClient = new QueryClient({
 });
 
 function PrivateRoute(props: PropsWithChildren<{ path: string; exact?: boolean }>) {
-  if (!auth.currentUser) {
+  const [auth, loading, error] = useAuth();
+  if (loading) {
+    return <Loading />;
+  }
+  if (error) {
+    return <APIError error={error} />;
+  }
+  if (!auth) {
     return <Redirect to="/login" />;
   }
   return <Route {...props} />;
@@ -35,21 +45,63 @@ const ROOT_URL = '/embed/v1/catogeries';
 
 const NotFound = () => <>NOT FOUND</>;
 
+const TicketInfoContext = createContext<{
+  meta?: Record<string, unknown> | null;
+  tags?: Array<string | null> | null;
+  // fields
+}>({});
+export const useTicketContext = () => useContext(TicketInfoContext);
+
+const AuthContext = createContext<[User | null, boolean, any]>([null, true, null]);
+export const useAuth = () => useContext(AuthContext);
+
 export default function App() {
   const pathname = window.location.pathname;
   if (!pathname.startsWith(ROOT_URL)) return <NotFound />;
   const paths = pathname.split('/');
   const rootCategory = paths[4] === '-' ? undefined : paths[4];
 
+  const params = useMemo(
+    () =>
+      decodeQueryParams(
+        { meta: JsonParam, tags: ArrayParam, auth: JsonParam },
+        parse(window.location.hash)
+      ),
+    []
+  );
+  const ticketInfo = useMemo(() => ({ meta: params.meta, tags: params.tags }), [params]);
+
+  const [auth, setAuth] = useState<[User | null, boolean, any]>([null, true, null]);
+  useEffect(() => {
+    if (params.auth) {
+      if (!params.auth['platform']) {
+        setAuth([null, false, new Error('Malformed auth param: platform is required')]);
+        return;
+      }
+      lcAuth
+        .loginWithAuthData(params.auth.platform, params.auth.data)
+        .then((user) => setAuth([user, false, null]))
+        .catch((error) => setAuth([null, false, error]));
+    } else if (lcAuth.currentUser) {
+      setAuth([lcAuth.currentUser, false, null]);
+    } else {
+      setAuth([null, false, null]);
+    }
+  }, []);
+
   return (
     <BrowserRouter basename={`${ROOT_URL}/${paths[4]}`}>
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary>
           <RootCategoryContext.Provider value={rootCategory}>
-            <div className="h-full p-4 sm:px-24 pt-14 sm:pt-4">
-              <ControlButton />
-              <Routes />
-            </div>
+            <AuthContext.Provider value={auth}>
+              <TicketInfoContext.Provider value={ticketInfo}>
+                <div className="h-full p-4 sm:px-24 pt-14 sm:pt-4">
+                  <ControlButton />
+                  <Routes />
+                </div>
+              </TicketInfoContext.Provider>
+            </AuthContext.Provider>
           </RootCategoryContext.Provider>
         </ErrorBoundary>
       </QueryClientProvider>
@@ -57,37 +109,27 @@ export default function App() {
   );
 }
 
-const TicketContext = createContext<object>({});
-export const useTicketContext = () => useContext(TicketContext);
-
 const Routes = () => {
-  const ticketContext = useMemo(
-    () => decodeQueryParams({ meta: JsonParam, auth: JsonParam }, parse(window.location.hash)),
-    []
-  );
-
   return (
-    <TicketContext.Provider value={ticketContext}>
-      <Switch>
-        <Route path="/login">
-          <LogIn />
-        </Route>
-        <PrivateRoute path="/tickets">
-          <Tickets />
-        </PrivateRoute>
-        <PrivateRoute path="/categories/:id">
-          <Categories />
-        </PrivateRoute>
-        <PrivateRoute path="/tickets">
-          <Tickets />
-        </PrivateRoute>
-        <PrivateRoute path="/" exact>
-          <Home />
-        </PrivateRoute>
-        <Route path="*">
-          <NotFound />
-        </Route>
-      </Switch>
-    </TicketContext.Provider>
+    <Switch>
+      <Route path="/login">
+        <LogIn />
+      </Route>
+      <PrivateRoute path="/tickets">
+        <Tickets />
+      </PrivateRoute>
+      <PrivateRoute path="/categories/:id">
+        <Categories />
+      </PrivateRoute>
+      <PrivateRoute path="/tickets">
+        <Tickets />
+      </PrivateRoute>
+      <PrivateRoute path="/" exact>
+        <Home />
+      </PrivateRoute>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
   );
 };

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -50,7 +50,7 @@ const TicketInfoContext = createContext<{
   tags?: Array<string | null> | null;
   // fields
 }>({});
-export const useTicketContext = () => useContext(TicketInfoContext);
+export const useTicketInfo = () => useContext(TicketInfoContext);
 
 const AuthContext = createContext<[User | null, boolean, any]>([null, true, null]);
 export const useAuth = () => useContext(AuthContext);

--- a/embed/v1/src/App/index.tsx
+++ b/embed/v1/src/App/index.tsx
@@ -41,7 +41,7 @@ function PrivateRoute(props: PropsWithChildren<{ path: string; exact?: boolean }
 const RootCategoryContext = createContext<string | undefined>(undefined);
 export const useRootCategory = () => useContext(RootCategoryContext);
 
-const ROOT_URL = '/embed/v1/categories';
+const ROOT_URL = '/in-app/v1/categories';
 
 const NotFound = () => <>NOT FOUND</>;
 

--- a/embed/v1/src/components/ControlButton/index.tsx
+++ b/embed/v1/src/components/ControlButton/index.tsx
@@ -10,7 +10,7 @@ function Divider() {
 export function ControlButton() {
   const history = useHistory();
   const goBack = () => history.goBack();
-  const goHome = () => history.push('/home');
+  const goHome = () => history.push('/');
 
   return (
     <div

--- a/embed/v1/src/index.tsx
+++ b/embed/v1/src/index.tsx
@@ -1,31 +1,12 @@
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
-
 import './index.css';
 import './i18n';
-import { ErrorBoundary } from 'components/ErrorBoundary';
 import App from './App';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
-    },
-  },
-});
 
 render(
   <StrictMode>
-    <BrowserRouter basename="/embed/v1">
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary>
-          <App />
-        </ErrorBoundary>
-      </QueryClientProvider>
-    </BrowserRouter>
+    <App />
   </StrictMode>,
   document.getElementById('root')
 );

--- a/embed/v1/src/leancloud/index.ts
+++ b/embed/v1/src/leancloud/index.ts
@@ -19,7 +19,7 @@ export const db = app.database();
 export const storage = app.storage();
 
 export const http = axios.create({
-  headers: {
-    'X-LC-Session': auth.currentUser?.sessionToken,
+  transformRequest: (data, header) => {
+    header['X-LC-Session'] = auth.currentUser?.sessionToken;
   },
 });

--- a/embed/v1/vite.config.js
+++ b/embed/v1/vite.config.js
@@ -4,7 +4,7 @@ import reactJSX from 'vite-react-jsx';
 import path from 'path';
 
 export default defineConfig({
-  base: '/embed/v1/',
+  base: '/in-app/v1/',
   plugins: [reactRefresh(), reactJSX()],
   server: {
     port: 8081,

--- a/modules/Settings/Category.js
+++ b/modules/Settings/Category.js
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from 'react'
-import { Button, Form } from 'react-bootstrap'
+import { Button, Form, Breadcrumb } from 'react-bootstrap'
 import { withTranslation } from 'react-i18next'
-import { withRouter } from 'react-router-dom'
+import { withRouter, Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { db } from '../../lib/leancloud'
@@ -192,6 +192,14 @@ class Category extends React.Component {
 
     return (
       <Form onSubmit={this.handleSubmit.bind(this)}>
+        <Breadcrumb>
+          <Breadcrumb.Item linkProps={{ to: '/settings/categories' }} linkAs={Link}>
+            {t('category')}
+          </Breadcrumb.Item>
+          <Breadcrumb.Item active>
+            {this.state.category?.id ? this.state.category.id : t('add')}
+          </Breadcrumb.Item>
+        </Breadcrumb>
         <Form.Group controlId="nameText">
           <Form.Label>{t('categoryName')}</Form.Label>
           <Form.Control value={this.state.name} onChange={this.handleNameChange.bind(this)} />

--- a/modules/Ticket/Category/index.js
+++ b/modules/Ticket/Category/index.js
@@ -32,20 +32,8 @@ AsyncCategory.propTypes = {
   block: PropTypes.bool,
 }
 
-function CategoryByPath({ block, categoryPath }) {
-  const fullName = useMemo(() => categoryPath.map((c) => c.name).join(' / '), [categoryPath])
-  return <span className={classNames(css.category, { [css.block]: block })}>{fullName}</span>
-}
-CategoryByPath.propTypes = {
-  categoryPath: PropTypes.array.isRequired,
-  block: PropTypes.bool,
-}
-
 // eslint-disable-next-line react/prop-types
-export function Category({ categoryId, categoryPath, block }) {
-  if (categoryPath) {
-    return <CategoryByPath block={block} categoryPath={categoryPath} />
-  }
+export function Category({ categoryId, block }) {
   return <AsyncCategory block={block} categoryId={categoryId} />
 }
 

--- a/modules/Ticket/OpsLog.js
+++ b/modules/Ticket/OpsLog.js
@@ -24,7 +24,7 @@ export function AsyncUserLabel({ userId }) {
   return data ? <UserLabel user={data} /> : 'Loading...'
 }
 AsyncUserLabel.propTypes = {
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.string,
 }
 
 function SelectAssignee({ id, assignee_id, created_at }) {
@@ -91,7 +91,7 @@ function ChangeGroup({ id, operator_id, group_id, created_at }) {
 }
 ChangeGroup.propTypes = {
   id: PropTypes.string.isRequired,
-  operator_id: PropTypes.string.isRequired,
+  operator_id: PropTypes.string,
   group_id: PropTypes.string,
   created_at: PropTypes.string.isRequired,
 }
@@ -115,7 +115,7 @@ function ChangeAssignee({ id, operator_id, assignee_id, created_at }) {
 }
 ChangeAssignee.propTypes = {
   id: PropTypes.string.isRequired,
-  operator_id: PropTypes.string.isRequired,
+  operator_id: PropTypes.string,
   assignee_id: PropTypes.string,
   created_at: PropTypes.string.isRequired,
 }

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -222,7 +222,7 @@ function CategorySection({ ticket, isCustomerService }) {
         />
       ) : (
         <div className="d-flex align-items-center">
-          <Category block categoryPath={ticket.category_path} />
+          <Category block categoryId={ticket.category_id} />
           {isCustomerService && (
             <Button variant="link" onClick={() => setEditingCategory(true)}>
               <Icon.PencilFill />
@@ -237,7 +237,6 @@ CategorySection.propTypes = {
   ticket: PropTypes.shape({
     id: PropTypes.string.isRequired,
     category_id: PropTypes.string.isRequired,
-    category_path: PropTypes.array.isRequired,
   }),
   isCustomerService: PropTypes.bool,
 }

--- a/resources/schema/Ticket.json
+++ b/resources/schema/Ticket.json
@@ -3,9 +3,6 @@
     "category": {
       "type": "Object"
     },
-    "categoryPath": {
-      "type": "Array"
-    },
     "privateTags": {
       "type": "Array",
       "v": 2,

--- a/resources/schema/Ticket.json
+++ b/resources/schema/Ticket.json
@@ -3,6 +3,9 @@
     "category": {
       "type": "Object"
     },
+    "categoryPath": {
+      "type": "Array"
+    },
     "privateTags": {
       "type": "Array",
       "v": 2,

--- a/server.js
+++ b/server.js
@@ -40,9 +40,9 @@ app.use(express.urlencoded({ extended: false }))
 // legacy api
 app.use(require('./api'))
 
-// embed pages
-app.use('/embed/v1', express.static(path.join(__dirname, 'embed/v1/dist')))
-app.get('/embed/v1/*', (req, res) => {
+// in-app pages
+app.use('/in-app/v1', express.static(path.join(__dirname, 'embed/v1/dist')))
+app.get('/in-app/v1/*', (req, res) => {
   res.sendFile(path.join(__dirname, 'embed/v1/dist/index.html'))
 })
 


### PR DESCRIPTION
多个应用的情况下，可以使用应用作为一级分类。此时对于某个应用，应用内嵌的工单页应该看不到其他的分类。所以内嵌工单页的  baseurl 加了两级，支持指定一个分类为 root 分类。

- [x] 从 URL 中解析出 root 分类
- [x] 落地页仅展示 root 分类的子分类
- [x] 提交工单时在 Ticket 表中冗余 categoryPath，方便指定 root 分类查询该分类及子分类下的所有工单
  - [x] 工单列表页仅展示  root 分类下的工单
  - 工单详情页展示分类路径隐藏 root 分类（不过现在似乎并没有展示分类）

一些考虑：

- root category 是可选的，从语义化的角度放在 search 里会比较合适，但这里直接作为 basename 加到了 URL path 部分，是为了保持这部分信息在路由跳转之间保留（放在 search 里很难保证），同时让内部的路由操作完全感知不到这部分的存在。
- 同样为了保证不会不小心把无关的 category 露出，如果没有指定 root category，会明确返回 404 页面。如果开发者不需要指定 root category，则需要在 URL 里显式的使用 `-` 作为 root category 的 ID。