### PR TITLE
fix(in-app): upload files

### DIFF
--- a/in-app/v1/package-lock.json
+++ b/in-app/v1/package-lock.json
@@ -18,7 +18,7 @@
         "i18next-browser-languagedetector": "^6.1.2",
         "immer": "^9.0.6",
         "lodash-es": "^4.17.21",
-        "open-leancloud-storage": "0.0.37",
+        "open-leancloud-storage": "0.0.35",
         "query-string": "^7.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -1106,9 +1106,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
-      "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -2812,23 +2812,28 @@
       }
     },
     "node_modules/open-leancloud-storage": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/open-leancloud-storage/-/open-leancloud-storage-0.0.37.tgz",
-      "integrity": "sha512-s5zyntbcxsJQApUUGvN61yC9cQXNpDhaPhYmSStDZhLUY8d/mLdjX0PWWsvu6cJceg8dAHXeI/7jA6DIn0dZdA==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/open-leancloud-storage/-/open-leancloud-storage-0.0.35.tgz",
+      "integrity": "sha512-bwOdxrbTACnwiOX0pCiF9U5lBWaQM4sanL5yLfFFq0ozQh5POKT/oVIE5Mb3/HqJ6JpEZUHDLtAZ2H1jO1GbQQ==",
       "dependencies": {
         "@leancloud/adapter-types": "^5.0.0",
         "@leancloud/platform-adapters-browser": "^1.5.2",
         "@leancloud/platform-adapters-node": "^1.5.2",
-        "@types/debug": "^4.1.7",
-        "@types/node": "^16.10.1",
-        "base64-arraybuffer": "^1.0.1",
-        "debug": "^4.3.2",
+        "@types/debug": "^4.1.5",
+        "@types/node": "^15.12.2",
+        "base64-arraybuffer": "^0.2.0",
+        "debug": "^4.3.1",
         "eventemitter3": "^4.0.7",
-        "leancloud-realtime": "^5.0.0-rc.7",
+        "leancloud-realtime": "^5.0.0-rc.6",
         "leancloud-realtime-plugin-live-query": "^1.2.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2"
       }
+    },
+    "node_modules/open-leancloud-storage/node_modules/@types/node": {
+      "version": "15.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
     "node_modules/optjs": {
       "version": "3.2.2",
@@ -4835,9 +4840,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
-      "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
     },
     "big-integer": {
       "version": "1.6.48",
@@ -6104,22 +6109,29 @@
       }
     },
     "open-leancloud-storage": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/open-leancloud-storage/-/open-leancloud-storage-0.0.37.tgz",
-      "integrity": "sha512-s5zyntbcxsJQApUUGvN61yC9cQXNpDhaPhYmSStDZhLUY8d/mLdjX0PWWsvu6cJceg8dAHXeI/7jA6DIn0dZdA==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/open-leancloud-storage/-/open-leancloud-storage-0.0.35.tgz",
+      "integrity": "sha512-bwOdxrbTACnwiOX0pCiF9U5lBWaQM4sanL5yLfFFq0ozQh5POKT/oVIE5Mb3/HqJ6JpEZUHDLtAZ2H1jO1GbQQ==",
       "requires": {
         "@leancloud/adapter-types": "^5.0.0",
         "@leancloud/platform-adapters-browser": "^1.5.2",
         "@leancloud/platform-adapters-node": "^1.5.2",
-        "@types/debug": "^4.1.7",
-        "@types/node": "^16.10.1",
-        "base64-arraybuffer": "^1.0.1",
-        "debug": "^4.3.2",
+        "@types/debug": "^4.1.5",
+        "@types/node": "^15.12.2",
+        "base64-arraybuffer": "^0.2.0",
+        "debug": "^4.3.1",
         "eventemitter3": "^4.0.7",
-        "leancloud-realtime": "^5.0.0-rc.7",
+        "leancloud-realtime": "^5.0.0-rc.6",
         "leancloud-realtime-plugin-live-query": "^1.2.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "15.14.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+          "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+        }
       }
     },
     "optjs": {

--- a/in-app/v1/package.json
+++ b/in-app/v1/package.json
@@ -20,7 +20,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "immer": "^9.0.6",
     "lodash-es": "^4.17.21",
-    "open-leancloud-storage": "0.0.37",
+    "open-leancloud-storage": "0.0.35",
     "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
升级 open-leancloud-storage 到 0.0.37 后无法上传文件，原因是 rollup 无法解析 open-leancloud-storage 的项目结构，导致引入了针对 node.js 平台的 storage package。但是 webpack 就没问题 🤔 

在 rollup 支持或者调整 sdk 结构之前，先继续用 0.0.35 吧，反正 0.0.35 到 0.0.37 之间也没有功能更新。

