### PR TITLE
fix: unify locale

### DIFF
--- a/api/TicketForm.js
+++ b/api/TicketForm.js
@@ -50,15 +50,26 @@ router.param(
   })
 )
 
+const getLocale = (locale) => {
+  if (!locale) {
+    return
+  }
+  locale = locale.toLowerCase()
+  if (locale === 'zh') {
+    return 'zh-cn'
+  }
+  if (LOCALES.includes(locale)) {
+    return locale
+  }
+  return
+}
+
 router.get(
   '/:id',
-  check('locale')
-    .isString()
-    .custom((value) => LOCALES.includes(value))
-    .optional(),
+
   catchError(async (req, res) => {
     const { form } = req
-    const { locale } = req.query
+    const locale = getLocale(req.query.locale)
     const fieldIds = form.get('fieldIds')
     const fieldDataList = await getFieldsDetail(fieldIds)
     const fields = []

--- a/modules/NewTicket.js
+++ b/modules/NewTicket.js
@@ -224,7 +224,7 @@ const useCustomForm = (formId) => {
     queryFn: () =>
       http.get(`/api/1/ticket-forms/${formId}`, {
         params: {
-          locale: i18next.language === 'zh' ? 'zh-cn' : i18next.language,
+          locale: i18next.language,
         },
       }),
     select: (data) => data.fields,

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -414,7 +414,7 @@ const TicketFormValues = memo(({ ticket, loadMoreOpsLogs }) => {
     queryFn: () =>
       http.get(`/api/1/ticket-forms/${formId}`, {
         params: {
-          locale: i18next.language === 'zh' ? 'zh-cn' : i18next.language,
+          locale: i18next.language,
         },
       }),
     select: (data) =>


### PR DESCRIPTION
统一后端处理 locale 这样其他客户端只需要传递 language 即可。

还有一种做法是客户端处理 服务端只接受合法的 locale