### PR TITLE
feat(next/api): create reply

### DIFF
--- a/next/api/src/model/Group.ts
+++ b/next/api/src/model/Group.ts
@@ -1,6 +1,11 @@
 import { Model, field, pointTo, pointerId } from '../orm';
 import { Role } from './Role';
 
+export interface TinyGroupInfo {
+  objectId: string;
+  name: string;
+}
+
 export class Group extends Model {
   @field()
   name!: string;
@@ -13,4 +18,11 @@ export class Group extends Model {
 
   @pointTo(() => Role)
   role!: Role;
+
+  tinyInfo(): TinyGroupInfo {
+    return {
+      objectId: this.id,
+      name: this.name,
+    };
+  }
 }

--- a/next/api/src/model/Group.ts
+++ b/next/api/src/model/Group.ts
@@ -19,7 +19,7 @@ export class Group extends Model {
   @pointTo(() => Role)
   role!: Role;
 
-  tinyInfo(): TinyGroupInfo {
+  getTinyInfo(): TinyGroupInfo {
     return {
       objectId: this.id,
       name: this.name,

--- a/next/api/src/model/OpsLog.ts
+++ b/next/api/src/model/OpsLog.ts
@@ -39,7 +39,7 @@ export class OpsLog extends Model {
       ticketId: ticket.id,
       action: 'selectAssignee',
       data: {
-        assignee: makeTinyUserInfo(assignee),
+        assignee: assignee.tinyInfo(),
       },
     };
   }
@@ -52,8 +52,8 @@ export class OpsLog extends Model {
       ticketId: ticket.id,
       action: 'changeGroup',
       data: {
-        group: group ? makeTinyGroupInfo(group) : null,
-        operator: makeTinyUserInfo(operator),
+        group: group?.tinyInfo() ?? null,
+        operator: operator.tinyInfo(),
       },
       internal: true,
     };
@@ -64,19 +64,3 @@ OpsLog.beforeCreate(({ avObject }) => {
   // XXX: 旧版在 beforeSave 中设置 OpsLog 的 ACL
   avObject.disableBeforeHook();
 });
-
-function makeTinyUserInfo(user: User) {
-  return {
-    objectId: user.id,
-    username: user.username,
-    name: user.name,
-    email: user.email,
-  };
-}
-
-function makeTinyGroupInfo(group: Group) {
-  return {
-    objectId: group.id,
-    name: group.name,
-  };
-}

--- a/next/api/src/model/OpsLog.ts
+++ b/next/api/src/model/OpsLog.ts
@@ -39,7 +39,7 @@ export class OpsLog extends Model {
       ticketId: ticket.id,
       action: 'selectAssignee',
       data: {
-        assignee: assignee.tinyInfo(),
+        assignee: assignee.getTinyInfo(),
       },
     };
   }
@@ -52,8 +52,8 @@ export class OpsLog extends Model {
       ticketId: ticket.id,
       action: 'changeGroup',
       data: {
-        group: group?.tinyInfo() ?? null,
-        operator: operator.tinyInfo(),
+        group: group?.getTinyInfo() ?? null,
+        operator: operator.getTinyInfo(),
       },
       internal: true,
     };

--- a/next/api/src/model/Reply.ts
+++ b/next/api/src/model/Reply.ts
@@ -1,7 +1,16 @@
 import { Model, field, pointerId, pointTo, pointerIds, hasManyThroughPointerArray } from '../orm';
 import { File } from './File';
 import { Ticket } from './Ticket';
-import { User } from './User';
+import { TinyUserInfo, User } from './User';
+
+export interface TinyReplyInfo {
+  objectId: string;
+  content: string;
+  author: TinyUserInfo;
+  isCustomerService: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
 
 export class Reply extends Model {
   @field()
@@ -36,4 +45,23 @@ export class Reply extends Model {
 
   @field()
   deletedAt?: Date;
+
+  tinyInfo(): TinyReplyInfo {
+    if (!this.author) {
+      throw new Error('missing reply author');
+    }
+    return {
+      objectId: this.id,
+      author: this.author.tinyInfo(),
+      content: this.content,
+      isCustomerService: this.isCustomerService,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
 }
+
+Reply.beforeCreate(({ avObject }) => {
+  avObject.disableBeforeHook();
+  avObject.disableAfterHook();
+});

--- a/next/api/src/model/Reply.ts
+++ b/next/api/src/model/Reply.ts
@@ -46,13 +46,13 @@ export class Reply extends Model {
   @field()
   deletedAt?: Date;
 
-  tinyInfo(): TinyReplyInfo {
+  getTinyInfo(): TinyReplyInfo {
     if (!this.author) {
       throw new Error('missing reply author');
     }
     return {
       objectId: this.id,
-      author: this.author.tinyInfo(),
+      author: this.author.getTinyInfo(),
       content: this.content,
       isCustomerService: this.isCustomerService,
       createdAt: this.createdAt,

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -244,11 +244,11 @@ export class Ticket extends Model {
 
     if (!internal) {
       const updateData: UpdateData<Ticket> = {
-        latestReply: reply.tinyInfo(),
+        latestReply: reply.getTinyInfo(),
         replyCount: commands.inc(),
       };
       if (isCustomerService) {
-        updateData.joinedCustomerServices = commands.pushUniq(author.tinyInfo());
+        updateData.joinedCustomerServices = commands.pushUniq(author.getTinyInfo());
       }
       if (this.status < STATUS.FULFILLED) {
         updateData.status = isCustomerService

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -211,7 +211,7 @@ async function selectAssignee(
       getVacationerIds(),
     ]);
     customerServices = await User.queryBuilder()
-      .relatedTo(Role, 'users', csRole.id)
+      .relatedTo(csRole, 'users')
       .where('objectId', 'not-in', vacationerIds)
       .find({ useMasterKey: true });
   }

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -12,11 +12,13 @@ import {
   pointerIds,
   pointTo,
   hasManyThroughPointerArray,
+  hasOne,
 } from '../orm';
 import htmlify from '../utils/htmlify';
 import { Category, CategoryManager } from './Category';
 import { File } from './File';
 import { Group } from './Group';
+import { Notification } from './Notification';
 import { OpsLog } from './OpsLog';
 import { Organization } from './Organization';
 import { Reply, TinyReplyInfo } from './Reply';
@@ -146,6 +148,9 @@ export class Ticket extends Model {
 
   @field()
   metaData?: Record<string, any>;
+
+  @hasOne(() => Notification)
+  notification?: Notification;
 
   static STATUS = STATUS;
 

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -4,7 +4,9 @@ import {
   CreateData,
   Model,
   RawACL,
+  UpdateData,
   belongsTo,
+  commands,
   field,
   pointerId,
   pointerIds,
@@ -17,30 +19,34 @@ import { File } from './File';
 import { Group } from './Group';
 import { OpsLog } from './OpsLog';
 import { Organization } from './Organization';
+import { Reply, TinyReplyInfo } from './Reply';
 import { Role } from './Role';
-import { systemUser, User } from './User';
+import { TinyUserInfo, User, systemUser } from './User';
 import { Vacation } from './Vacation';
+
+export enum STATUS {
+  // 0~99 未开始处理
+  NEW = 50, // 新工单，还没有技术支持人员回复
+  // 100~199 处理中
+  WAITING_CUSTOMER_SERVICE = 120,
+  WAITING_CUSTOMER = 160,
+  // 200~299 处理完成
+  PRE_FULFILLED = 220, // 技术支持人员点击“解决”时会设置该状态，用户确认后状态变更为 FULFILLED
+  FULFILLED = 250, // 已解决
+  CLOSED = 280, // 已关闭
+}
 
 export interface Evaluation {
   star: number;
   content: string;
 }
 
-export interface LatestReply {
+export interface LatestReply extends Omit<TinyReplyInfo, 'objectId'> {
+  // 较早记录的数据没有 objectId
   objectId?: string;
-  content: string;
-  author: {
-    objectId: string;
-    username: string;
-    name: string;
-    email?: string;
-  };
-  isCustomerService: boolean;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
-export interface CreatedTicketData {
+export interface CreateTicketData {
   title: string;
   content: string;
   author: User;
@@ -48,6 +54,14 @@ export interface CreatedTicketData {
   organization?: Organization;
   fileIds?: string[];
   metaData?: Record<string, any>;
+}
+
+export interface CreateReplyData {
+  content: string;
+  author: User;
+  isCustomerService: boolean;
+  fileIds?: string[];
+  internal?: boolean;
 }
 
 export class Ticket extends Model {
@@ -128,7 +142,12 @@ export class Ticket extends Model {
   latestReply?: LatestReply;
 
   @field()
+  joinedCustomerServices?: TinyUserInfo[];
+
+  @field()
   metaData?: Record<string, any>;
+
+  static STATUS = STATUS;
 
   static async createTicket({
     title,
@@ -138,7 +157,7 @@ export class Ticket extends Model {
     organization,
     fileIds,
     metaData,
-  }: CreatedTicketData): Promise<Ticket> {
+  }: CreateTicketData): Promise<Ticket> {
     const [assignee, group] = await Promise.all([selectAssignee(category), selectGroup(category)]);
 
     const ACL: RawACL = {
@@ -147,7 +166,8 @@ export class Ticket extends Model {
       'role:staff': { read: true },
     };
     if (organization) {
-      ACL[organization.id + '_member'] = { read: true, write: true };
+      const orgRole = 'role:' + organization.id + '_member';
+      ACL[orgRole] = { read: true, write: true };
     }
 
     const ticket = await this.create(
@@ -162,13 +182,9 @@ export class Ticket extends Model {
         groupId: group?.id,
         fileIds,
         metaData,
-        status: 50,
+        status: STATUS.NEW,
       },
-      {
-        ignoreBeforeHooks: true,
-        ignoreAfterHooks: true,
-        sessionToken: author.sessionToken,
-      }
+      author.getAuthOptions()
     );
 
     const opsLogDatas: CreateData<OpsLog>[] = [];
@@ -190,7 +206,70 @@ export class Ticket extends Model {
     }
     return this.categoryPath;
   }
+
+  async reply(
+    this: Ticket,
+    { content, author, isCustomerService, fileIds, internal }: CreateReplyData
+  ): Promise<Reply> {
+    const ACL: RawACL = {
+      [author.id]: { read: true, write: true },
+      'role:customerService': { read: true },
+      'role:staff': { read: true },
+    };
+    if (!internal) {
+      if (this.authorId !== author.id) {
+        ACL[this.authorId] = { read: true };
+      }
+      if (this.organizationId) {
+        const orgRole = 'role:' + this.organizationId + '_member';
+        ACL[orgRole] = { read: true };
+      }
+    }
+
+    const authOptions = author.getAuthOptions();
+    const reply = await Reply.create(
+      {
+        ACL,
+        content,
+        contentHTML: htmlify(content),
+        ticketId: this.id,
+        authorId: author.id,
+        isCustomerService,
+        fileIds,
+        internal: internal || undefined,
+      },
+      authOptions
+    );
+    reply.author = author;
+
+    if (!internal) {
+      const updateData: UpdateData<Ticket> = {
+        latestReply: reply.tinyInfo(),
+        replyCount: commands.inc(),
+      };
+      if (isCustomerService) {
+        updateData.joinedCustomerServices = commands.pushUniq(author.tinyInfo());
+      }
+      if (this.status < STATUS.FULFILLED) {
+        updateData.status = isCustomerService
+          ? STATUS.WAITING_CUSTOMER
+          : STATUS.WAITING_CUSTOMER_SERVICE;
+      }
+
+      // TODO: Sentry
+      this.update(updateData, authOptions).catch(console.error);
+
+      // TODO: notification
+    }
+
+    return reply;
+  }
 }
+
+Ticket.beforeCreate(({ avObject }) => {
+  avObject.disableBeforeHook();
+  avObject.disableAfterHook();
+});
 
 async function getVacationerIds(): Promise<string[]> {
   const now = new Date();

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -178,7 +178,7 @@ export class User extends Model {
     return false;
   }
 
-  tinyInfo(): TinyUserInfo {
+  getTinyInfo(): TinyUserInfo {
     return {
       objectId: this.id,
       username: this.username,

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -112,7 +112,7 @@ export class User extends Model {
 
   static async getCustomerServices(): Promise<User[]> {
     const customerService = await Role.getCustomerServiceRole();
-    const query = User.queryBuilder().relatedTo(Role, 'users', customerService.id);
+    const query = User.queryBuilder().relatedTo(customerService, 'users');
     return query.find({ useMasterKey: true });
   }
 

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -48,6 +48,13 @@ export interface LeanCloudAccount {
   current_support_service?: any;
 }
 
+export interface TinyUserInfo {
+  objectId: string;
+  username: string;
+  name?: string;
+  email?: string;
+}
+
 export class User extends Model {
   static readonly className = '_User';
 
@@ -170,10 +177,33 @@ export class User extends Model {
     }
     return false;
   }
+
+  tinyInfo(): TinyUserInfo {
+    return {
+      objectId: this.id,
+      username: this.username,
+      name: this.name,
+      email: this.email,
+    };
+  }
 }
 
-export const systemUser = new User();
-systemUser.id = 'system';
-systemUser.username = 'system';
-systemUser.createdAt = new Date(0);
-systemUser.updatedAt = new Date(0);
+class SystemUser extends User {
+  constructor() {
+    super();
+    this.id = 'system';
+    this.username = 'system';
+    this.createdAt = new Date(0);
+    this.updatedAt = new Date(0);
+  }
+
+  async isCustomerService() {
+    return true;
+  }
+
+  getAuthOptions() {
+    return { useMasterKey: true };
+  }
+}
+
+export const systemUser = new SystemUser();

--- a/next/api/src/orm/command.ts
+++ b/next/api/src/orm/command.ts
@@ -1,0 +1,30 @@
+import { Flat } from './utils';
+
+export interface IncCommand {
+  __op: 'Increment';
+  amount: number;
+}
+
+export interface PushUniqCommand<T> {
+  __op: 'AddUnique';
+  objects: T[];
+}
+
+export type TypeCommands<T> = T extends number
+  ? IncCommand
+  : T extends any[]
+  ? PushUniqCommand<Flat<T>>
+  : never;
+
+function inc(amount = 1): IncCommand {
+  return { __op: 'Increment', amount };
+}
+
+function pushUniq<T>(...objects: T[]): PushUniqCommand<T> {
+  return { __op: 'AddUnique', objects };
+}
+
+export const commands = {
+  inc,
+  pushUniq,
+};

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -111,6 +111,22 @@ export function belongsTo(
   };
 }
 
+export function hasOne(getRelatedModel: ModelGetter, pointerKey?: string) {
+  return (target: Model, name: string) => {
+    const model = target.constructor as typeof Model;
+    if (pointerKey === undefined) {
+      pointerKey = model.getClassName().toLowerCase();
+    }
+    model.setRelation({
+      name,
+      type: 'hasOne',
+      model,
+      getRelatedModel,
+      pointerKey,
+    });
+  };
+}
+
 export function pointTo(
   getRelatedModel: ModelGetter,
   includeKey?: string,

--- a/next/api/src/orm/index.ts
+++ b/next/api/src/orm/index.ts
@@ -1,3 +1,4 @@
 export * from './model';
 export * from './helpers';
 export * from './query';
+export * from './command';

--- a/next/api/src/orm/query.ts
+++ b/next/api/src/orm/query.ts
@@ -174,8 +174,16 @@ export class Query<M extends typeof Model> {
     return query;
   }
 
-  relatedTo(model: typeof Model, key: string, id: string): Query<M> {
-    return this.where('$relatedTo', '==', { key, object: model.ptr(id) });
+  relatedTo(model: typeof Model, key: string, id: string): Query<M>;
+  relatedTo(model: Model, key: string): Query<M>;
+  relatedTo(model: typeof Model | Model, key: string, id?: string): Query<M> {
+    let object: ReturnType<typeof Model.ptr>;
+    if (id) {
+      object = (model as typeof Model).ptr(id);
+    } else {
+      object = (model as Model).toPointer();
+    }
+    return this.where('$relatedTo', '==', { key, object });
   }
 
   skip(count: number): Query<M> {

--- a/next/api/src/orm/query.ts
+++ b/next/api/src/orm/query.ts
@@ -104,6 +104,7 @@ export interface PreloadOptions<
 > {
   data?: Flat<NonNullable<InstanceType<M>[K]>>[];
   authOptions?: AuthOptions;
+  onQuery?: (query: QueryBuilder<any>) => void;
 }
 
 interface QueryPreloader {
@@ -210,6 +211,9 @@ export class Query<M extends typeof Model> {
     const preloader = preloaderFactory(this.model, key);
     if (options?.data) {
       preloader.data = options.data as Model[];
+    }
+    if (options?.onQuery) {
+      preloader.queryModifier = options.onQuery;
     }
     query.preloaders[key] = {
       preloader,

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -22,6 +22,14 @@ export interface PointTo extends Omit<BelongsTo, 'type'> {
   includeKey: string;
 }
 
+export interface HasOne {
+  name: string;
+  type: 'hasOne';
+  model: typeof Model;
+  getRelatedModel: ModelGetter;
+  pointerKey: string;
+}
+
 export interface HasManyThroughIdArray {
   name: string;
   type: 'hasManyThroughIdArray';
@@ -46,6 +54,7 @@ export interface HasManyThroughRelation {
 export type Relation =
   | BelongsTo
   | PointTo
+  | HasOne
   | HasManyThroughIdArray
   | HasManyThroughPointerArray
   | HasManyThroughRelation;

--- a/next/api/src/response/ticket.ts
+++ b/next/api/src/response/ticket.ts
@@ -24,6 +24,7 @@ export class TicketListItemResponse {
       status: this.ticket.status,
       evaluation: this.ticket.evaluation,
       replyCount: this.ticket.replyCount,
+      unreadCount: this.ticket.notification?.unreadCount ?? 0,
       createdAt: this.ticket.createdAt.toISOString(),
       updatedAt: this.ticket.updatedAt.toISOString(),
     };


### PR DESCRIPTION
照搬旧版，缺少通知。

与旧版的区别：internal 为 `false` 时不将该字段写入数据库，因为最早的回复也是没有 internal 字段的，避免后续被误解为非 internal 回复的 internal 一定为 `false` 。