### PR TITLE
feat(in-app): persist user inputs

### DIFF
--- a/in-app/v1/src/App/Tickets/New/CustomForm/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/CustomForm/index.tsx
@@ -44,13 +44,25 @@ export function Group({ title, required, children, labelAtTop }: GroupProps) {
 
 export interface CustomFormProps {
   fields: CategoryFieldSchema[];
+  defaultValues?: Record<string, any>;
+  onChange?: (data: Record<string, any>) => void;
   onSubmit: (data: Record<string, any>) => void;
   submitting?: boolean;
 }
 
-export function CustomForm({ fields, onSubmit, submitting }: CustomFormProps) {
+export function CustomForm({
+  fields,
+  defaultValues,
+  onChange,
+  onSubmit,
+  submitting,
+}: CustomFormProps) {
   const { t } = useTranslation();
-  const methods = useForm();
+  const methods = useForm({ defaultValues });
+
+  if (onChange) {
+    methods.watch(onChange);
+  }
 
   const getFieldTitle = useCallback(
     ({ id, title }: CategoryFieldSchema) => {

--- a/in-app/v1/src/App/Tickets/New/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/index.tsx
@@ -50,7 +50,7 @@ interface NewTicketData {
 
 interface TicketFormProps {
   categoryId: string;
-  onSubmit: (data: NewTicketData) => void;
+  onSubmit: (data: NewTicketData) => Promise<any>;
   submitting?: boolean;
 }
 
@@ -88,8 +88,7 @@ function TicketForm({ categoryId, onSubmit, submitting }: TicketFormProps) {
       content: description,
       form_values: Object.entries(fieldValues).map(([id, value]) => ({ field: id, value })),
       metadata: meta ?? undefined,
-    });
-    clear();
+    }).then(clear);
   };
 
   return (

--- a/in-app/v1/src/App/Tickets/New/usePersistFormData.ts
+++ b/in-app/v1/src/App/Tickets/New/usePersistFormData.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+const STORAGE_KEY = 'TapDesk/formData';
+
+interface FormData {
+  categoryId: string;
+  data: Record<string, any>;
+}
+
+function persistFormData(data: FormData) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+function loadFormData(): FormData | undefined {
+  const encoded = localStorage.getItem(STORAGE_KEY);
+  if (encoded) {
+    return JSON.parse(encoded);
+  }
+}
+function clearFormData() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function usePersistFormData(categoryId: string) {
+  const $timerId = useRef<number | undefined>();
+
+  const initData = useMemo(() => {
+    const data = loadFormData();
+    if (data && data.categoryId === categoryId) {
+      return data.data;
+    }
+  }, [categoryId]);
+
+  const onChange = useCallback(
+    (data: FormData['data']) => {
+      clearTimeout($timerId.current);
+      $timerId.current = setTimeout(() => {
+        persistFormData({ categoryId, data });
+      }, 1000) as any;
+    },
+    [categoryId]
+  );
+
+  return { initData, onChange, clear: clearFormData };
+}


### PR DESCRIPTION
把用户创建工单时临时输入的数据存到 localStorage 中，防止切换页面导致丢失已输入的数据。