### PR TITLE
feat(next): more api

### DIFF
--- a/next/api/src/cache/index.ts
+++ b/next/api/src/cache/index.ts
@@ -1,8 +1,2 @@
-import Redis from 'ioredis';
-
-export const redis = new Redis(process.env.REDIS_URL_CACHE);
-
-redis.on('error', (error) => {
-  // TODO(sdjdd): Sentry
-  console.error('[Redis] Error:', error);
-});
+export * from './redis';
+export * from './local';

--- a/next/api/src/cache/local.ts
+++ b/next/api/src/cache/local.ts
@@ -1,0 +1,30 @@
+export type Fetcher<T> = () => Promise<T>;
+
+export class LocalCache<T> {
+  private data?: T;
+  private fetchTask?: Promise<T>;
+
+  /**
+   * @param ttl 和 redis 保持一致, 单位是秒!
+   * @param fetcher
+   */
+  constructor(readonly ttl: number, private fetcher: Fetcher<T>) {}
+
+  async get(): Promise<T> {
+    if (this.data) {
+      return this.data;
+    }
+    if (!this.fetchTask) {
+      this.fetchTask = (async () => {
+        try {
+          this.data = await this.fetcher();
+          setTimeout(() => delete this.data, this.ttl * 1000);
+          return this.data;
+        } finally {
+          delete this.fetchTask;
+        }
+      })();
+    }
+    return this.fetchTask;
+  }
+}

--- a/next/api/src/cache/redis.ts
+++ b/next/api/src/cache/redis.ts
@@ -1,0 +1,8 @@
+import Redis from 'ioredis';
+
+export const redis = new Redis(process.env.REDIS_URL_CACHE);
+
+redis.on('error', (error) => {
+  // TODO(sdjdd): Sentry
+  console.error('[Redis] Error:', error);
+});

--- a/next/api/src/middlewares/error.ts
+++ b/next/api/src/middlewares/error.ts
@@ -19,6 +19,8 @@ export const catchLCError: Middleware = async (ctx, next) => {
     switch (error.code) {
       case 211:
         ctx.throw(404, error.rawMessage);
+      case 403:
+        ctx.throw(403, error.rawMessage);
     }
     throw error;
   }

--- a/next/api/src/middlewares/index.ts
+++ b/next/api/src/middlewares/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './error';
+export * from './sort';

--- a/next/api/src/middlewares/search.ts
+++ b/next/api/src/middlewares/search.ts
@@ -2,11 +2,6 @@ import { Middleware } from 'koa';
 
 import { Field, parse as parseQ } from '../utils/search';
 
-export interface SortItem {
-  key: string;
-  order: 'asc' | 'desc';
-}
-
 export interface Searching {
   text: string[];
   eq: Record<string, string>;
@@ -73,31 +68,3 @@ export const search: Middleware = (ctx, next) => {
   }
   return next();
 };
-
-function parseSort(key: string): SortItem {
-  let order: SortItem['order'] = 'asc';
-  if (key.endsWith('-asc')) {
-    key = key.slice(0, -4);
-  } else if (key.endsWith('-desc')) {
-    key = key.slice(0, -5);
-    order = 'desc';
-  }
-  return { key, order };
-}
-
-export function sort(fields?: string[]): Middleware {
-  return (ctx, next) => {
-    ctx.state.sort = [];
-    if (ctx.query.sort) {
-      const keys = typeof ctx.query.sort === 'string' ? ctx.query.sort.split(',') : ctx.query.sort;
-      keys.forEach((key) => {
-        const item = parseSort(key);
-        if (fields && !fields.includes(item.key)) {
-          ctx.throw(400, 'sort must be one of ' + fields.join(', '));
-        }
-        ctx.state.sort.push(item);
-      });
-    }
-    return next();
-  };
-}

--- a/next/api/src/middlewares/sort.ts
+++ b/next/api/src/middlewares/sort.ts
@@ -1,0 +1,35 @@
+import { Middleware } from 'koa';
+
+export interface SortItem {
+  key: string;
+  order: 'asc' | 'desc';
+}
+
+function parseSort(key: string): SortItem {
+  let order: SortItem['order'] = 'asc';
+  if (key.endsWith('-asc')) {
+    key = key.slice(0, -4);
+  } else if (key.endsWith('-desc')) {
+    key = key.slice(0, -5);
+    order = 'desc';
+  }
+  return { key, order };
+}
+
+export function sort(key: string, fields?: string[]): Middleware {
+  return (ctx, next) => {
+    ctx.state.sort = [];
+    const data = ctx.query[key];
+    if (data) {
+      const keys = typeof data === 'string' ? data.split(',') : data;
+      keys.forEach((key) => {
+        const item = parseSort(key);
+        if (fields && !fields.includes(item.key)) {
+          ctx.throw(400, key + ' must be one of ' + fields.join(', '));
+        }
+        ctx.state.sort.push(item);
+      });
+    }
+    return next();
+  };
+}

--- a/next/api/src/models/form/index.ts
+++ b/next/api/src/models/form/index.ts
@@ -1,0 +1,233 @@
+import AV from 'leancloud-storage';
+
+import { array2map } from '../../utils/convert';
+
+export interface TicketFieldData {
+  id: string;
+  title: string;
+  type: string;
+  active: boolean;
+  defaultLocale: string;
+  required?: boolean;
+}
+
+export class TicketField {
+  id: string;
+  title: string;
+  type: string;
+  active: boolean;
+  defaultLocale: string;
+  required: boolean;
+
+  constructor(data: TicketFieldData) {
+    this.id = data.id;
+    this.title = data.title;
+    this.type = data.type;
+    this.active = data.active;
+    this.defaultLocale = data.defaultLocale;
+    this.required = !!data.required;
+  }
+
+  static pointer(id: string) {
+    return AV.Object.createWithoutData('TicketField', id);
+  }
+
+  async getSome(ids: string[]): Promise<TicketField[]> {
+    const query = new AV.Query<AV.Object>('TicketField');
+    query.containedIn('objectId', ids);
+    const objects = await query.find({ useMasterKey: true });
+    return objects.map((obj) => {
+      return new TicketField({
+        id: obj.id!,
+        title: obj.get('title'),
+        type: obj.get('type'),
+        active: obj.get('active'),
+        defaultLocale: obj.get('defaultLocale'),
+        required: obj.get('required'),
+      });
+    });
+  }
+
+  toPointer() {
+    return AV.Object.createWithoutData('TicketField', this.id);
+  }
+}
+
+export interface TicketFieldOption {
+  title: string;
+  value: string;
+}
+
+export interface TicketFieldVariantData {
+  id: string;
+  locale: string;
+  title: string;
+  type: string;
+  required?: boolean;
+  options?: TicketFieldOption[];
+}
+
+export class TicketFieldVariant {
+  id: string;
+  locale: string;
+  title: string;
+  type: string;
+  required: boolean;
+  options?: TicketFieldOption[];
+
+  constructor(data: TicketFieldVariantData) {
+    this.id = data.id;
+    this.locale = data.locale;
+    this.title = data.title;
+    this.type = data.type;
+    this.required = !!data.required;
+    this.options = data.options;
+  }
+}
+
+export interface TicketFormData {
+  id: string;
+  title: string;
+  fieldIds: string[];
+}
+
+export class TicketForm {
+  id: string;
+  title: string;
+  fieldIds: string[];
+
+  constructor(data: TicketFormData) {
+    this.id = data.id;
+    this.title = data.title;
+    this.fieldIds = data.fieldIds;
+  }
+
+  static fromAVObject(object: AV.Object) {
+    // TODO(sdjdd): check attributes
+    return new TicketForm({
+      id: object.id!,
+      title: object.get('title'),
+      fieldIds: object.get('fieldIds'),
+    });
+  }
+
+  static fromJSON(data: any) {
+    return new TicketForm(data);
+  }
+
+  async getFields(): Promise<TicketField[]> {
+    const query = new AV.Query<AV.Object>('TicketField');
+    query.containedIn('objectId', this.fieldIds);
+    const objects = await query.find({ useMasterKey: true });
+    const fieldMap: Record<string, TicketField> = {};
+    objects.forEach((obj) => {
+      fieldMap[obj.id!] = new TicketField({
+        id: obj.id!,
+        title: obj.get('title'),
+        type: obj.get('type'),
+        active: obj.get('active'),
+        defaultLocale: obj.get('defaultLocale'),
+        required: obj.get('required'),
+      });
+    });
+    const fields: TicketField[] = [];
+    this.fieldIds.forEach((id) => {
+      const field = fieldMap[id];
+      if (field) {
+        fields.push(field);
+      }
+    });
+    return fields;
+  }
+
+  async getFieldVariants(locale: string): Promise<TicketFieldVariant[]> {
+    const fields = await this.getFields();
+    const field_map = array2map(fields, 'id');
+    const locale_set = new Set(
+      getAvailableLocales(locale).concat(fields.map((f) => f.defaultLocale))
+    );
+
+    const query = new AV.Query<AV.Object>('TicketFieldVariant');
+    query.containedIn(
+      'field',
+      fields.map((f) => f.toPointer())
+    );
+    query.containedIn('locale', Array.from(locale_set));
+    const objects = await query.find({ useMasterKey: true });
+
+    const fieldVariants_map: Record<string, TicketFieldVariant[]> = {};
+    objects.forEach((obj) => {
+      const fieldId = obj.get('field').id as string;
+      const field = field_map[fieldId];
+      const variant = new TicketFieldVariant({
+        id: obj.id!,
+        locale: obj.get('locale'),
+        title: obj.get('title'),
+        type: field.type,
+        required: field.required,
+        options: (obj.get('options') as [string, string][])?.map(optionTupleToObject),
+      });
+
+      if (fieldVariants_map[fieldId]) {
+        fieldVariants_map[fieldId].push(variant);
+      } else {
+        fieldVariants_map[fieldId] = [variant];
+      }
+    });
+
+    const fieldVariants: TicketFieldVariant[] = [];
+    for (const field of fields) {
+      const variants = fieldVariants_map[field.id];
+      if (!variants) continue;
+
+      let exactLocal: TicketFieldVariant | undefined;
+      let defaultLocale: TicketFieldVariant | undefined;
+      let fallbackLocale: TicketFieldVariant | undefined;
+      for (const variant of variants) {
+        if (variant.locale === locale) {
+          exactLocal = variant;
+          break;
+        }
+        if (variant.locale === field.defaultLocale) {
+          defaultLocale = variant;
+        }
+        if (locale.startsWith(variant.locale)) {
+          fallbackLocale = variant;
+        }
+      }
+
+      if (exactLocal) {
+        fieldVariants.push(exactLocal);
+      } else {
+        if (!defaultLocale) {
+          throw new Error(
+            `Ticket field ${field.id} has no variant of default locale (${field.defaultLocale})`
+          );
+        }
+        fieldVariants.push(fallbackLocale ?? defaultLocale);
+      }
+    }
+    return fieldVariants;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      title: this.title,
+      fieldIds: this.fieldIds,
+    };
+  }
+}
+
+function getAvailableLocales(locale: string): string[] {
+  const locales: string[] = [locale];
+  const index = locale.indexOf('-');
+  if (index > 0) {
+    locales.push(locale.slice(0, index));
+  }
+  return locales;
+}
+
+function optionTupleToObject([value, title]: [string, string]): TicketFieldOption {
+  return { title, value };
+}

--- a/next/api/src/models/ticket/index.ts
+++ b/next/api/src/models/ticket/index.ts
@@ -4,40 +4,26 @@ import { Categories, Category, CategoryPathItem } from '../category';
 import { Group } from '../group';
 import { User } from '../user';
 
-export interface TicketFilters {
-  id?: string | string[];
+export interface TicketFilter {
   authorId?: string;
   assigneeId?: string;
+  categoryId?: string | string[];
   groupId?: string | string[];
   status?: number | number[];
   evaluationStar?: number;
-  createdAtGT?: Date;
-  createdAtLT?: Date;
-  createdAtGTE?: Date;
-  createdAtLTE?: Date;
+  createdAt?: [Date | undefined, Date | undefined];
 }
 
 export function makeQuery({
-  id,
   authorId,
   assigneeId,
+  categoryId,
   groupId,
   status,
   evaluationStar,
-  createdAtGT,
-  createdAtLT,
-  createdAtGTE,
-  createdAtLTE,
-}: TicketFilters): AV.Query<AV.Object> {
+  createdAt,
+}: TicketFilter): AV.Query<AV.Object> {
   const query = new AV.Query<AV.Object>('Ticket');
-
-  if (id !== undefined) {
-    if (typeof id === 'string') {
-      query.equalTo('objectId', id);
-    } else {
-      query.containedIn('objectId', [...id]);
-    }
-  }
 
   if (authorId) {
     query.equalTo('author', User.pointer(authorId));
@@ -48,6 +34,14 @@ export function makeQuery({
       query.equalTo('assignee', User.pointer(assigneeId));
     } else {
       query.doesNotExist('assignee');
+    }
+  }
+
+  if (categoryId) {
+    if (typeof categoryId === 'string') {
+      query.equalTo('category.objectId', categoryId);
+    } else {
+      query.containedIn('category.objectId', categoryId);
     }
   }
 
@@ -75,17 +69,14 @@ export function makeQuery({
     query.equalTo('evaluation.star', evaluationStar);
   }
 
-  if (createdAtGT) {
-    query.greaterThan('createdAt', createdAtGT);
-  }
-  if (createdAtLT) {
-    query.lessThan('createdAt', createdAtLT);
-  }
-  if (createdAtGTE) {
-    query.greaterThanOrEqualTo('createdAt', createdAtGTE);
-  }
-  if (createdAtLTE) {
-    query.lessThanOrEqualTo('createdAt', createdAtLTE);
+  if (createdAt) {
+    const [since, until] = createdAt;
+    if (since) {
+      query.greaterThanOrEqualTo('createdAt', since);
+    }
+    if (until) {
+      query.lessThan('createdAt', until);
+    }
   }
 
   return query;
@@ -141,7 +132,7 @@ export class TicketItem {
       },
       categoryPath: this.categoryPath,
       author: this.author.toJSON(),
-      assignee: this.assignee?.toJSON(),
+      assignee: this.assignee ? this.assignee.toJSON() : null,
       group: this.group,
       status: this.status,
       createdAt: this.createdAt.toISOString(),
@@ -164,9 +155,48 @@ export interface FindResults {
   totalCount?: number;
 }
 
+export interface GetTicketOptions {
+  user?: FindOptions['user'];
+  includeGroup?: FindOptions['includeGroup'];
+}
+
+export interface TicketData extends TicketItemData {
+  content: string;
+  contentHtml: string;
+}
+
 export class Ticket {
-  static async find(filters: TicketFilters, options?: FindOptions): Promise<FindResults> {
-    const query = makeQuery(filters);
+  id: string;
+  nid: number;
+  title: string;
+  category: Category;
+  categoryPath: CategoryPathItem[];
+  author: User;
+  assignee?: User;
+  group?: Group | null;
+  status: number;
+  content: string;
+  contentHtml: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(data: TicketData) {
+    this.id = data.id;
+    this.nid = data.nid;
+    this.title = data.title;
+    this.category = data.category;
+    this.categoryPath = data.categoryPath;
+    this.author = data.author;
+    this.assignee = data.assignee;
+    this.status = data.status;
+    this.content = data.content;
+    this.contentHtml = data.contentHtml;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+
+  static async find(filter: TicketFilter, options?: FindOptions): Promise<FindResults> {
+    const query = makeQuery(filter);
     query.select('nid', 'title', 'category', 'author', 'assignee', 'status');
     query.include('author', 'assignee');
     if (options) {
@@ -224,6 +254,65 @@ export class Ticket {
     });
 
     return { tickets, totalCount };
+  }
+
+  static async get(id: string, options?: GetTicketOptions): Promise<Ticket> {
+    const query = new AV.Query<AV.Object>('Ticket');
+    query.include('author', 'assignee');
+    if (options?.includeGroup) {
+      query.include('group');
+    }
+
+    const authOptions = {
+      sessionToken: options?.user?.sessionToken,
+    };
+    const [object, categories] = await Promise.all([
+      query.get(id, authOptions),
+      Categories.create(),
+    ]);
+
+    const categoryId = object.get('category').objectId;
+    const ticket = new Ticket({
+      id: object.id!,
+      nid: object.get('nid'),
+      title: object.get('title'),
+      category: categories.get(categoryId),
+      categoryPath: categories.getPath(categoryId),
+      author: User.fromAVObject(object.get('author')),
+      assignee: object.has('assignee') ? User.fromAVObject(object.get('assignee')) : undefined,
+      status: object.get('status'),
+      content: object.get('content'),
+      contentHtml: object.get('content_HTML'),
+      createdAt: object.createdAt!,
+      updatedAt: object.updatedAt!,
+    });
+
+    if (options?.includeGroup) {
+      ticket.group = object.has('group') ? Group.fromAVObject(object.get('group')) : null;
+    }
+
+    return ticket;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      nid: this.nid,
+      title: this.title,
+      category: {
+        id: this.category.id,
+        name: this.category.name,
+      },
+      categoryPath: this.categoryPath,
+      author: this.author.toJSON(),
+      assignee: this.assignee ? this.assignee.toJSON() : null,
+      group: this.group,
+      content: this.content,
+      contentHtml: this.contentHtml,
+      status: this.status,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAt.toISOString(),
+    };
   }
 }
 

--- a/next/api/src/models/user/index.ts
+++ b/next/api/src/models/user/index.ts
@@ -7,7 +7,7 @@ import { isCustomerService } from './customer-service';
 export interface UserData {
   id: string;
   username: string;
-  name?: string;
+  nickname?: string;
   email?: string;
   createdAt: Date;
   updatedAt: Date;
@@ -18,11 +18,11 @@ export type AuthedUser = User & Required<Pick<User, 'sessionToken'>>;
 export class User {
   id: string;
   username: string;
-  name?: string;
+  nickname: string;
   email?: string;
   createdAt: Date;
   updatedAt: Date;
-  avatar: string;
+  avatarUrl: string;
   sessionToken?: string;
 
   private _isCustomerService?: boolean;
@@ -30,11 +30,11 @@ export class User {
   constructor(data: UserData) {
     this.id = data.id;
     this.username = data.username;
-    this.name = data.name;
+    this.nickname = data.nickname || data.username;
     this.email = data.email;
     this.createdAt = data.createdAt;
     this.updatedAt = data.updatedAt;
-    this.avatar = getGravatarURL(this.email ?? this.username);
+    this.avatarUrl = getGravatarURL(this.email ?? this.username);
   }
 
   static pointer(id: string) {
@@ -46,7 +46,7 @@ export class User {
     return new User({
       id: object.id!,
       username: object.get('username'),
-      name: object.get('name') ?? undefined,
+      nickname: object.get('name') ?? undefined,
       email: object.get('email') ?? undefined,
       createdAt: object.createdAt!,
       updatedAt: object.updatedAt!,
@@ -77,13 +77,6 @@ export class User {
     return this._isCustomerService;
   }
 
-  isCustomerServiceSync(): boolean | never {
-    if (this._isCustomerService === undefined) {
-      throw new Error('You should call User#isCustomerService first');
-    }
-    return this._isCustomerService;
-  }
-
   toPointer() {
     return AV.Object.createWithoutData('_User', this.id);
   }
@@ -92,8 +85,8 @@ export class User {
     return {
       id: this.id,
       username: this.username,
-      name: this.name,
-      avatar: this.avatar,
+      nickname: this.nickname,
+      avatarUrl: this.avatarUrl,
     };
   }
 }

--- a/next/api/src/routers/category.ts
+++ b/next/api/src/routers/category.ts
@@ -23,9 +23,7 @@ router.get('/', search, async (ctx) => {
     }
   }
 
-  ctx.body = {
-    items: categories,
-  };
+  ctx.body = categories;
 });
 
 export default router;

--- a/next/api/src/routers/category.ts
+++ b/next/api/src/routers/category.ts
@@ -1,9 +1,9 @@
+import { Context } from 'koa';
 import Router from '@koa/router';
 
 import * as yup from '../utils/yup';
 import { auth } from '../middlewares/auth';
-import { search } from '../middlewares/search';
-import { Category } from '../models/category';
+import { Categories, Category } from '../models/category';
 
 const router = new Router().use(auth);
 
@@ -11,19 +11,55 @@ const getCategoriesSchema = yup.object({
   active: yup.bool(),
 });
 
-router.get('/', search, async (ctx) => {
+router.get('/', async (ctx) => {
   const { active } = getCategoriesSchema.validateSync(ctx.query);
 
-  let categories = await Category.getAll();
-  if (active !== undefined) {
-    if (active) {
-      categories = categories.filter((c) => !c.deletedAt);
-    } else {
-      categories = categories.filter((c) => c.deletedAt);
-    }
+  let categories = (await Categories.create()).getAll();
+  if (active === true) {
+    categories = categories.filter((c) => !c.deletedAt);
+  } else if (active === false) {
+    categories = categories.filter((c) => c.deletedAt);
   }
 
-  ctx.body = categories;
+  ctx.body = categories.map((c) => ({
+    id: c.id,
+    name: c.name,
+    parentId: c.parentId,
+    order: c.order,
+    active: !c.deletedAt,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  }));
+});
+
+router.param('id', async (id, ctx, next) => {
+  const categories = await Categories.create();
+  ctx.state.category = categories.get(id);
+  return next();
+});
+
+function getPreferedLocale(ctx: Context): string {
+  let locale: string;
+  if (ctx.query.locale) {
+    if (typeof ctx.query.locale === 'string') {
+      locale = ctx.query.locale;
+    } else {
+      locale = ctx.query.locale[ctx.query.locale.length - 1];
+    }
+  } else {
+    locale = ctx.get('Accept-Language') ?? 'en';
+  }
+  return locale.toLowerCase();
+}
+
+router.get('/:id/fields', async (ctx) => {
+  const locale = getPreferedLocale(ctx);
+  const category = ctx.state.category as Category;
+  if (category.form) {
+    ctx.body = await category.form.getFieldVariants(locale);
+  } else {
+    ctx.body = [];
+  }
 });
 
 export default router;

--- a/next/api/src/routers/staff.ts
+++ b/next/api/src/routers/staff.ts
@@ -22,9 +22,7 @@ router.param('user', async (id, ctx, next) => {
 router.get('/:user/groups', async (ctx) => {
   const user = ctx.state.user as User;
   const groups = await Group.findForUser(user.id);
-  ctx.body = {
-    items: groups,
-  };
+  ctx.body = groups;
 });
 
 export default router;


### PR DESCRIPTION
- 返回结果去掉 `items` ，直接返回数组；通过 `X-Total-Count` 返回总数
- 添加本地缓存；在 redis 缓存的基础上，使用本地缓存缓存所有分类，TTL = 10 seconds
- 添加工单详情 API
- 添加 `GET /categories/:id/fields` 获取分类字段