### PR TITLE
feat(next): orm

### DIFF
--- a/next/api/src/model2/Category.ts
+++ b/next/api/src/model2/Category.ts
@@ -1,4 +1,4 @@
-import { Model, field, pointerArray, pointerId, pointTo } from '../orm';
+import { Model, field, pointerIds, pointerId, pointTo } from '../orm';
 import { FAQ } from './FAQ';
 import { TicketForm } from './TicketForm';
 
@@ -15,7 +15,7 @@ export class Category extends Model {
   @field()
   order?: number;
 
-  @pointerArray(FAQ)
+  @pointerIds(FAQ)
   FAQIds?: string[];
 
   @pointerId(TicketForm)

--- a/next/api/src/model2/Category.ts
+++ b/next/api/src/model2/Category.ts
@@ -1,0 +1,29 @@
+import { Model, field, pointerArray, pointerId, pointTo } from '../orm';
+import { FAQ } from './FAQ';
+import { TicketForm } from './TicketForm';
+
+export class Category extends Model {
+  @field()
+  name!: string;
+
+  @field()
+  description?: string;
+
+  @pointerId(Category)
+  parentId?: string;
+
+  @field()
+  order?: number;
+
+  @pointerArray(FAQ)
+  FAQIds?: string[];
+
+  @pointerId(TicketForm)
+  formId?: string;
+
+  @pointTo(TicketForm)
+  form?: TicketForm;
+
+  @field()
+  deletedAt?: Date;
+}

--- a/next/api/src/model2/FAQ.ts
+++ b/next/api/src/model2/FAQ.ts
@@ -1,0 +1,3 @@
+import { Model } from '../orm';
+
+export class FAQ extends Model {}

--- a/next/api/src/model2/File.ts
+++ b/next/api/src/model2/File.ts
@@ -1,0 +1,14 @@
+import { field, Model } from '../orm';
+
+export class File extends Model {
+  static readonly className = '_File';
+
+  @field()
+  name!: string;
+
+  @field('mime_type')
+  mime!: string;
+
+  @field()
+  url!: string;
+}

--- a/next/api/src/model2/Group.ts
+++ b/next/api/src/model2/Group.ts
@@ -1,0 +1,3 @@
+import { Model } from '../orm';
+
+export class Group extends Model {}

--- a/next/api/src/model2/Organization.ts
+++ b/next/api/src/model2/Organization.ts
@@ -1,0 +1,3 @@
+import { Model } from '../orm';
+
+export class Organization extends Model {}

--- a/next/api/src/model2/Ticket.ts
+++ b/next/api/src/model2/Ticket.ts
@@ -39,7 +39,7 @@ export class Ticket extends Model {
   categoryId!: string;
 
   @field({
-    encode: (c: Category) => ({ name: c.name, objectId: c.id }),
+    encode: (c: Category) => ({ objectId: c.id, name: c.name }),
     decode: false,
   })
   @belongsTo(Category)
@@ -75,3 +75,12 @@ export class Ticket extends Model {
   @field()
   evaluation?: Evaluation;
 }
+
+Ticket.beforeCreate(({ avObject }) => {
+  const authorId = avObject.get('author').id as string;
+  avObject.set('ACL', {
+    [authorId]: { read: true, write: true },
+    'role:customerService': { read: true, write: true },
+    'role:staff': { read: true },
+  });
+});

--- a/next/api/src/model2/Ticket.ts
+++ b/next/api/src/model2/Ticket.ts
@@ -5,7 +5,7 @@ import {
   belongsTo,
   field,
   pointerId,
-  pointerArray,
+  pointerIds,
   pointTo,
   hasManyThroughPointerArray,
 } from '../orm';
@@ -63,7 +63,7 @@ export class Ticket extends Model {
   @pointerId(Organization)
   organizationId?: string;
 
-  @pointerArray(File)
+  @pointerIds(File)
   fileIds?: string[];
 
   @hasManyThroughPointerArray(File)

--- a/next/api/src/model2/Ticket.ts
+++ b/next/api/src/model2/Ticket.ts
@@ -1,0 +1,77 @@
+import _ from 'lodash';
+
+import {
+  Model,
+  belongsTo,
+  field,
+  pointerId,
+  pointerArray,
+  pointTo,
+  hasManyThroughPointerArray,
+} from '../orm';
+import { Category } from './Category';
+import { File } from './File';
+import { Group } from './Group';
+import { Organization } from './Organization';
+import { User } from './User';
+
+export interface Evaluation {
+  star: number;
+  content: string;
+}
+
+export class Ticket extends Model {
+  @field()
+  nid!: number;
+
+  @field()
+  title!: string;
+
+  @field()
+  content!: string;
+
+  @field({
+    avObjectKey: 'category',
+    // 不 encode ，而是通过 category 设置分类。目的是同时设置分类名称，兼容旧的数据结构。
+    encode: false,
+    decode: (category) => category.objectId,
+  })
+  categoryId!: string;
+
+  @field({
+    encode: (c: Category) => ({ name: c.name, objectId: c.id }),
+    decode: false,
+  })
+  @belongsTo(Category)
+  category?: Category;
+
+  @pointerId(User)
+  authorId!: string;
+
+  @pointTo(User)
+  author?: User;
+
+  @pointerId(User)
+  assigneeId?: string;
+
+  @pointTo(User)
+  assignee?: User;
+
+  @pointerId(Group)
+  groupId?: string;
+
+  @pointerId(Organization)
+  organizationId?: string;
+
+  @pointerArray(File)
+  fileIds?: string[];
+
+  @hasManyThroughPointerArray(File)
+  files?: File[];
+
+  @field()
+  status!: number;
+
+  @field()
+  evaluation?: Evaluation;
+}

--- a/next/api/src/model2/TicketField.ts
+++ b/next/api/src/model2/TicketField.ts
@@ -1,0 +1,34 @@
+import { Model, field } from '../orm';
+
+export class TicketField extends Model {
+  @field()
+  title!: string;
+
+  @field()
+  type!: string;
+
+  @field()
+  defaultLocale!: string;
+
+  @field()
+  active!: boolean;
+
+  @field()
+  required!: boolean;
+}
+
+const title = new TicketField();
+title.id = 'title';
+title.type = 'text';
+title.defaultLocale = 'en';
+title.active = true;
+title.required = true;
+
+const descroption = new TicketField();
+descroption.id = 'description';
+descroption.type = 'multi-line';
+descroption.defaultLocale = 'en';
+descroption.active = true;
+descroption.required = true;
+
+export const presetTicketFields = [title, descroption];

--- a/next/api/src/model2/TicketField.ts
+++ b/next/api/src/model2/TicketField.ts
@@ -18,6 +18,7 @@ export class TicketField extends Model {
 }
 
 const title = new TicketField();
+// @ts-ignore
 title.id = 'title';
 title.type = 'text';
 title.defaultLocale = 'en';
@@ -25,6 +26,7 @@ title.active = true;
 title.required = true;
 
 const descroption = new TicketField();
+// @ts-ignore
 descroption.id = 'description';
 descroption.type = 'multi-line';
 descroption.defaultLocale = 'en';

--- a/next/api/src/model2/TicketField.ts
+++ b/next/api/src/model2/TicketField.ts
@@ -25,12 +25,12 @@ title.defaultLocale = 'en';
 title.active = true;
 title.required = true;
 
-const descroption = new TicketField();
+const descroiption = new TicketField();
 // @ts-ignore
-descroption.id = 'description';
-descroption.type = 'multi-line';
-descroption.defaultLocale = 'en';
-descroption.active = true;
-descroption.required = true;
+descroiption.id = 'description';
+descroiption.type = 'multi-line';
+descroiption.defaultLocale = 'en';
+descroiption.active = true;
+descroiption.required = true;
 
-export const presetTicketFields = [title, descroption];
+export const presetTicketFields = [title, descroiption];

--- a/next/api/src/model2/TicketForm.ts
+++ b/next/api/src/model2/TicketForm.ts
@@ -1,0 +1,13 @@
+import { Model, field, hasManyThroughIdArray } from '../orm';
+import { TicketField } from './TicketField';
+
+export class TicketForm extends Model {
+  @field()
+  title!: string;
+
+  @field()
+  fieldIds!: string[];
+
+  @hasManyThroughIdArray(TicketField)
+  fields!: TicketField[];
+}

--- a/next/api/src/model2/User.ts
+++ b/next/api/src/model2/User.ts
@@ -1,0 +1,40 @@
+import AV from 'leancloud-storage';
+
+import { Model, field } from '../orm';
+
+export class User extends Model {
+  static readonly className = '_User';
+
+  static readonly avObjectConstructor = AV.User;
+
+  @field()
+  username!: string;
+
+  @field()
+  name?: string;
+
+  @field()
+  email?: string;
+
+  @field({
+    encode: false,
+    decode: false,
+    onEncode: (user: User, avUser) => {
+      if (user.sessionToken) {
+        (avUser as any)._sessionToken = user.sessionToken;
+      }
+    },
+    onDecode: (user: User, avUser) => {
+      const sessionToken = (avUser as AV.User).getSessionToken();
+      if (sessionToken) {
+        user.sessionToken = sessionToken;
+      }
+    },
+  })
+  sessionToken?: string;
+
+  static async findBySessionToken(sessionToken: string): Promise<User> {
+    const avUser = await AV.User.become(sessionToken);
+    return this.fromAVObject(avUser);
+  }
+}

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -1,0 +1,162 @@
+import AV from 'leancloud-storage';
+import _ from 'lodash';
+
+import { Field, Model } from './model';
+import { RelatedIdGetter, RelatedIdsGetter } from './relation';
+
+export type DefineFieldOptions = Partial<Field> & Pick<Field, 'localKey'>;
+
+export function defineField(modelClass: typeof Model, options: DefineFieldOptions) {
+  const {
+    localKey,
+    avObjectKey = localKey,
+    encode = _.identity,
+    decode = _.identity,
+    onEncode,
+    onDecode,
+  } = options;
+
+  modelClass.setField(localKey, {
+    localKey,
+    avObjectKey,
+    encode,
+    decode,
+    onEncode,
+    onDecode,
+  });
+}
+
+export function field(config?: string | Partial<Omit<DefineFieldOptions, 'localKey'>>) {
+  return (target: Model, localKey: string) => {
+    const modelClass = target.constructor as typeof Model;
+    if (typeof config === 'string') {
+      defineField(modelClass, { localKey, avObjectKey: config });
+    } else {
+      defineField(modelClass, { ...config, localKey });
+    }
+  };
+}
+
+export function pointerId(pointerClass: typeof Model, avObjectKey?: string) {
+  return (target: Model, localKey: string) => {
+    const modelClass = target.constructor as typeof Model;
+    avObjectKey ??= localKey.endsWith('Id') ? localKey.slice(0, -2) : localKey;
+    const className = pointerClass.getClassName();
+    defineField(modelClass, {
+      localKey,
+      avObjectKey,
+      encode: (id: string) => AV.Object.createWithoutData(className, id),
+      decode: (obj: AV.Object) => obj.id,
+    });
+  };
+}
+
+export function pointerArray(pointerClass: typeof Model, avObjectKey?: string) {
+  return (target: Model, localKey: string) => {
+    const modelClass = target.constructor as typeof Model;
+    avObjectKey ??= localKey.endsWith('Ids') ? localKey.slice(0, -3) + 's' : localKey;
+    const className = pointerClass.getClassName();
+    defineField(modelClass, {
+      localKey,
+      avObjectKey,
+      encode: (ids: string[]) => ids.map((id) => AV.Object.createWithoutData(className, id)),
+      decode: (objs: AV.Object[]) => objs.map((o) => o.id),
+    });
+  };
+}
+
+export function belongsTo(
+  relatedModel: typeof Model,
+  getRelatedId?: string | RelatedIdGetter<any>
+) {
+  return (target: Model, name: string) => {
+    if (getRelatedId === undefined) {
+      getRelatedId = name + 'Id';
+    }
+    if (typeof getRelatedId === 'string') {
+      const idKey = getRelatedId;
+      getRelatedId = (o) => o[idKey];
+    }
+    const model = target.constructor as typeof Model;
+    model.setRelation(name, {
+      name,
+      type: 'belongsTo',
+      model,
+      relatedModel,
+      getRelatedId,
+    });
+  };
+}
+
+export function pointTo(
+  relatedModel: typeof Model,
+  includeKey?: string,
+  getRelatedId?: string | RelatedIdGetter<any>
+) {
+  return (target: Model, name: string) => {
+    if (getRelatedId === undefined) {
+      getRelatedId = name + 'Id';
+    }
+    if (typeof getRelatedId === 'string') {
+      const key = getRelatedId;
+      getRelatedId = (o) => o[key];
+    }
+    const model = target.constructor as typeof Model;
+    model.setRelation(name, {
+      name,
+      type: 'pointTo',
+      model,
+      relatedModel,
+      getRelatedId,
+      includeKey: includeKey ?? name,
+    });
+  };
+}
+
+export function hasManyThroughIdArray(
+  relatedModel: typeof Model,
+  getRelatedIds?: string | RelatedIdsGetter<any>
+) {
+  return (target: Model, name: string) => {
+    if (getRelatedIds === undefined) {
+      getRelatedIds = (name.endsWith('s') ? name.slice(0, -1) : name) + 'Ids';
+    }
+    if (typeof getRelatedIds === 'string') {
+      const key = getRelatedIds;
+      getRelatedIds = (o) => o[key];
+    }
+    const model = target.constructor as typeof Model;
+    model.setRelation(name, {
+      name,
+      type: 'hasManyThroughIdArray',
+      model,
+      relatedModel,
+      getRelatedIds,
+    });
+  };
+}
+
+export function hasManyThroughPointerArray(
+  relatedModel: typeof Model,
+  includeKey?: string,
+  getRelatedIds?: string | RelatedIdsGetter<any>
+) {
+  return (target: Model, name: string) => {
+    if (getRelatedIds === undefined) {
+      getRelatedIds = (name.endsWith('s') ? name.slice(0, -1) : name) + 'Ids';
+    }
+    if (typeof getRelatedIds === 'string') {
+      const key = getRelatedIds;
+      getRelatedIds = (o) => o[key];
+    }
+    const model = target.constructor as typeof Model;
+    model.setRelation(name, {
+      name,
+      type: 'hasManyThroughPointerArray',
+      model,
+      relatedModel,
+      getRelatedIds,
+      includeKey: includeKey ?? name,
+    });
+  };
+}

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -2,7 +2,7 @@ import AV from 'leancloud-storage';
 import _ from 'lodash';
 
 import { Field, Model } from './model';
-import { RelatedIdGetter, RelatedIdsGetter } from './relation';
+import { BelongsTo, HasManyThroughIdArray, HasManyThroughPointerArray, PointTo } from './relation';
 
 export type DefineFieldOptions = Partial<Field> & Pick<Field, 'localKey'>;
 
@@ -67,7 +67,7 @@ export function pointerArray(pointerClass: typeof Model, avObjectKey?: string) {
 
 export function belongsTo(
   relatedModel: typeof Model,
-  getRelatedId?: string | RelatedIdGetter<any>
+  getRelatedId?: string | BelongsTo['getRelatedId']
 ) {
   return (target: Model, name: string) => {
     if (getRelatedId === undefined) {
@@ -91,7 +91,7 @@ export function belongsTo(
 export function pointTo(
   relatedModel: typeof Model,
   includeKey?: string,
-  getRelatedId?: string | RelatedIdGetter<any>
+  getRelatedId?: string | PointTo['getRelatedId']
 ) {
   return (target: Model, name: string) => {
     if (getRelatedId === undefined) {
@@ -115,7 +115,7 @@ export function pointTo(
 
 export function hasManyThroughIdArray(
   relatedModel: typeof Model,
-  getRelatedIds?: string | RelatedIdsGetter<any>
+  getRelatedIds?: string | HasManyThroughIdArray['getRelatedIds']
 ) {
   return (target: Model, name: string) => {
     if (getRelatedIds === undefined) {
@@ -139,7 +139,7 @@ export function hasManyThroughIdArray(
 export function hasManyThroughPointerArray(
   relatedModel: typeof Model,
   includeKey?: string,
-  getRelatedIds?: string | RelatedIdsGetter<any>
+  getRelatedIds?: string | HasManyThroughPointerArray['getRelatedIds']
 ) {
   return (target: Model, name: string) => {
     if (getRelatedIds === undefined) {

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -51,7 +51,7 @@ export function pointerId(pointerClass: typeof Model, avObjectKey?: string) {
   };
 }
 
-export function pointerArray(pointerClass: typeof Model, avObjectKey?: string) {
+export function pointerIds(pointerClass: typeof Model, avObjectKey?: string) {
   return (target: Model, localKey: string) => {
     const modelClass = target.constructor as typeof Model;
     avObjectKey ??= localKey.endsWith('Ids') ? localKey.slice(0, -3) + 's' : localKey;

--- a/next/api/src/orm/index.ts
+++ b/next/api/src/orm/index.ts
@@ -1,0 +1,2 @@
+export * from './model';
+export * from './helpers';

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -1,0 +1,170 @@
+import AV from 'leancloud-storage';
+import _ from 'lodash';
+
+import { AuthOptions, Query } from './query';
+import { KeysOfType } from './utils';
+import { Relation } from './relation';
+import { preloaderFactory } from './preloader';
+
+type RelationKeys<T> = Extract<KeysOfType<T, Model | Model[] | undefined>, string>;
+
+type CreateData<T> = Partial<Omit<T, 'id' | 'createdAt' | 'updatedAt' | KeysOfType<T, Function>>>;
+
+export type FieldEncoder = (data: any) => any;
+
+export type FieldDecoder = (data: any) => any;
+
+export type OnDecodeField = (instance: any, object: AV.Object) => void;
+
+export type OnEncodeField = (instance: any, object: AV.Object) => void;
+
+export interface Field {
+  localKey: string;
+  avObjectKey: string;
+  encode: FieldEncoder | false;
+  decode: FieldDecoder | false;
+  onEncode?: OnEncodeField;
+  onDecode?: OnDecodeField;
+}
+
+export abstract class Model {
+  static readonly className: string;
+
+  static readonly avObjectConstructor = AV.Object;
+
+  private static fields: Record<string, Field>;
+
+  private static relations: Record<string, Relation<any, any>>;
+
+  id!: string;
+
+  createdAt!: Date;
+
+  updatedAt!: Date;
+
+  static getClassName(): string {
+    return this.className ?? this.name;
+  }
+
+  static setField(name: string, field: Field) {
+    this.fields ??= {};
+    this.fields[name] = field;
+  }
+
+  static setRelation(name: string, relation: Relation<any, any>) {
+    this.relations ??= {};
+    this.relations[name] = relation;
+  }
+
+  static getRelation(name: string): Relation | undefined {
+    return this.relations?.[name];
+  }
+
+  static fromAVObject<M extends typeof Model>(this: M, object: AV.Object): InstanceType<M> {
+    // @ts-ignore
+    const instance = new this();
+    instance.id = object.id;
+    if (this.fields) {
+      Object.entries(this.fields).forEach(([key, { avObjectKey, decode, onDecode }]) => {
+        if (decode) {
+          const value = object.get(avObjectKey);
+          if (value !== undefined) {
+            const decodedValue = decode(value);
+            if (decodedValue !== undefined) {
+              instance[key] = decodedValue;
+            }
+          }
+        }
+        onDecode?.(instance, object);
+      });
+    }
+    instance.createdAt = object.createdAt;
+    instance.updatedAt = object.updatedAt ?? object.createdAt;
+    return instance;
+  }
+
+  static query<M extends typeof Model>(this: M): Query<M> {
+    return new Query(this);
+  }
+
+  static queryBuilder<M extends typeof Model>(this: M): Query<M> {
+    const query = new Query(this);
+    query.builderMode = true;
+    return query;
+  }
+
+  static async find<M extends typeof Model>(
+    this: M,
+    id: string,
+    options?: AuthOptions
+  ): Promise<InstanceType<M>> {
+    const query = new AV.Query<AV.Object>(this.getClassName());
+    const object = await query.get(id, options);
+    return this.fromAVObject(object);
+  }
+
+  get className() {
+    return (this.constructor as typeof Model).getClassName();
+  }
+
+  async load<M extends Model, K extends RelationKeys<M>>(
+    this: M,
+    field: K,
+    options?: AuthOptions
+  ): Promise<M[K]> {
+    if (this[field as keyof M] !== undefined) {
+      return this[field as keyof M] as M[K];
+    }
+    const preloader = preloaderFactory(this.constructor as any, field);
+    await preloader.load([this], options);
+    return this[field as keyof M] as M[K];
+  }
+
+  static ptr(objectId: string) {
+    return {
+      __type: 'Pointer',
+      className: this.getClassName(),
+      objectId,
+    };
+  }
+
+  static async create<T extends typeof Model>(
+    this: T,
+    data: CreateData<InstanceType<T>>
+  ): Promise<any> {
+    throw new Error('Not implemented');
+    return {} as any;
+  }
+
+  toJSON(): any {
+    return {
+      id: this.id,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAt.toISOString(),
+    };
+  }
+
+  toAVObject(): AV.Object {
+    const clazz = this.constructor as typeof Model;
+    const className = clazz.getClassName();
+    const AVObject = clazz.avObjectConstructor;
+
+    const object = this.id
+      ? AVObject.createWithoutData(className, this.id)
+      : new AVObject(className);
+
+    Object.values(clazz.fields).forEach(({ localKey, avObjectKey, encode, onEncode }) => {
+      if (encode) {
+        const value = this[localKey as keyof this];
+        if (value !== undefined) {
+          const encodedValue = encode(value);
+          if (encodedValue !== undefined) {
+            object.set(avObjectKey, encodedValue);
+          }
+        }
+      }
+      onEncode?.(this, object);
+    });
+    return object;
+  }
+}

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -34,7 +34,7 @@ export abstract class Model {
 
   private static fields: Record<string, Field>;
 
-  private static relations: Record<string, Relation<any, any>>;
+  private static relations: Record<string, Relation>;
 
   id!: string;
 
@@ -51,7 +51,7 @@ export abstract class Model {
     this.fields[name] = field;
   }
 
-  static setRelation(name: string, relation: Relation<any, any>) {
+  static setRelation(name: string, relation: Relation) {
     this.relations ??= {};
     this.relations[name] = relation;
   }

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -177,15 +177,17 @@ export abstract class Model {
     const avObject = instance.toAVObject();
 
     if (this.beforeCreateHooks) {
-      await Promise.all(this.beforeCreateHooks.map((hook) => hook({ avObject })));
+      const ctx = { avObject };
+      await Promise.all(this.beforeCreateHooks.map((hook) => hook(ctx)));
     }
 
     await saveAVObject(avObject, { ...options, fetchWhenSave: true });
     instance = this.fromAVObject(avObject);
 
     if (this.afterCreateHooks) {
+      const ctx = { instance };
       try {
-        this.afterCreateHooks.forEach((hook) => hook({ instance }));
+        this.afterCreateHooks.forEach((hook) => hook(ctx));
       } catch {} // ignore error
     }
 

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -127,7 +127,15 @@ export abstract class Model {
     return query;
   }
 
-  static async find<M extends typeof Model>(
+  static find<M extends typeof Model>(
+    this: M,
+    id: string,
+    options?: AuthOptions
+  ): Promise<InstanceType<M> | undefined> {
+    return this.query().where('objectId', '==', id).first(options);
+  }
+
+  static async findOrFail<M extends typeof Model>(
     this: M,
     id: string,
     options?: AuthOptions

--- a/next/api/src/orm/preloader.ts
+++ b/next/api/src/orm/preloader.ts
@@ -1,0 +1,203 @@
+import AV from 'leancloud-storage';
+import _ from 'lodash';
+
+import { Model } from './model';
+import { BelongsTo, HasManyThroughIdArray, HasManyThroughPointerArray, PointTo } from './relation';
+import { AuthOptions, AVQuery } from './query';
+import { KeysOfType } from './utils';
+
+export type PreloadKeys<M extends typeof Model> = Extract<
+  KeysOfType<InstanceType<M>, Model | Model[] | undefined>,
+  string
+>;
+
+export type PreloadData<
+  M extends typeof Model,
+  K extends PreloadKeys<M> = PreloadKeys<M>
+> = NonNullable<InstanceType<M>[K]>[];
+
+export interface BeforeQueryConntext {
+  avQuery: AVQuery;
+}
+
+export interface AfterQueryContext {
+  objects: AV.Object[];
+}
+
+export interface Preloader<M extends typeof Model, K extends PreloadKeys<M> = PreloadKeys<M>> {
+  data?: PreloadData<M, K>;
+  beforeQuery?: (ctx: BeforeQueryConntext) => void | Promise<void>;
+  afterQuery?: (ctx: AfterQueryContext) => void | Promise<void>;
+  load: (items: InstanceType<M>[], options?: AuthOptions) => Promise<void>;
+}
+
+class BelongsToPreloader<
+  M extends typeof Model,
+  R extends typeof Model,
+  K extends PreloadKeys<M> = PreloadKeys<M>
+> {
+  data?: PreloadData<M, K>;
+
+  constructor(private relation: BelongsTo<M, R>) {}
+
+  async load(items: InstanceType<M>[], options?: AuthOptions) {
+    if (items.length === 0) {
+      return;
+    }
+
+    const { name, relatedModel, getRelatedId } = this.relation;
+
+    let relatedItems: InstanceType<R>[];
+    if (this.data) {
+      relatedItems = this.data;
+    } else {
+      const ids = _.uniq(items.map(getRelatedId).filter(_.isString));
+      if (ids.length === 0) {
+        return;
+      }
+      const query = relatedModel.query().where('objectId', 'in', ids);
+      relatedItems = await query.find(options);
+    }
+
+    const relatedItemMap = _.keyBy(relatedItems, (t) => t.id);
+
+    items.forEach((item) => {
+      const relatedId = getRelatedId(item);
+      if (relatedId) {
+        const relatedItem = relatedItemMap[relatedId];
+        if (relatedItem) {
+          item[name as keyof typeof item] = relatedItem as any;
+        }
+      }
+    });
+  }
+}
+
+class PointToPreloader<M extends typeof Model, R extends typeof Model> {
+  private objects?: AV.Object[];
+
+  constructor(private relation: PointTo<M, R>) {}
+
+  beforeQuery({ avQuery }: BeforeQueryConntext) {
+    avQuery.include(this.relation.includeKey);
+  }
+
+  afterQuery({ objects }: AfterQueryContext) {
+    this.objects = objects;
+  }
+
+  async load(items: InstanceType<M>[], options?: AuthOptions) {
+    if (this.objects) {
+      const { name, relatedModel, includeKey } = this.relation;
+      const objectMap = _.keyBy(this.objects, (o) => o.id!);
+      items.forEach((item) => {
+        const object = objectMap[item.id];
+        const subObject = object.get(includeKey) as AV.Object | undefined;
+        if (subObject) {
+          const data = relatedModel.fromAVObject(subObject);
+          item[name as keyof typeof item] = data as any;
+        }
+      });
+    } else {
+      // 退化成 BelongsToPreloader
+      const preloader = new BelongsToPreloader({ ...this.relation, type: 'belongsTo' });
+      await preloader.load(items, options);
+    }
+  }
+}
+
+class HasManyThrouchIdArrayPreloader<
+  M extends typeof Model,
+  R extends typeof Model,
+  K extends PreloadKeys<M> = PreloadKeys<M>
+> {
+  data?: PreloadData<M, K>;
+
+  constructor(private relation: HasManyThroughIdArray<M, R>) {}
+
+  async load(items: InstanceType<M>[], options?: AuthOptions) {
+    if (items.length === 0) {
+      return;
+    }
+
+    const { name, relatedModel, getRelatedIds } = this.relation;
+
+    let relatedItems: InstanceType<R>[];
+    if (this.data) {
+      relatedItems = this.data;
+    } else {
+      const ids = _.uniq(items.map(getRelatedIds).flat().filter(_.isString));
+      if (ids.length === 0) {
+        return;
+      }
+      const query = relatedModel.query().where('objectId', 'in', ids);
+      relatedItems = await query.find(options);
+    }
+
+    const relatedItemMap = _.keyBy(relatedItems, (t) => t.id);
+
+    items.forEach((item) => {
+      const relatedIds = getRelatedIds(item);
+      if (relatedIds) {
+        const relatedItems = relatedIds.map((id) => relatedItemMap[id]);
+        item[name as keyof typeof item] = _.compact(relatedItems) as any;
+      }
+    });
+  }
+}
+
+class HasManyThrouchPointerArrayPreloader<M extends typeof Model, R extends typeof Model> {
+  private objects?: AV.Object[];
+
+  constructor(private relation: HasManyThroughPointerArray<M, R>) {}
+
+  beforeQuery({ avQuery }: BeforeQueryConntext) {
+    avQuery.include(this.relation.includeKey);
+  }
+
+  afterQuery({ objects }: AfterQueryContext) {
+    this.objects = objects;
+  }
+
+  async load(items: InstanceType<M>[], options?: AuthOptions) {
+    if (this.objects) {
+      const { name, relatedModel, includeKey } = this.relation;
+      const objectMap = _.keyBy(this.objects, (o) => o.id!);
+      items.forEach((item) => {
+        const object = objectMap[item.id];
+        const subObjects = object.get(includeKey) as AV.Object[] | undefined;
+        if (subObjects) {
+          const data = subObjects.map((o) => relatedModel.fromAVObject(o));
+          item[name as keyof typeof item] = data as any;
+        }
+      });
+    } else {
+      // 退化成 HasManyThrouchIdArrayPreloader
+      const preloader = new HasManyThrouchIdArrayPreloader({
+        ...this.relation,
+        type: 'hasManyThroughIdArray',
+      });
+      await preloader.load(items, options);
+    }
+  }
+}
+
+export function preloaderFactory<M extends typeof Model>(
+  model: M,
+  key: PreloadKeys<M>
+): Preloader<M> {
+  const relation = model.getRelation(key);
+  if (!relation) {
+    throw new Error(`Cannot create preloader, relation ${key} is not exists`);
+  }
+  switch (relation.type) {
+    case 'belongsTo':
+      return new BelongsToPreloader(relation);
+    case 'pointTo':
+      return new PointToPreloader(relation);
+    case 'hasManyThroughIdArray':
+      return new HasManyThrouchIdArrayPreloader(relation);
+    case 'hasManyThroughPointerArray':
+      return new HasManyThrouchPointerArrayPreloader(relation);
+  }
+}

--- a/next/api/src/orm/query.ts
+++ b/next/api/src/orm/query.ts
@@ -1,0 +1,231 @@
+import AV from 'leancloud-storage';
+import _ from 'lodash';
+
+import { Model } from './model';
+import { PreloadData, Preloader, preloaderFactory, PreloadKeys } from './preloader';
+
+export interface AuthOptions {
+  sessionToken?: string;
+  useMasterKey?: boolean;
+}
+
+export type AVQuery = AV.Query<AV.Object>;
+
+const staticQuery = new AV.Query<AV.Object>('_');
+
+function merge(where: any, modifier: (query: AVQuery) => void) {
+  (staticQuery as any)._where = where;
+  modifier(staticQuery);
+  (staticQuery as any)._where = {};
+}
+
+function and(where1: any, where2: any): any {
+  const empty1 = _.isEmpty(where1);
+  const empty2 = _.isEmpty(where2);
+  if (empty1 && empty2) {
+    return {};
+  } else if (empty1) {
+    return { ...where2 };
+  } else if (empty2) {
+    return { ...where1 };
+  } else {
+    return { $and: [where1, where2] };
+  }
+}
+
+function or(where1: any, where2: any): any {
+  const where = and(where1, where2);
+  if (where.$and) {
+    where.$or = where.$and;
+    delete where.$and;
+  }
+  return where;
+}
+
+const queryModifiers = {
+  '==': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.equalTo(key, value));
+  },
+  '!=': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.notEqualTo(key, value));
+  },
+  '>': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.greaterThan(key, value));
+  },
+  '>=': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.greaterThanOrEqualTo(key, value));
+  },
+  '<': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.lessThan(key, value));
+  },
+  '<=': (where: any, key: string, value: any) => {
+    merge(where, (q) => q.lessThanOrEqualTo(key, value));
+  },
+  in: (where: any, key: string, value: any[]) => {
+    if (value.length === 1) {
+      queryModifiers['=='](where, key, value[0]);
+    } else {
+      merge(where, (q) => q.containedIn(key, value));
+    }
+  },
+  exists: (where: any, key: string) => {
+    merge(where, (q) => q.exists(key));
+  },
+  'not-exists': (where: any, key: string) => {
+    merge(where, (q) => q.doesNotExist(key));
+  },
+};
+
+export type QueryCommand = keyof typeof queryModifiers;
+
+type ValuesType<T> = T extends (where: any, key: string, ...values: infer V) => void ? V : never;
+
+export type QueryBunch<M extends typeof Model> = (query: Query<M>) => Query<M>;
+
+export interface PreloadOptions<M extends typeof Model, K extends PreloadKeys<M> = PreloadKeys<M>> {
+  data?: PreloadData<M, K>;
+  authOptions?: AuthOptions;
+}
+
+interface QueryPreloader<M extends typeof Model> {
+  preloader: Preloader<M>;
+  authOptions?: AuthOptions;
+}
+
+export class Query<M extends typeof Model> {
+  builderMode = false;
+
+  private condition: any = {};
+  private skipCount?: number;
+  private limitCount?: number;
+  private preloaders: Record<string, QueryPreloader<M>> = {};
+
+  constructor(protected model: M) {}
+
+  clone(): Query<M> {
+    if (this.builderMode) {
+      return this;
+    }
+
+    const query = new Query(this.model);
+    query.condition = { ...this.condition };
+    query.skipCount = this.skipCount;
+    query.limitCount = this.limitCount;
+    query.preloaders = { ...this.preloaders };
+    return query;
+  }
+
+  setRawCondition(condition: any): Query<M> {
+    const query = this.clone();
+    query.condition = condition;
+    return query;
+  }
+
+  where<Cmd extends QueryCommand>(
+    key: string,
+    command: Cmd,
+    ...values: ValuesType<typeof queryModifiers[Cmd]>
+  ): Query<M>;
+  where(bunch: QueryBunch<M>): Query<M>;
+  where(key: any, command?: any, ...values: any[]) {
+    const query = this.clone();
+    if (typeof key === 'string') {
+      const modifier = queryModifiers[command as QueryCommand];
+      modifier(query.condition, key, values[0]);
+    } else {
+      const newQuery = key(new Query(this.model)) as Query<M>;
+      query.condition = and(query.condition, newQuery.condition);
+    }
+    return query;
+  }
+
+  orWhere<Cmd extends QueryCommand>(
+    key: string,
+    command: Cmd,
+    ...values: ValuesType<typeof queryModifiers[Cmd]>
+  ): Query<M>;
+  orWhere(bunch: QueryBunch<M>): Query<M>;
+  orWhere(key: any, command?: any, ...values: any[]) {
+    const query = this.clone();
+    if (typeof key === 'string') {
+      const modifier = queryModifiers[command as QueryCommand];
+      const newCondition = {};
+      modifier(newCondition, key, values[0]);
+      query.condition = or(query.condition, newCondition);
+    } else {
+      const newQuery = key(new Query(this.model)) as Query<M>;
+      query.condition = or(query.condition, newQuery.condition);
+    }
+    return query;
+  }
+
+  skip(count: number): Query<M> {
+    const query = this.clone();
+    query.skipCount = count;
+    return query;
+  }
+
+  limit(count: number): Query<M> {
+    const query = this.clone();
+    query.limitCount = count;
+    return query;
+  }
+
+  preload<K extends PreloadKeys<M>>(key: K, options?: PreloadOptions<M, K>): Query<M> {
+    const query = this.clone();
+
+    const preloader = preloaderFactory(this.model, key);
+    if (options?.data) {
+      preloader.data = options.data;
+    }
+    query.preloaders[key] = {
+      preloader,
+      authOptions: options?.authOptions,
+    };
+
+    return query;
+  }
+
+  private buildAVQuery(): AVQuery {
+    const avQuery = new AV.Query<AV.Object>(this.model.getClassName());
+    (avQuery as any)._where = this.condition;
+    if (this.skipCount !== undefined) {
+      avQuery.skip(this.skipCount);
+    }
+    if (this.limitCount !== undefined) {
+      avQuery.limit(this.limitCount);
+    }
+    return avQuery;
+  }
+
+  async find(options?: AuthOptions): Promise<InstanceType<M>[]> {
+    const avQuery = this.buildAVQuery();
+    const preloaders = Object.values(this.preloaders);
+
+    await Promise.all(preloaders.map(({ preloader }) => preloader.beforeQuery?.({ avQuery })));
+    const objects = await avQuery.find(options);
+    await Promise.all(preloaders.map(({ preloader }) => preloader.afterQuery?.({ objects })));
+
+    const items = objects.map((o) => this.model.fromAVObject(o));
+    await Promise.all(
+      preloaders.map(({ preloader, authOptions }) => preloader.load(items, authOptions ?? options))
+    );
+
+    return items;
+  }
+
+  async first(options?: AuthOptions): Promise<InstanceType<M> | undefined> {
+    const limitCount = this.limitCount;
+    this.limitCount = 1;
+    try {
+      const items = await this.find(options);
+      return items[0];
+    } finally {
+      this.limitCount = limitCount;
+    }
+  }
+
+  count(options?: AuthOptions): Promise<number> {
+    return this.buildAVQuery().count(options);
+  }
+}

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -1,47 +1,36 @@
 import { Model } from './model';
 
-type DataGetter<M extends Model, T> = (instance: M) => T;
+import { KeysOfType } from './utils';
 
-export type RelatedIdGetter<M extends Model> = DataGetter<M, string | undefined>;
+export type RelationName<M extends typeof Model> = Extract<
+  KeysOfType<InstanceType<M>, Model | Model[] | undefined>,
+  string
+>;
 
-export type RelatedIdsGetter<M extends Model> = DataGetter<M, string[] | undefined>;
-
-export interface BelongsTo<
-  M extends typeof Model = typeof Model,
-  R extends typeof Model = typeof Model
-> {
+export interface BelongsTo {
   name: string;
   type: 'belongsTo';
-  model: M;
-  relatedModel: R;
-  getRelatedId: RelatedIdGetter<InstanceType<M>>;
+  model: typeof Model;
+  relatedModel: typeof Model;
+  getRelatedId: (instance: any) => string | undefined;
 }
 
-export interface PointTo<M extends typeof Model, R extends typeof Model>
-  extends Omit<BelongsTo<M, R>, 'type'> {
+export interface PointTo extends Omit<BelongsTo, 'type'> {
   type: 'pointTo';
   includeKey: string;
 }
 
-export interface HasManyThroughIdArray<M extends typeof Model, R extends typeof Model> {
+export interface HasManyThroughIdArray {
   name: string;
   type: 'hasManyThroughIdArray';
-  model: M;
-  relatedModel: R;
-  getRelatedIds: RelatedIdsGetter<InstanceType<M>>;
+  model: typeof Model;
+  relatedModel: typeof Model;
+  getRelatedIds: (instance: any) => string[] | undefined;
 }
 
-export interface HasManyThroughPointerArray<M extends typeof Model, R extends typeof Model>
-  extends Omit<HasManyThroughIdArray<M, R>, 'type'> {
+export interface HasManyThroughPointerArray extends Omit<HasManyThroughIdArray, 'type'> {
   type: 'hasManyThroughPointerArray';
   includeKey: string;
 }
 
-export type Relation<
-  M extends typeof Model = typeof Model,
-  R extends typeof Model = typeof Model
-> =
-  | BelongsTo<M, R>
-  | PointTo<M, R>
-  | HasManyThroughIdArray<M, R>
-  | HasManyThroughPointerArray<M, R>;
+export type Relation = BelongsTo | PointTo | HasManyThroughIdArray | HasManyThroughPointerArray;

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -1,0 +1,47 @@
+import { Model } from './model';
+
+type DataGetter<M extends Model, T> = (instance: M) => T;
+
+export type RelatedIdGetter<M extends Model> = DataGetter<M, string | undefined>;
+
+export type RelatedIdsGetter<M extends Model> = DataGetter<M, string[] | undefined>;
+
+export interface BelongsTo<
+  M extends typeof Model = typeof Model,
+  R extends typeof Model = typeof Model
+> {
+  name: string;
+  type: 'belongsTo';
+  model: M;
+  relatedModel: R;
+  getRelatedId: RelatedIdGetter<InstanceType<M>>;
+}
+
+export interface PointTo<M extends typeof Model, R extends typeof Model>
+  extends Omit<BelongsTo<M, R>, 'type'> {
+  type: 'pointTo';
+  includeKey: string;
+}
+
+export interface HasManyThroughIdArray<M extends typeof Model, R extends typeof Model> {
+  name: string;
+  type: 'hasManyThroughIdArray';
+  model: M;
+  relatedModel: R;
+  getRelatedIds: RelatedIdsGetter<InstanceType<M>>;
+}
+
+export interface HasManyThroughPointerArray<M extends typeof Model, R extends typeof Model>
+  extends Omit<HasManyThroughIdArray<M, R>, 'type'> {
+  type: 'hasManyThroughPointerArray';
+  includeKey: string;
+}
+
+export type Relation<
+  M extends typeof Model = typeof Model,
+  R extends typeof Model = typeof Model
+> =
+  | BelongsTo<M, R>
+  | PointTo<M, R>
+  | HasManyThroughIdArray<M, R>
+  | HasManyThroughPointerArray<M, R>;

--- a/next/api/src/orm/utils.ts
+++ b/next/api/src/orm/utils.ts
@@ -1,1 +1,3 @@
 export type KeysOfType<O, T> = { [K in keyof O]: O[K] extends T ? K : never }[keyof O];
+
+export type Flat<T> = T extends (infer P)[] ? P : T;

--- a/next/api/src/orm/utils.ts
+++ b/next/api/src/orm/utils.ts
@@ -1,0 +1,1 @@
+export type KeysOfType<O, T> = { [K in keyof O]: O[K] extends T ? K : never }[keyof O];

--- a/next/api/tsconfig.json
+++ b/next/api/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "esModuleInterop": true,
+    "experimentalDecorators": true,
     "moduleResolution": "Node",
     "skipLibCheck": true
   },


### PR DESCRIPTION
为了少写一些查询、组合数据的逻辑，基于 leancloud-storage 实现了一个 ORM 。
目前还差中间表和 AV.Relation 的关系没有实现（反向关联也都没有实现，因为我们没有用到，等用到的时候再说吧 🏃 💨 ）。先提出来让各位 review 一下，收集一些意见。

### 介绍一下用法

在 `/next/api/src/model2` 里添加了一些基于这个 ORM 定义的数据模型，可以先看一下这些文件。

为模型字段设置好关系类型后，就可以在查询数据时把相关联的数据加载进来。比如 Ticket 模型中有如下字段：
```ts
export class Ticket extends Model {
  @field({
    avObjectKey: 'category',
    encode: false,
    decode: (category) => category.objectId,
  })
  categoryId!: string;

  @field({
    encode: (c: Category) => ({ name: c.name, objectId: c.id }),
    decode: false,
  })
  @belongsTo(Category)
  category?: Category;

  @pointerId(User)
  authorId!: string;

  @pointTo(User)
  author?: User;

  @pointerIds(File)
  fileIds?: string[];

  @hasManyThroughPointerArray(File)
  files?: File[];
}

```

查询 ticket 时可以将 category 、author 和 files 一并查询出来，且只发送 2 次请求：

```ts
const query = Ticket.query()
  .preload('category') // category 通过 id 关联，在查询完 ticket 后会使用 ticket.categoryId 再查一次 Category 表
  .preload('author') // author 通过 Pointer 关联，会在查询 ticket 的时候 include 进来
  .preload('files'); // files 通过 Pointer 数组关联，也会 include 进来
```

也可以通过 Ticket 实例上的 load 方法惰性加载关联的数据：
```ts
const ticket = await Ticket.find('xxx');
const author = await ticket.load('author');
const files = await ticket.load('files');
```

API 命名和风格参考了 Laravel 和 Adonis 自带的 ORM 。