### PR TITLE
feat(next/api): not autofill custom field description any more

### DIFF
--- a/next/api/src/response/ticket-field.ts
+++ b/next/api/src/response/ticket-field.ts
@@ -23,7 +23,7 @@ export class TicketFieldResponse {
         _.keyBy(this.variants, (v) => v.locale),
         (v) => ({
           title: v.title,
-          description: v.description ?? '',
+          description: v.description,
           options: v.options,
         })
       );


### PR DESCRIPTION
不再往自定义字段描述的返回值里填充空字符串。打算后续通过 API 返回内置字段（title、description），这俩本身是没有 description 的，强行返回空字符串很奇怪。