### PR TITLE
fix: mark reply as deleted by deletedAt

### DIFF
--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -370,7 +370,7 @@ router.get(
     const isCS = await isCSInTicket(req.user, req.ticket.get('author'))
 
     let query = new AV.Query('Reply').equalTo('ticket', req.ticket)
-    query.equalTo('active', true)
+    query.doesNotExist('deletedAt')
     if (created_at_gt) {
       query.greaterThan('createdAt', new Date(created_at_gt))
     }
@@ -439,8 +439,7 @@ router.delete(
     if (reply.get('author').id !== req.user.id) {
       throw new Error('This action must be done by the author')
     }
-    reply.set('active', false)
-    // reply.setACL({})
+    reply.set('deletedAt', new Date())
     await reply.save(null, { useMasterKey: true })
     // 同时修改 active 和 acl 会导致 liveQuery 无法收到更新
     reply.setACL({})

--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -148,14 +148,9 @@ function useReplies(ticketId) {
       .subscribe()
       .then((subscription) => {
         subscription.on('update', (reply) => {
-          const replyObj = reply.toJSON()
           // delete
-          if (!replyObj.active) {
-            setReplies((pre) =>
-              pre.filter((curr) => {
-                return curr.id !== replyObj.objectId
-              })
-            )
+          if (reply.data.deletedAt) {
+            deleteReply(reply.id)
           }
           // update
         })

--- a/resources/schema/Reply.json
+++ b/resources/schema/Reply.json
@@ -25,6 +25,13 @@
     "createdAt": {
       "type": "Date"
     },
+    "deletedAt": {
+      "type": "Date",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
     "author": {
       "type": "Pointer",
       "className": "_User"
@@ -45,14 +52,6 @@
       "required": false,
       "hidden": false,
       "read_only": false
-    },
-    "active": {
-      "type": "Boolean",
-      "v": 2,
-      "required": false,
-      "hidden": false,
-      "read_only": false,
-      "default": true
     }
   },
   "permissions": {


### PR DESCRIPTION
https://xindong.slack.com/archives/C01RY5JHB47/p1630553941034500

之前通过 Reply 表的 active 列判断回复是否被删除（值为 `false` 表示被删除）。获取回复时只获取 active = `true` 的行，但这样拿不到之前发布的回复（active 列为空）。

现改成通过 deletedAt 判断（和判断分类是否被删除的逻辑保持一致）。