### PR TITLE
refactor: do not fetch all categories on create ticket

### DIFF
--- a/api/category/utils.js
+++ b/api/category/utils.js
@@ -37,35 +37,14 @@ function encodeCategoryObject(category) {
 }
 
 /**
- * @returns {Promise<Category[]>}
- */
-async function fetchCategories() {
-  const query = new AV.Query('Category')
-  const categories = await query.find({ useMasterKey: true })
-  return categories.map(encodeCategoryObject)
-}
-
-/**
- * @returns {Promise<{[key: string]: Category}>}
- */
-async function fetchCategoryMap() {
-  return (await fetchCategories()).reduce((map, category) => {
-    map[category.id] = category
-    return map
-  }, {})
-}
-
-/**
  * @param {string} categoryId
  * @returns {Promise<{ objectId: string; name: string; }>}
  */
-async function getTinyCategoryInfo(categoryId, categories) {
-  const category = categories
-    ? categories[categoryId]
-    : encodeCategoryObject(await new AV.Query('Category').get(categoryId))
+async function getTinyCategoryInfo(categoryId) {
+  const category = await new AV.Query('Category').get(categoryId)
   return {
     objectId: category.id,
-    name: category.name,
+    name: category.get('name'),
   }
 }
 
@@ -81,8 +60,6 @@ function getCategoryPath(categoryId, categoryById) {
 
 module.exports = {
   encodeCategoryObject,
-  fetchCategories,
-  fetchCategoryMap,
   getTinyCategoryInfo,
   getCategoryPath,
 }

--- a/api/ticket/model.js
+++ b/api/ticket/model.js
@@ -8,7 +8,6 @@ const { getTinyGroupInfo } = require('../group/utils')
 const { systemUser, makeTinyUserInfo, getTinyUserInfo } = require('../user/utils')
 const { captureException } = require('../errorHandler')
 const { selectAssignee, getActionStatus, selectGroup } = require('./utils')
-const { fetchCategoryMap } = require('../category/utils')
 
 const ATTRIBUTES = ['nid', 'title', 'category', 'author', 'content', 'status']
 
@@ -183,12 +182,11 @@ class Ticket {
   static async create(data) {
     const assignee = data.assignee || (await selectAssignee(data.category_id))
     const group = await selectGroup(data.category_id)
-    const categories = await fetchCategoryMap()
 
     const obj = new AV.Object('Ticket')
     obj.set('status', TICKET_STATUS.NEW)
     obj.set('title', data.title)
-    obj.set('category', await getTinyCategoryInfo(data.category_id, categories))
+    obj.set('category', await getTinyCategoryInfo(data.category_id))
     obj.set('author', AV.Object.createWithoutData('_User', data.author.id))
     if (assignee) {
       obj.set('assignee', AV.Object.createWithoutData('_User', assignee.id))
@@ -500,8 +498,7 @@ class Ticket {
     }
 
     if (this.isUpdated('category_id')) {
-      const categories = await fetchCategoryMap()
-      this._category = await getTinyCategoryInfo(this.category_id, categories)
+      this._category = await getTinyCategoryInfo(this.category_id)
     }
 
     const object = this._getDirtyAVObject()


### PR DESCRIPTION
Dyin 反馈 DC 侧无法提交工单，看日志判断应该是分类查询默认 limit 100 的问题，给 DC hotfix 了一下（手动设置 limit 为 1000）。

后来改 master 的时候发现不需要每次创建/更新工单时都查询全部分类。这个应该是之前打算冗余 categoryPath 到 ticket 表，但后来取消了，代码没删干净。现在改成只获取指定的分类。