### PR TITLE
refactor(in-app): custom fields

### DIFF
--- a/in-app/v1/package-lock.json
+++ b/in-app/v1/package-lock.json
@@ -22,6 +22,7 @@
         "query-string": "^7.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-hook-form": "^7.19.5",
         "react-i18next": "^11.14.2",
         "react-intersection-observer": "^8.32.2",
         "react-query": "^3.33.1",
@@ -3182,6 +3183,18 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.19.5.tgz",
+      "integrity": "sha512-+M9gd0nWWASuEitf5PQGOGNElnHknzY3rGISrPDXwsOmZb7c/jyvkRUqk4OJXaZit1ZwesSv+EysttdAeFEfmw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "11.14.2",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.14.2.tgz",
@@ -6339,6 +6352,12 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
+    },
+    "react-hook-form": {
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.19.5.tgz",
+      "integrity": "sha512-+M9gd0nWWASuEitf5PQGOGNElnHknzY3rGISrPDXwsOmZb7c/jyvkRUqk4OJXaZit1ZwesSv+EysttdAeFEfmw==",
+      "requires": {}
     },
     "react-i18next": {
       "version": "11.14.2",

--- a/in-app/v1/package.json
+++ b/in-app/v1/package.json
@@ -24,6 +24,7 @@
     "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.19.5",
     "react-i18next": "^11.14.2",
     "react-intersection-observer": "^8.32.2",
     "react-query": "^3.33.1",

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/CheckboxGroup/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/CheckboxGroup/index.tsx
@@ -1,0 +1,60 @@
+import { useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Checkbox } from '@/components/Form';
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+export function CheckboxGroup({ id, required, options }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { control } = useFormContext();
+  const {
+    field: { ref, value, onChange },
+    fieldState: { error },
+  } = useController<Record<string, string[] | undefined>>({
+    control,
+    name: id,
+    rules: {
+      required: {
+        value: required,
+        message: t('validation.required'),
+      },
+    },
+  });
+
+  const values = useMemo(() => new Set(value), [value]);
+  const handleCheck = (checked: boolean, value: string) => {
+    const nextValues = new Set(values);
+    if (checked) {
+      nextValues.add(value);
+    } else {
+      nextValues.delete(value);
+    }
+    onChange(Array.from(nextValues));
+  };
+
+  const $container = useRef<HTMLDivElement>(null!);
+  ref({
+    focus: () => $container.current.scrollIntoView(),
+  });
+
+  return (
+    <div ref={$container}>
+      <div className="grid sm:grid-cols-2 gap-3">
+        {options?.map((option) => (
+          <div key={option.value} className="flex items-center break-all">
+            <Checkbox
+              fluid
+              checked={values.has(option.value)}
+              onChange={(checked) => handleCheck(checked, option.value)}
+            >
+              {option.title}
+            </Checkbox>
+          </div>
+        ))}
+      </div>
+      {error && <ErrorMessage className="mt-3">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/ErrorMessage.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/ErrorMessage.tsx
@@ -1,0 +1,8 @@
+import { ComponentPropsWithoutRef } from 'react';
+import classNames from 'classnames';
+
+export type ErrorMessageProps = ComponentPropsWithoutRef<'div'>;
+
+export function ErrorMessage({ className, ...props }: ErrorMessageProps) {
+  return <div {...props} className={classNames(className, 'text-xs text-red-500')} />;
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Input/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Input/index.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+import { useFormContext } from 'react-hook-form';
+import cx from 'classnames';
+
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+export function Input({ id, required }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { register, formState } = useFormContext();
+  const error = formState.errors[id];
+
+  return (
+    <div>
+      <input
+        {...register(id, {
+          required: {
+            value: required,
+            message: t('validation.required'),
+          },
+        })}
+        className={cx('w-full px-3 py-2 border rounded text-sm', {
+          'focus:border-tapBlue focus:ring-1 focus:ring-tapBlue': !error,
+          'border-[rgba(0,0,0,0.08)]': !error,
+          'border-red-500': error,
+        })}
+        type="text"
+      />
+      {error && <ErrorMessage className="mt-1">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/RadioGroup/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/RadioGroup/index.tsx
@@ -1,0 +1,45 @@
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Radio } from '@/components/Form';
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+export function RadioGroup({ id, required, options }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { control } = useFormContext();
+  const {
+    field: { ref, value, onChange },
+    fieldState: { error },
+  } = useController({
+    control,
+    name: id,
+    rules: {
+      required: {
+        value: required,
+        message: t('validation.required'),
+      },
+    },
+  });
+
+  const $container = useRef<HTMLDivElement>(null!);
+  ref({
+    focus: () => $container.current.scrollIntoView(),
+  });
+
+  return (
+    <div ref={$container}>
+      <div className="grid sm:grid-cols-2 gap-3">
+        {options?.map((option) => (
+          <div key={option.value} className="flex items-center break-all">
+            <Radio fluid checked={value === option.value} onChange={() => onChange(option.value)}>
+              {option.title}
+            </Radio>
+          </div>
+        ))}
+      </div>
+      {error && <ErrorMessage className="mt-3">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Select/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Select/index.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { ChevronDownIcon } from '@heroicons/react/solid';
+import cx from 'classnames';
+
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+export function Select({ id, required, options }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { register, formState, control } = useFormContext();
+  const value = useWatch({ control, name: id });
+  const error = formState.errors[id];
+
+  return (
+    <div>
+      <div className="relative flex items-center">
+        <select
+          {...register(id, {
+            required: {
+              value: required,
+              message: t('validation.required'),
+            },
+          })}
+          className={cx('w-full px-3 py-2 border rounded text-sm', {
+            'text-[#BFBFBF]': !value,
+            'focus:border-tapBlue focus:ring-1 focus:ring-tapBlue': !error,
+            'border-[rgba(0,0,0,0.08)]': !error,
+            'border-red-500': error,
+          })}
+        >
+          <option value="" hidden>
+            {t('general.select_hint')}
+          </option>
+          {options?.map(({ title, value }, index) => (
+            <option key={index} value={value}>
+              {title}
+            </option>
+          ))}
+        </select>
+
+        <ChevronDownIcon className="w-4 h-4 absolute right-2 text-[#BFBFBF] pointer-events-none" />
+      </div>
+
+      {error && <ErrorMessage className="mt-1">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Textarea/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Textarea/index.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+import { useFormContext } from 'react-hook-form';
+import cx from 'classnames';
+
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+const DEFAULT_ROWS = 3;
+
+export function Textarea({ id, required }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { register, formState } = useFormContext();
+  const error = formState.errors[id];
+
+  return (
+    <div>
+      <textarea
+        {...register(id, {
+          required: {
+            value: required,
+            message: t('validation.required'),
+          },
+        })}
+        className={cx('w-full px-3 py-1.5 border rounded text-sm', {
+          'border-red-500': error,
+          'border-[rgba(0,0,0,0.08)]': !error,
+          'focus:border-tapBlue focus:ring-1 focus:ring-tapBlue': !error,
+        })}
+        rows={DEFAULT_ROWS}
+      />
+      {error && <ErrorMessage className="mt-0.5">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Uploader/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/Uploader/index.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Uploader as _Uploader } from '@/components/Uploader';
+import { useAlert } from '@/utils/useAlert';
+import { useUpload } from '@/utils/useUpload';
+import { CustomFieldProps } from '..';
+import { ErrorMessage } from '../ErrorMessage';
+
+export function Uploader({ id, required }: CustomFieldProps) {
+  const { t } = useTranslation();
+  const { element: alertElement, alert } = useAlert();
+
+  const { control } = useFormContext();
+  const {
+    field: { ref, onChange },
+    fieldState: { error },
+  } = useController<Record<string, string[] | undefined>>({
+    control,
+    name: id,
+    rules: {
+      required: {
+        value: required,
+        message: t('validation.required'),
+      },
+      validate: (fileIds) => {
+        // 未上传完毕的文件没有 id
+        if (fileIds?.some((id) => id === undefined)) {
+          return t('validation.attachment_not_uploaded') as string;
+        }
+        return true;
+      },
+    },
+  });
+
+  const { files, upload, remove } = useUpload({
+    onError: (e) =>
+      alert({
+        title: t('validation.attachment_too_big'),
+        content: e.message,
+      }),
+  });
+
+  useEffect(() => {
+    onChange(files.map((f) => f.id));
+  }, [files]);
+
+  const $container = useRef<HTMLDivElement>(null!);
+  ref({
+    focus: () => $container.current.scrollIntoView(),
+  });
+
+  return (
+    <div ref={$container}>
+      {alertElement}
+      <_Uploader
+        files={files}
+        onUpload={(files) => upload(files[0])}
+        onDelete={(file) => remove(file.key)}
+        error={!!error}
+      />
+      {error && <ErrorMessage className="mt-1">{error.message}</ErrorMessage>}
+    </div>
+  );
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/CustomField/index.tsx
@@ -1,0 +1,33 @@
+import { JSXElementConstructor } from 'react';
+
+import { CategoryFieldSchema, FieldType } from '@/api/category';
+
+import { Input } from './Input';
+import { Textarea } from './Textarea';
+import { Select } from './Select';
+import { CheckboxGroup } from './CheckboxGroup';
+import { RadioGroup } from './RadioGroup';
+import { Uploader } from './Uploader';
+
+export interface CustomFieldProps extends CategoryFieldSchema {}
+
+const components: Record<FieldType, JSXElementConstructor<CustomFieldProps>> = {
+  text: Input,
+  'multi-line': Textarea,
+  dropdown: Select,
+  'multi-select': CheckboxGroup,
+  radios: RadioGroup,
+  file: Uploader,
+};
+
+function Unknown({ type }: { type: string }) {
+  return <div className="text-red-500">Unsupported component: {type}</div>;
+}
+
+export function CustomField(props: CustomFieldProps) {
+  const Component = components[props.type];
+  if (!Component) {
+    return <Unknown type={props.type} />;
+  }
+  return <Component {...props} />;
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/index.module.css
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/index.module.css
@@ -1,0 +1,9 @@
+.required {
+  &::after {
+    content: '*';
+    color: #F64C4C;
+    position: absolute;
+    line-height: 18px;
+    padding-left: 2px;
+  }
+}

--- a/in-app/v1/src/App/Tickets/New/CustomForm/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/index.tsx
@@ -1,0 +1,87 @@
+import { ReactNode, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FormProvider, useForm } from 'react-hook-form';
+import cx from 'classnames';
+
+import { CategoryFieldSchema, FieldType } from '@/api/category';
+import { Button } from '@/components/Button';
+import { SpaceChinese } from '@/components/SpaceChinese';
+import style from './index.module.css';
+import { CustomField } from './CustomField';
+
+const TOP_LABEL_TYPES: FieldType[] = ['multi-select', 'radios'];
+const I18N_KEY_BY_ID: Record<string, string | undefined> = {
+  title: 'general.title',
+  description: 'general.description',
+};
+
+export interface GroupProps {
+  title?: string;
+  required?: boolean;
+  children?: ReactNode;
+  labelAtTop?: boolean;
+}
+
+export function Group({ title, required, children, labelAtTop }: GroupProps) {
+  return (
+    <div className="flex flex-col sm:flex-row mb-5 last:mb-0">
+      <div className="flex-shrink-0 mb-2 sm:mb-0 sm:w-[60px] sm:mr-4">
+        {title && (
+          <label
+            className={cx('relative break-words', {
+              [style.required]: required,
+              'sm:top-[7px]': !labelAtTop,
+            })}
+          >
+            {title}
+          </label>
+        )}
+      </div>
+      <div className="flex-grow">{children}</div>
+    </div>
+  );
+}
+
+export interface CustomFormProps {
+  fields: CategoryFieldSchema[];
+  onSubmit: (data: Record<string, any>) => void;
+  submitting?: boolean;
+}
+
+export function CustomForm({ fields, onSubmit, submitting }: CustomFormProps) {
+  const { t } = useTranslation();
+  const methods = useForm();
+
+  const getFieldTitle = useCallback(
+    ({ id, title }: CategoryFieldSchema) => {
+      const key = I18N_KEY_BY_ID[id];
+      return key ? t(key) : title;
+    },
+    [t]
+  );
+
+  return (
+    <FormProvider {...methods}>
+      <form className="px-5 sm:px-10 py-7" onSubmit={methods.handleSubmit(onSubmit)}>
+        {fields.map((field) => (
+          <Group
+            key={field.id}
+            title={getFieldTitle(field)}
+            required={field.required}
+            labelAtTop={TOP_LABEL_TYPES.includes(field.type)}
+          >
+            <CustomField {...field} />
+          </Group>
+        ))}
+
+        <Button
+          className="sm:ml-20 w-full sm:max-w-max sm:px-11"
+          type="submit"
+          disabled={submitting}
+        >
+          <SpaceChinese>{t('general.commit')}</SpaceChinese>
+        </Button>
+      </form>
+    </FormProvider>
+  );
+}

--- a/in-app/v1/src/api/category.ts
+++ b/in-app/v1/src/api/category.ts
@@ -1,0 +1,35 @@
+import { UseQueryOptions, useQuery } from 'react-query';
+
+import { http } from '@/leancloud';
+
+export type FieldType = 'text' | 'multi-line' | 'dropdown' | 'multi-select' | 'radios' | 'file';
+
+export interface FieldOption {
+  title: string;
+  value: string;
+}
+
+export interface CategoryFieldSchema {
+  id: string;
+  type: FieldType;
+  title: string;
+  required: boolean;
+  options?: FieldOption[];
+}
+
+export async function fetchCategoryFields(categoryId: string): Promise<CategoryFieldSchema[]> {
+  const { data } = await http.get(`/api/2/categories/${categoryId}/fields`);
+  return data;
+}
+
+export function useCategoryFields(
+  categoryId: string,
+  options?: UseQueryOptions<CategoryFieldSchema[]>
+) {
+  return useQuery({
+    queryKey: ['categoryFields', categoryId],
+    queryFn: () => fetchCategoryFields(categoryId),
+    staleTime: Infinity,
+    ...options,
+  });
+}

--- a/in-app/v1/src/components/Uploader/index.tsx
+++ b/in-app/v1/src/components/Uploader/index.tsx
@@ -47,9 +47,10 @@ export function Uploader<Key extends FileKey>({
     <div className="w-full">
       <div
         className={cx(
-          'w-full h-12 p-4 border rounded flex justify-center items-center active:border active:border-tapBlue hover:border-tapBlue cursor-pointer',
+          'w-full h-12 p-4 border border-dashed rounded flex justify-center items-center cursor-pointer',
           {
-            'border-dashed border-[#D9D9D9]': !error,
+            'active:border active:border-tapBlue hover:border-tapBlue': !error,
+            'border-[#D9D9D9]': !error,
             'border-red-500': error,
           }
         )}

--- a/in-app/v1/src/i18n/locales/zh.json
+++ b/in-app/v1/src/i18n/locales/zh.json
@@ -55,7 +55,8 @@
   "validation": {
     "required": "该内容不能为空",
     "attachment_too_big": "上传失败",
-    "attachment_too_big_text": "附件大小不能超过 {{size}} {{unit}}"
+    "attachment_too_big_text": "附件大小不能超过 {{size}} {{unit}}",
+    "attachment_not_uploaded": "请等待附件上传完毕"
   },
   "network_error": "网络异常，请尝试重连",
   "network_error.retry": "尝试重连"

--- a/in-app/v1/src/leancloud/index.ts
+++ b/in-app/v1/src/leancloud/index.ts
@@ -49,10 +49,12 @@ export const db = app.database();
 export const storage = app.storage();
 
 export const http = axios.create();
-http.interceptors.request.use((config) => ({
-  ...config,
-  headers: {
-    ...config.headers,
-    'X-LC-Session': auth.currentUser?.sessionToken,
-  },
-}));
+http.interceptors.request.use((config) => {
+  if (auth.currentUser) {
+    if (!config.headers) {
+      config.headers = {};
+    }
+    config.headers['X-LC-Session'] = auth.currentUser.sessionToken;
+  }
+  return config;
+});

--- a/in-app/v1/tsconfig.json
+++ b/in-app/v1/tsconfig.json
@@ -10,6 +10,7 @@
     "isolatedModules": true,
     "baseUrl": "src",
     "paths": {
+      "@/*": ["./*"],
       "components/*": ["components/*"],
       "utils/*": ["utils/*"],
       "leancloud/*": ["leancloud/*"],

--- a/in-app/v1/vite.config.js
+++ b/in-app/v1/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@': path.resolve('./src'),
       components: path.resolve('./src/components/'),
       utils: path.resolve('./src/utils/'),
       leancloud: path.resolve('./src/leancloud'),


### PR DESCRIPTION
重写自定义表单和字段，现在的自定义表单是一个真正的 `<form />`。

由于 header 不再固定，ios 下 scrollIntoView 位置不准确的问题得到解决，之前的一些奇技淫巧也没有重新实现。

旧代码没删，留作参考。

---

API 用的还是 v1，单开一个 PR 升 API 版本。