### PR TITLE
refactor(next/api): 使用 getter 获取关联的 Model

### DIFF
--- a/next/api/src/model2/Category.ts
+++ b/next/api/src/model2/Category.ts
@@ -9,19 +9,19 @@ export class Category extends Model {
   @field()
   description?: string;
 
-  @pointerId(Category)
+  @pointerId(() => Category)
   parentId?: string;
 
   @field()
   order?: number;
 
-  @pointerIds(FAQ)
+  @pointerIds(() => FAQ)
   FAQIds?: string[];
 
-  @pointerId(TicketForm)
+  @pointerId(() => TicketForm)
   formId?: string;
 
-  @pointTo(TicketForm)
+  @pointTo(() => TicketForm)
   form?: TicketForm;
 
   @field()

--- a/next/api/src/model2/Group.ts
+++ b/next/api/src/model2/Group.ts
@@ -8,9 +8,9 @@ export class Group extends Model {
   @field()
   description?: string;
 
-  @pointerId(Role)
+  @pointerId(() => Role)
   roleId!: string;
 
-  @pointTo(Role)
+  @pointTo(() => Role)
   role!: Role;
 }

--- a/next/api/src/model2/Role.ts
+++ b/next/api/src/model2/Role.ts
@@ -11,9 +11,9 @@ export class Role extends Model {
   @field()
   name!: string;
 
-  @hasManyThroughRelation(Role)
+  @hasManyThroughRelation(() => Role)
   roles!: Role[];
 
-  @hasManyThroughRelation(User)
+  @hasManyThroughRelation(() => User)
   users!: User[];
 }

--- a/next/api/src/model2/Ticket.ts
+++ b/next/api/src/model2/Ticket.ts
@@ -42,31 +42,31 @@ export class Ticket extends Model {
     encode: (c: Category) => ({ objectId: c.id, name: c.name }),
     decode: false,
   })
-  @belongsTo(Category)
+  @belongsTo(() => Category)
   category?: Category;
 
-  @pointerId(User)
+  @pointerId(() => User)
   authorId!: string;
 
-  @pointTo(User)
+  @pointTo(() => User)
   author?: User;
 
-  @pointerId(User)
+  @pointerId(() => User)
   assigneeId?: string;
 
-  @pointTo(User)
+  @pointTo(() => User)
   assignee?: User;
 
-  @pointerId(Group)
+  @pointerId(() => Group)
   groupId?: string;
 
-  @pointerId(Organization)
+  @pointerId(() => Organization)
   organizationId?: string;
 
-  @pointerIds(File)
+  @pointerIds(() => File)
   fileIds?: string[];
 
-  @hasManyThroughPointerArray(File)
+  @hasManyThroughPointerArray(() => File)
   files?: File[];
 
   @field()

--- a/next/api/src/model2/TicketForm.ts
+++ b/next/api/src/model2/TicketForm.ts
@@ -8,6 +8,6 @@ export class TicketForm extends Model {
   @field()
   fieldIds!: string[];
 
-  @hasManyThroughIdArray(TicketField)
+  @hasManyThroughIdArray(() => TicketField)
   fields!: TicketField[];
 }

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -66,6 +66,10 @@ export abstract class Model {
 
   readonly updatedAt!: Date;
 
+  get className() {
+    return (this.constructor as typeof Model).getClassName();
+  }
+
   static getClassName(): string {
     return this.className ?? this.name;
   }
@@ -143,21 +147,25 @@ export abstract class Model {
     return this.fromAVObject(object);
   }
 
-  get className() {
-    return (this.constructor as typeof Model).getClassName();
-  }
-
-  async load<M extends Model, K extends RelationKeys<M>>(
+  async reload<M extends Model, K extends RelationKeys<M>>(
     this: M,
-    field: K,
+    key: K,
     options?: AuthOptions
   ): Promise<M[K]> {
-    if (this[field as keyof M] !== undefined) {
-      return this[field as keyof M] as M[K];
-    }
-    const preloader = preloaderFactory(this.constructor as any, field);
+    const preloader = preloaderFactory(this.constructor as any, key);
     await preloader.load([this], options);
-    return this[field as keyof M] as M[K];
+    return this[key as keyof M] as M[K];
+  }
+
+  load<M extends Model, K extends RelationKeys<M>>(
+    this: M,
+    key: K,
+    options?: AuthOptions
+  ): Promise<M[K]> {
+    if (this[key as keyof M] !== undefined) {
+      return this[key as keyof M] as M[K];
+    }
+    return this.reload(key, options);
   }
 
   static ptr(objectId: string) {

--- a/next/api/src/orm/preloader.ts
+++ b/next/api/src/orm/preloader.ts
@@ -41,7 +41,7 @@ class BelongsToPreloader {
       return;
     }
 
-    const { name, relatedModel, getRelatedId } = this.relation;
+    const { name, getRelatedModel, getRelatedId } = this.relation;
 
     const relatedItems = this.data ?? [];
 
@@ -53,7 +53,7 @@ class BelongsToPreloader {
       .value();
 
     if (ids.length) {
-      const query = relatedModel.query().where('objectId', 'in', ids);
+      const query = getRelatedModel().query().where('objectId', 'in', ids);
       const fetchedItems = await query.find(options);
       fetchedItems.forEach((item) => relatedItems.push(item));
     }
@@ -87,7 +87,8 @@ class PointToPreloader {
 
   async load(items: Item[], options?: AuthOptions) {
     if (this.objects) {
-      const { name, relatedModel, includeKey } = this.relation;
+      const { name, getRelatedModel, includeKey } = this.relation;
+      const relatedModel = getRelatedModel();
       const objectMap = _.keyBy(this.objects, (o) => o.id!);
       items.forEach((item) => {
         const object = objectMap[item.id];
@@ -115,7 +116,7 @@ class HasManyThrouchIdArrayPreloader {
       return;
     }
 
-    const { name, relatedModel, getRelatedIds } = this.relation;
+    const { name, getRelatedModel, getRelatedIds } = this.relation;
 
     const relatedItems = this.data ?? [];
 
@@ -128,7 +129,7 @@ class HasManyThrouchIdArrayPreloader {
       .value();
 
     if (ids.length) {
-      const query = relatedModel.query().where('objectId', 'in', ids);
+      const query = getRelatedModel().query().where('objectId', 'in', ids);
       const fetchedItems = await query.find(options);
       fetchedItems.forEach((item) => relatedItems.push(item));
     }
@@ -159,7 +160,8 @@ class HasManyThrouchPointerArrayPreloader {
 
   async load(items: Item[], options?: AuthOptions) {
     if (this.objects) {
-      const { name, relatedModel, includeKey } = this.relation;
+      const { name, getRelatedModel, includeKey } = this.relation;
+      const relatedModel = getRelatedModel();
       const objectMap = _.keyBy(this.objects, (o) => o.id!);
       items.forEach((item) => {
         const object = objectMap[item.id];
@@ -188,7 +190,8 @@ class HasManyThrouchRelationPreloader {
       return;
     }
 
-    const { name, model, relatedModel, relatedKey } = this.relation;
+    const { name, model, getRelatedModel, relatedKey } = this.relation;
+    const relatedModel = getRelatedModel();
 
     const tasks = items.map(async (item) => {
       const query = relatedModel.queryBuilder().relatedTo(model, relatedKey, item.id);

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -7,11 +7,13 @@ export type RelationName<M extends typeof Model> = Extract<
   string
 >;
 
+export type ModelGetter = () => typeof Model;
+
 export interface BelongsTo {
   name: string;
   type: 'belongsTo';
   model: typeof Model;
-  relatedModel: typeof Model;
+  getRelatedModel: ModelGetter;
   getRelatedId: (instance: any) => string | undefined;
 }
 
@@ -24,7 +26,7 @@ export interface HasManyThroughIdArray {
   name: string;
   type: 'hasManyThroughIdArray';
   model: typeof Model;
-  relatedModel: typeof Model;
+  getRelatedModel: ModelGetter;
   getRelatedIds: (instance: any) => string[] | undefined;
 }
 
@@ -37,7 +39,7 @@ export interface HasManyThroughRelation {
   name: string;
   type: 'hasManyThroughRelation';
   model: typeof Model;
-  relatedModel: typeof Model;
+  getRelatedModel: ModelGetter;
   relatedKey: string;
 }
 


### PR DESCRIPTION
改的过程中又发现一个问题，cjs 有循环依赖的时候，没法在加载脚本的过程中拿到这个依赖的值（值是 undefined）。所以改成通过 getter ，在使用的时候获取。

我现在明白为啥 Adonis 用 getter 定义关联模型了 😑 。