### PR TITLE
feat(next): slack integration

### DIFF
--- a/next/api/src/integration/slack.ts
+++ b/next/api/src/integration/slack.ts
@@ -1,0 +1,212 @@
+import { WebClient } from '@slack/web-api';
+
+import notification, {
+  ChangeStatusContext,
+  DelayNotifyContext,
+  NewTicketContext,
+  ReplyTicketContext,
+  TicketEvaluationContext,
+} from '../notification';
+import type { Reply } from '../model/Reply';
+import type { Ticket } from '../model/Ticket';
+import type { User } from '../model/User';
+
+const token = process.env.SLACK_TOKEN;
+const channel = process.env.SLACK_CHANNEL; // broadcast target
+
+class Message {
+  constructor(readonly summary: string, readonly content: string) {}
+
+  toJSON() {
+    return {
+      text: this.summary,
+      attachments: [
+        {
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: this.content,
+              },
+            },
+          ],
+        },
+      ],
+    };
+  }
+}
+
+function getTicketLink(ticket: Ticket): string {
+  return `<${ticket.getUrl()}|#${ticket.nid}>`;
+}
+
+class NewTicketMessage extends Message {
+  constructor(ticket: Ticket, author: User, assignee?: User) {
+    let summary = `:envelope: ${author.getDisplayName()} 提交工单 ${getTicketLink(ticket)}`;
+    if (assignee) {
+      summary += ` 给 ${assignee.getDisplayName()}`;
+    }
+    super(summary, ticket.title + '\n\n' + ticket.content);
+  }
+}
+
+class ChangeAssigneeMessage extends Message {
+  constructor(ticket: Ticket, operator: User, assignee?: User) {
+    const assigneeName = assignee ? assignee.getDisplayName() : '<未分配>';
+    const summary = `:arrows_counterclockwise: ${operator.getDisplayName()} 转移工单 ${getTicketLink(
+      ticket
+    )} 给 ${assigneeName}`;
+    let content = ticket.title;
+    if (ticket.latestReply) {
+      content += '\n\n' + ticket.latestReply.content;
+    }
+    super(summary, content);
+  }
+}
+
+class ReplyTicketMessage extends Message {
+  constructor(ticket: Ticket, reply: Reply, author: User) {
+    super(
+      `:left_speech_bubble: ${author.getDisplayName()} 回复工单 ${getTicketLink(ticket)}`,
+      ticket.title + '\n\n' + reply.content
+    );
+  }
+}
+
+class EvaluateTicketMessage extends Message {
+  constructor(ticket: Ticket, operator: User) {
+    const { star, content } = ticket.evaluation!;
+    const emoji = star ? ':thumbsup:' : ':thumbsdown:';
+    super(
+      `${emoji} ${operator.getDisplayName()} 评价工单 ${getTicketLink(ticket)}`,
+      ticket.title + '\n\n' + content
+    );
+  }
+}
+
+class DelayNotifyMessage extends Message {
+  constructor(ticket: Ticket, assignee?: User) {
+    const assigneeName = assignee ? assignee.getDisplayName() : '<未分配>';
+    let content = ticket.title;
+    if (ticket.latestReply) {
+      content += '\n\n' + ticket.latestReply.content;
+    }
+    super(`:alarm_clock: 提醒 ${assigneeName} 回复工单 ${getTicketLink(ticket)}`, content);
+  }
+}
+
+class SlackIntegration {
+  private client: WebClient;
+  private userIdMap: Map<string, string> = new Map();
+  private channelIdMap: Map<string, string> = new Map();
+
+  constructor(token: string, readonly broadcastChannelId?: string) {
+    this.client = new WebClient(token);
+    notification.on('newTicket', this.sendNewTicket);
+    notification.on('changeAssignee', this.sendChangeAssignee);
+    notification.on('replyTicket', this.sendReplyTicket);
+    notification.on('ticketEvaluation', this.sendEvaluation);
+    notification.on('delayNotify', this.sendDelayNotify);
+  }
+
+  async getUserId(email: string): Promise<string> {
+    const id = this.userIdMap.get(email);
+    if (id) {
+      return id;
+    }
+
+    const { user } = await this.client.users.lookupByEmail({ email });
+    if (!user || !user.id) {
+      throw new Error('Slack API returns an invalid user');
+    }
+    this.userIdMap.set(email, user.id);
+    return user.id;
+  }
+
+  async getChannelId(userId: string): Promise<string> {
+    const channelId = this.channelIdMap.get(userId);
+    if (channelId) {
+      return channelId;
+    }
+
+    const { channel } = await this.client.conversations.open({ users: userId });
+    if (!channel || !channel.id) {
+      throw new Error('Slack API returns an invalid channel');
+    }
+    this.channelIdMap.set(userId, channel.id);
+    return channel.id;
+  }
+
+  send(channel: string, message: Message) {
+    return this.client.chat.postMessage({ ...message.toJSON(), channel });
+  }
+
+  broadcast(message: Message) {
+    if (this.broadcastChannelId) {
+      return this.send(this.broadcastChannelId, message);
+    }
+  }
+
+  async sendToUser(email: string, message: Message) {
+    let userId: string;
+    try {
+      userId = await this.getUserId(email);
+    } catch (error: any) {
+      if (error.data.error === 'users_not_found') {
+        return;
+      }
+      throw error;
+    }
+
+    const channelId = await this.getChannelId(userId);
+    return this.send(channelId, message);
+  }
+
+  sendNewTicket = ({ ticket, from, to }: NewTicketContext) => {
+    const message = new NewTicketMessage(ticket, from, to);
+    if (to?.email) {
+      this.sendToUser(to.email, message);
+    }
+    this.broadcast(message);
+  };
+
+  sendChangeAssignee = ({ ticket, from, to }: ChangeStatusContext) => {
+    const message = new ChangeAssigneeMessage(ticket, from, to);
+    if (to?.email) {
+      this.sendToUser(to.email, message);
+    }
+    this.broadcast(message);
+  };
+
+  sendReplyTicket = ({ ticket, reply, from, to }: ReplyTicketContext) => {
+    const message = new ReplyTicketMessage(ticket, reply, from);
+    if (to?.email) {
+      this.sendToUser(to.email, message);
+    }
+    this.broadcast(message);
+  };
+
+  sendEvaluation = ({ ticket, from, to }: TicketEvaluationContext) => {
+    const message = new EvaluateTicketMessage(ticket, from);
+    if (to?.email) {
+      this.sendToUser(to.email, message);
+    }
+    this.broadcast(message);
+  };
+
+  sendDelayNotify = ({ ticket, to }: DelayNotifyContext) => {
+    const message = new DelayNotifyMessage(ticket, to);
+    if (to?.email) {
+      this.sendToUser(to.email, message);
+    }
+    this.broadcast(message);
+  };
+}
+
+export const enabled = !!token;
+
+if (token) {
+  new SlackIntegration(token, channel);
+  console.log('[Slack] Enabled');
+}

--- a/next/api/src/integration/slack.ts
+++ b/next/api/src/integration/slack.ts
@@ -68,7 +68,7 @@ class ChangeAssigneeMessage extends Message {
 class ReplyTicketMessage extends Message {
   constructor(ticket: Ticket, reply: Reply, author: User) {
     super(
-      `:left_speech_bubble: ${author.getDisplayName()} 回复工单 ${getTicketLink(ticket)}`,
+      `:speech_balloon: ${author.getDisplayName()} 回复工单 ${getTicketLink(ticket)}`,
       ticket.title + '\n\n' + reply.content
     );
   }

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -13,6 +13,7 @@
         "@headlessui/react": "^1.4.0",
         "@koa/cors": "^3.1.0",
         "@koa/router": "^10.1.1",
+        "@slack/web-api": "^6.4.0",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",
         "highlight.js": "^11.2.0",
@@ -778,6 +779,67 @@
         "node": ">=6"
       }
     },
+    "node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-/yHEFvgp0UY/lfFvQqbq9BocW/pM4xnGycqGAx+plRgYp96dZp1y50Whz7yzOgasEUsy5TyQfBK07cj0RwUyIg==",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.4.0.tgz",
+      "integrity": "sha512-Hi0pq60d/zCqn1UQvuSyrMcoLGNbKUBL/Tmk1b1RPTZdVYiRK8zp337glvhxTBwiaGOu+58uO5yflpK1AAuoRw==",
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "^2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/@slack/web-api/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -915,6 +977,14 @@
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.7.tgz",
       "integrity": "sha512-TOGRR+e1to00CihjgPNygD7+G7ruVnMi62YdIvGUBRfj11k/aWq+Fv5Ea8St0Oy56NngTBfA8GvLn1uvHvhX6Q==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1097,6 +1167,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -3437,6 +3512,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3539,6 +3619,14 @@
       "dependencies": {
         "isobject": "^3.0.1"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4486,12 +4574,63 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-map": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/package-json": {
@@ -5164,6 +5303,14 @@
       "dev": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -6719,6 +6866,54 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "requires": {
+        "@types/node": ">=12.0.0"
+      }
+    },
+    "@slack/types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-/yHEFvgp0UY/lfFvQqbq9BocW/pM4xnGycqGAx+plRgYp96dZp1y50Whz7yzOgasEUsy5TyQfBK07cj0RwUyIg=="
+    },
+    "@slack/web-api": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.4.0.tgz",
+      "integrity": "sha512-Hi0pq60d/zCqn1UQvuSyrMcoLGNbKUBL/Tmk1b1RPTZdVYiRK8zp337glvhxTBwiaGOu+58uO5yflpK1AAuoRw==",
+      "requires": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "^2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -6849,6 +7044,14 @@
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.7.tgz",
       "integrity": "sha512-TOGRR+e1to00CihjgPNygD7+G7ruVnMi62YdIvGUBRfj11k/aWq+Fv5Ea8St0Oy56NngTBfA8GvLn1uvHvhX6Q==",
       "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
         "@types/node": "*"
       }
@@ -7027,6 +7230,11 @@
           "dev": true
         }
       }
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@types/scheduler": {
       "version": "0.16.2",
@@ -8847,6 +9055,11 @@
         "has": "^1.0.3"
       }
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8916,6 +9129,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -9647,10 +9865,48 @@
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-map": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
+    },
+    "p-retry": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "package-json": {
       "version": "6.5.0",
@@ -10113,6 +10369,11 @@
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/next/package.json
+++ b/next/package.json
@@ -19,6 +19,7 @@
     "@headlessui/react": "^1.4.0",
     "@koa/cors": "^3.1.0",
     "@koa/router": "^10.1.1",
+    "@slack/web-api": "^6.4.0",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",
     "highlight.js": "^11.2.0",


### PR DESCRIPTION
完全复刻旧版的 Slack 通知功能。

由于 Wechat 和 Zulip 已不使用，就不复刻了，用到的时候再说。这个合完开始往 next 上迁工单的创建、更新和回复。