### PR TITLE
fix(stats): ticket may has no assignee

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -149,9 +149,11 @@ class ReplyTimeStats {
       return
     }
     if (avObj.className === 'OpsLog' && avObj.get('action') === 'changeAssignee' && !this.isReply) {
-      const customerServiceTime = this.getCustomerServiceTime(this.lastCustomerService)
-      customerServiceTime.replyCount++
-      customerServiceTime.replyTime += avObj.createdAt - this.cursor
+      if (this.lastCustomerService) {
+        const customerServiceTime = this.getCustomerServiceTime(this.lastCustomerService)
+        customerServiceTime.replyCount++
+        customerServiceTime.replyTime += avObj.createdAt - this.cursor
+      }
       this.cursor = avObj.createdAt
       this.lastCustomerService = avObj.get('data').assignee
       return
@@ -161,9 +163,11 @@ class ReplyTimeStats {
       (avObj.get('action') === 'replyWithNoContent' || avObj.get('action') === 'replySoon') &&
       !this.isReply
     ) {
-      const customerServiceTime = this.getCustomerServiceTime(this.lastCustomerService)
-      customerServiceTime.replyCount++
-      customerServiceTime.replyTime += avObj.createdAt - this.cursor
+      if (this.lastCustomerService) {
+        const customerServiceTime = this.getCustomerServiceTime(this.lastCustomerService)
+        customerServiceTime.replyCount++
+        customerServiceTime.replyTime += avObj.createdAt - this.cursor
+      }
       this.cursor = avObj.createdAt
       this.isReply = true
       this.lastCustomerService = avObj.get('data').operator
@@ -190,7 +194,8 @@ class ReplyTimeStats {
         (this.ticket.get('status') === TICKET_STATUS.WAITING_CUSTOMER_SERVICE &&
           this.lastAction &&
           this.lastAction.className === 'OpsLog' &&
-          this.lastAction.get('action') !== 'replySoon'))
+          this.lastAction.get('action') !== 'replySoon')) &&
+      this.lastCustomerService
     ) {
       const customerServiceTime = this.getCustomerServiceTime(this.lastCustomerService)
       customerServiceTime.replyTime += new Date() - this.cursor

--- a/api/stats.js
+++ b/api/stats.js
@@ -92,7 +92,9 @@ class FirstReplyStats {
     }
     if (avObj.className === 'OpsLog' && avObj.get('action') === 'changeAssignee') {
       this.firstReplyAt = avObj.createdAt
-      this.userId = this.customerService.objectId
+      if (this.customerService) {
+        this.userId = this.customerService.objectId
+      }
       return
     }
   }


### PR DESCRIPTION
负责人改为可选后导致计算统计数据时可能出错。
```
[2021-09-26T02:11:58.018120000Z][instance:web1] err >> 60e4ffbd81c4dc47a2a61108 TypeError: Cannot read property 'id' of null
[2021-09-26T02:11:58.018187300Z][instance:web1]     at ReplyTimeStats.getCustomerServiceTime (/home/leanengine/app/api/stats.js:120:25)
[2021-09-26T02:11:58.018192600Z][instance:web1]     at ReplyTimeStats.forEachReplyOrOpsLog (/home/leanengine/app/api/stats.js:152:40)
[2021-09-26T02:11:58.018196200Z][instance:web1]     at /home/leanengine/app/api/stats.js:64:22
[2021-09-26T02:11:58.018199800Z][instance:web1]     at arrayEach (/home/leanengine/app/node_modules/lodash/lodash.js:530:11)
[2021-09-26T02:11:58.018203000Z][instance:web1]     at Function.forEach (/home/leanengine/app/node_modules/lodash/lodash.js:9410:14)
[2021-09-26T02:11:58.018206200Z][instance:web1]     at /home/leanengine/app/api/stats.js:62:7
[2021-09-26T02:11:58.018225400Z][instance:web1]     at bound (domain.js:416:15)
[2021-09-26T02:11:58.018228700Z][instance:web1]     at runBound (domain.js:427:12)
```
```
err >> 611a1c6c4db79775ff9adfd5 TypeError: Cannot read property 'objectId' of undefined
[2021-09-26T02:12:15.796757800Z][instance:web1]     at FirstReplyStats.forEachReplyOrOpsLog (/home/leanengine/app/api/stats.js:95:42)
[2021-09-26T02:12:15.796763400Z][instance:web1]     at /home/leanengine/app/api/stats.js:63:23
```
看不懂这块的逻辑，简单修一下保证不会中断整个计算流程。