### PR TITLE
fix(next/api): preloader auth options

### DIFF
--- a/next/api/src/orm/query.ts
+++ b/next/api/src/orm/query.ts
@@ -98,10 +98,13 @@ export type QueryBunch<M extends typeof Model> = (query: Query<M>) => Query<M>;
 
 export type OrderType = 'asc' | 'desc';
 
-export interface PreloadOptions<M extends typeof Model, K extends RelationName<M> = RelationName<M>>
-  extends AuthOptions {
+export interface PreloadOptions<
+  M extends typeof Model,
+  K extends RelationName<M> = RelationName<M>
+> {
   data?: Flat<NonNullable<InstanceType<M>[K]>>[];
   onQuery?: (query: QueryBuilder<any>) => void;
+  authOptions?: AuthOptions;
 }
 
 interface QueryPreloader {
@@ -209,11 +212,13 @@ export class Query<M extends typeof Model> {
     if (options) {
       preloader.data = options.data as Model[];
       preloader.queryModifier = options.onQuery;
+      query.preloaders[key] = {
+        preloader,
+        authOptions: options.authOptions,
+      };
+    } else {
+      query.preloaders[key] = { preloader };
     }
-    query.preloaders[key] = {
-      preloader,
-      authOptions: options,
-    };
 
     return query;
   }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -131,7 +131,7 @@ router.get(
     if (params.includeUnreadCount) {
       query.preload('notification', {
         onQuery: (query) => {
-          return query.where('user', '==', currentUser.toPointer()).where('unreadCount', '>', 0);
+          return query.where('user', '==', currentUser.toPointer());
         },
       });
     }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -27,6 +27,7 @@ const includeSchema = {
   includeGroup: yup.bool(),
   includeFiles: yup.bool(),
   includeCategoryPath: yup.bool(),
+  includeUnreadCount: yup.bool(),
 };
 
 const findTicketsSchema = yup.object({
@@ -127,13 +128,15 @@ router.get(
     if (params.includeFiles) {
       query.preload('files');
     }
+    if (params.includeUnreadCount) {
+      query.preload('notification', {
+        onQuery: (query) => {
+          return query.where('user', '==', currentUser.toPointer()).where('unreadCount', '>', 0);
+        },
+      });
+    }
 
-    query
-      .preload('notification', {
-        onQuery: (query) => query.where('user', '==', currentUser.toPointer()),
-      })
-      .skip((params.page - 1) * params.pageSize)
-      .limit(params.pageSize);
+    query.skip((params.page - 1) * params.pageSize).limit(params.pageSize);
 
     let tickets: Ticket[];
     if (params.count) {


### PR DESCRIPTION
之前 AuthOptions 和 PreloadOptions 共用同一个 object，导致设置 onQuery / data 时不再使用 .find 的 AuthOptions 覆盖 Preloader 的 AuthOptions。现在改成使用 PreloadOptions.authOptions 存放 AuthOptions，避免上述情况。

又加了个 `?include=unreadCount` 的开关。