### PR TITLE
feat: ticket field privilege

### DIFF
--- a/next/api/src/model/TicketFieldVariant.ts
+++ b/next/api/src/model/TicketFieldVariant.ts
@@ -17,6 +17,9 @@ export class TicketFieldVariant extends Model {
   title!: string;
 
   @field()
+  titleForCustomerService!: string;
+
+  @field()
   description?: string;
 
   @field()

--- a/next/api/src/model/TicketForm.ts
+++ b/next/api/src/model/TicketForm.ts
@@ -58,6 +58,8 @@ export class TicketForm extends Model {
           presetTicketFields.map((f) => f.id)
         )
       )
+      .where('active', '==', true)
+      .where('visible', '==', true)
       .find({ useMasterKey: true });
     const fieldMap = _.keyBy(presetTicketFields.concat(fields), 'id');
 

--- a/next/api/src/response/ticket-field.ts
+++ b/next/api/src/response/ticket-field.ts
@@ -6,6 +6,16 @@ import type { TicketFieldVariant } from '@/model/TicketFieldVariant';
 export class TicketFieldResponse {
   constructor(readonly field: TicketField, readonly variants?: TicketFieldVariant[]) {}
 
+  protected encodeVariant(variant: TicketFieldVariant) {
+    return {
+      locale: variant.locale,
+      title: variant.title,
+      titleForCustomerService: variant.titleForCustomerService,
+      description: variant.description,
+      options: variant.options,
+    };
+  }
+
   toJSON() {
     const data: Record<string, any> = {
       id: this.field.id,
@@ -13,20 +23,14 @@ export class TicketFieldResponse {
       title: this.field.title,
       defaultLocale: this.field.defaultLocale,
       active: this.field.active,
+      visible: this.field.visible,
       required: this.field.required,
       createdAt: this.field.createdAt,
       updatedAt: this.field.updatedAt,
     };
 
     if (this.variants) {
-      data.variants = _.mapValues(
-        _.keyBy(this.variants, (v) => v.locale),
-        (v) => ({
-          title: v.title,
-          description: v.description,
-          options: v.options,
-        })
-      );
+      data.variants = this.variants.map((v) => this.encodeVariant(v));
     }
 
     return data;

--- a/next/api/src/router/ticket-field.ts
+++ b/next/api/src/router/ticket-field.ts
@@ -1,3 +1,4 @@
+import { Context } from 'koa';
 import Router from '@koa/router';
 import { z } from 'zod';
 import _ from 'lodash';
@@ -32,6 +33,29 @@ function isValidLocale(locale: string): boolean {
 const localeSchema = z.string().refine(isValidLocale, {
   message: 'Unknown locale',
 });
+
+function assertNoDuplicatedLocale(ctx: Context, locales: string[]) {
+  const localeSet = new Set<string>();
+  for (const locale of locales) {
+    if (localeSet.has(locale)) {
+      ctx.throw(400, `variants: locale "${locale}" is duplicated`);
+    }
+    localeSet.add(locale);
+  }
+}
+
+function assertAllVariantsHasOptions(ctx: Context, variants: { options?: any[] }[]) {
+  const index = variants.findIndex((v) => v.options === undefined);
+  ctx.assert(index === -1, 400, `variants[${index}].options is undefined`);
+}
+
+function assertHasDefaultLocale(ctx: Context, locales: string[], defaultLocale: string) {
+  ctx.assert(
+    locales.includes(defaultLocale),
+    400,
+    `The defaultLocale "${defaultLocale}" is missing in variants`
+  );
+}
 
 router.get(
   '/',
@@ -70,19 +94,20 @@ const variantOptionSchema = z.object({
 });
 
 const variantSchema = z.object({
+  locale: localeSchema,
   title: z.string(),
+  titleForCustomerService: z.string(),
   description: z.string().optional(),
   options: z.array(variantOptionSchema).optional(),
 });
 
-const variantsSchema = z.record(variantSchema).refine(_.negate(_.isEmpty), {
-  message: 'The variants cannot be empty',
-});
+const variantsSchema = z.array(variantSchema).min(1);
 
 const createFieldDataSchema = z.object({
   type: z.enum(FIELD_TYPES),
   title: z.string(),
   defaultLocale: localeSchema,
+  visible: z.boolean().optional(),
   required: z.boolean().optional(),
   variants: variantsSchema,
 });
@@ -91,24 +116,14 @@ router.post('/', customerServiceOnly, async (ctx) => {
   const data = createFieldDataSchema.parse(ctx.request.body);
 
   if (OPTION_TYPES.includes(data.type)) {
-    Object.entries(data.variants).forEach(([locale, variant]) => {
-      if (!variant.options) {
-        ctx.throw(400, `The variants.${locale}.options is undefined`);
-      }
-    });
+    assertAllVariantsHasOptions(ctx, data.variants);
   } else {
-    Object.values(data.variants).forEach((variant) => delete variant.options);
+    data.variants.forEach((variant) => delete variant.options);
   }
 
-  Object.keys(data.variants).forEach((locale) => {
-    if (!isValidLocale(locale)) {
-      ctx.throw(400, `variants.${locale}: Unknown locale`);
-    }
-  });
-
-  if (!data.variants[data.defaultLocale]) {
-    ctx.throw(400, 'The defaultLocale is missing in variants');
-  }
+  const locales = data.variants.map((v) => v.locale);
+  assertNoDuplicatedLocale(ctx, locales);
+  assertHasDefaultLocale(ctx, locales, data.defaultLocale);
 
   const field = await TicketField.create(
     {
@@ -117,7 +132,8 @@ router.post('/', customerServiceOnly, async (ctx) => {
       type: data.type,
       title: data.title,
       defaultLocale: data.defaultLocale,
-      required: !!data.required,
+      visible: data.visible ?? true,
+      required: data.required ?? false,
     },
     { useMasterKey: true }
   );
@@ -167,23 +183,12 @@ router.patch('/:id', customerServiceOnly, async (ctx) => {
 
   if (data.variants) {
     if (OPTION_TYPES.includes(field.type)) {
-      Object.entries(data.variants).forEach(([locale, variant]) => {
-        if (!variant.options) {
-          ctx.throw(400, `The variants.${locale}.options is undefined`);
-        }
-      });
+      assertAllVariantsHasOptions(ctx, data.variants);
     }
 
-    Object.keys(data.variants).forEach((locale) => {
-      if (!isValidLocale(locale)) {
-        ctx.throw(400, `variants.${locale}: Unknown locale`);
-      }
-    });
-
+    const locales = data.variants.map((v) => v.locale);
     const defaultLocale = data.defaultLocale ?? field.defaultLocale;
-    if (!data.variants[defaultLocale]) {
-      ctx.throw(400, 'The defaultLocale is missing in variants');
-    }
+    assertHasDefaultLocale(ctx, locales, defaultLocale);
 
     await field.replaceVariants(data.variants);
   }

--- a/next/api/src/router/ticket-field.ts
+++ b/next/api/src/router/ticket-field.ts
@@ -163,6 +163,7 @@ router.get('/:id', async (ctx) => {
 const modifyFieldDataSchema = z.object({
   title: z.string().optional(),
   defaultLocale: localeSchema.optional(),
+  visible: z.boolean().optional(),
   required: z.boolean().optional(),
   active: z.boolean().optional(),
   variants: variantsSchema.optional(),
@@ -174,7 +175,7 @@ router.patch('/:id', customerServiceOnly, async (ctx) => {
 
   if (data.defaultLocale) {
     const locales = data.variants
-      ? Object.keys(data.variants)
+      ? data.variants.map((v) => v.locale)
       : (await field.getVariants()).map((v) => v.locale);
     if (!locales.includes(data.defaultLocale)) {
       ctx.throw(400, 'Variant for default locale is not defined');
@@ -197,6 +198,7 @@ router.patch('/:id', customerServiceOnly, async (ctx) => {
     {
       title: data.title,
       defaultLocale: data.defaultLocale,
+      visible: data.visible,
       required: data.required,
       active: data.active,
     },

--- a/next/web/src/App/Admin/Settings/TicketFields/index.tsx
+++ b/next/web/src/App/Admin/Settings/TicketFields/index.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import cx from 'classnames';
@@ -98,7 +97,7 @@ export function TicketFieldList() {
 
   const handleChangeActive = (value: string) => {
     setPage(1);
-    setActive(value);
+    setActive(value, { replace: true });
   };
 
   return (
@@ -114,11 +113,11 @@ export function TicketFieldList() {
       </div>
 
       <Tabs
-        activeKey={active === 'true' ? '1' : '2'}
-        onChange={(key) => handleChangeActive(key === '1' ? 'true' : 'false')}
+        activeKey={active === 'true' ? 'active' : 'inactive'}
+        onChange={(key) => handleChangeActive(key === 'active' ? 'true' : 'false')}
       >
-        <TabPane tab="启用" key="1" />
-        <TabPane tab="停用" key="2" />
+        <TabPane tab="启用" key="active" />
+        <TabPane tab="停用" key="inactive" />
       </Tabs>
 
       {isLoading && <div className="h-80 my-40 text-center" children={<Spin />} />}
@@ -164,23 +163,24 @@ export function NewTicketField() {
         variants: [
           {
             locale: 'zh-cn',
+            title: '',
+            titleForCustomerService: '',
+            description: '',
           },
         ],
       }}
       onCancel={() => navigate('..')}
       submitting={isLoading}
-      onSubmit={(data) =>
+      onSubmit={(data) => {
         mutate({
-          type: data.type!,
-          title: data.title!,
-          defaultLocale: data.defaultLocale!,
+          type: data.type,
+          title: data.title,
+          visible: data.visible,
           required: data.required,
-          variants: data.variants!.reduce((map, { locale, ...variant }) => {
-            map[locale] = variant;
-            return map;
-          }, {} as any),
-        })
-      }
+          defaultLocale: data.defaultLocale,
+          variants: data.variants,
+        });
+      }}
     />
   );
 }
@@ -189,18 +189,6 @@ export function TicketFieldDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { data, isLoading } = useTicketField(id!);
-  const parsedData = useMemo(() => {
-    if (!data) {
-      return undefined;
-    }
-    return {
-      ...data,
-      variants: Object.entries(data.variants!).map(([locale, variant]) => ({
-        ...variant,
-        locale,
-      })),
-    };
-  }, [data]);
 
   const queryClient = useQueryClient();
   const { mutate, isLoading: isSaving } = useMutation({
@@ -224,20 +212,18 @@ export function TicketFieldDetail() {
   return (
     <TicketFieldForm
       disableType
-      initData={parsedData}
+      initData={data}
       onCancel={() => navigate('..')}
       submitting={isSaving}
-      onSubmit={(data) =>
+      onSubmit={(data) => {
         mutate({
           title: data.title,
-          defaultLocale: data.defaultLocale,
+          visible: data.visible,
           required: data.required,
-          variants: data.variants!.reduce((map, { locale, ...variant }) => {
-            map[locale] = variant;
-            return map;
-          }, {} as any),
-        })
-      }
+          defaultLocale: data.defaultLocale,
+          variants: data.variants!,
+        });
+      }}
     />
   );
 }

--- a/next/web/src/App/Admin/Settings/TicketForms/index.tsx
+++ b/next/web/src/App/Admin/Settings/TicketForms/index.tsx
@@ -146,11 +146,13 @@ export function NewTicketForm() {
       }}
       submitting={isLoading}
       onSubmit={mutate}
+      onCancel={() => navigate('..')}
     />
   );
 }
 
 export function TicketFormDetail() {
+  const navigate = useNavigate();
   const { id } = useParams();
   const { data, isLoading } = useTicketForm(id!, {
     staleTime: 1000 * 60 * 5,
@@ -183,12 +185,8 @@ export function TicketFormDetail() {
     <EditTicketForm
       initData={data}
       submitting={isUpdating}
-      onSubmit={(data) =>
-        mutate({
-          title: data.title,
-          fieldIds: data.fieldIds,
-        })
-      }
+      onSubmit={mutate}
+      onCancel={() => navigate('..')}
     />
   );
 }

--- a/next/web/src/api/ticket-field.ts
+++ b/next/web/src/api/ticket-field.ts
@@ -5,7 +5,9 @@ import { http } from '@/leancloud';
 type TicketFieldType = 'text' | 'multi-line' | 'dropdown' | 'multi-select' | 'radios' | 'file';
 
 export interface TicketFieldVariantSchema {
+  locale: string;
   title: string;
+  titleForCustomerService: string;
   description: string;
   options?: { title: string; value: string }[];
 }
@@ -16,8 +18,9 @@ export interface TicketFieldSchema {
   title: string;
   defaultLocale: string;
   active: boolean;
+  visible: boolean;
   required: boolean;
-  variants?: Record<string, TicketFieldVariantSchema>;
+  variants?: TicketFieldVariantSchema[];
   createdAt: string;
   updatedAt: string;
 }
@@ -83,20 +86,17 @@ export interface CreateTicketFieldData {
   type: TicketFieldType;
   title: string;
   defaultLocale: string;
-  required?: boolean;
-  variants: Record<string, TicketFieldVariantSchema>;
+  required: boolean;
+  visible: boolean;
+  variants: TicketFieldVariantSchema[];
 }
 
 export async function createTicketField(data: CreateTicketFieldData) {
   await http.post('/api/2/ticket-fields', data);
 }
 
-export interface UpdateTicketFieldData {
-  title?: string;
-  defaultLocale?: string;
-  required?: boolean;
+export interface UpdateTicketFieldData extends Partial<Omit<CreateTicketFieldData, 'type'>> {
   active?: boolean;
-  variants?: Record<string, TicketFieldVariantSchema>;
 }
 
 export async function updateTicketField(fieldId: string, data: UpdateTicketFieldData) {

--- a/next/web/src/utils/useSearchParams.tsx
+++ b/next/web/src/utils/useSearchParams.tsx
@@ -7,13 +7,13 @@ import {
   useRef,
   useEffect,
 } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { NavigateOptions, useLocation, useNavigate } from 'react-router-dom';
 import { noop } from 'lodash-es';
 
 export const SearchParamsContext = createContext({
   params: {} as Record<string, string | undefined>,
-  set: noop as (params: Record<string, string | undefined>) => void,
-  merge: noop as (params: Record<string, string | undefined>) => void,
+  set: noop as (params: Record<string, string | undefined>, options?: NavigateOptions) => void,
+  merge: noop as (params: Record<string, string | undefined>, options?: NavigateOptions) => void,
 });
 
 export function SearchParamsProvider({ children }: { children: ReactNode }) {
@@ -32,22 +32,22 @@ export function SearchParamsProvider({ children }: { children: ReactNode }) {
   }, [search]);
 
   const set = useCallback(
-    (newParams: Record<string, string | undefined>) => {
+    (newParams: Record<string, string | undefined>, options?: NavigateOptions) => {
       const searchParams = new URLSearchParams();
       Object.entries(newParams).forEach(([key, value]) => {
         if (value !== undefined) {
           searchParams.set(key, value);
         }
       });
-      navigate({ search: searchParams.toString() });
+      navigate({ search: searchParams.toString() }, options);
     },
     [navigate]
   );
 
   const merge = useCallback(
-    (newParams: Record<string, string | undefined>) => {
+    (newParams: Record<string, string | undefined>, options?: NavigateOptions) => {
       $dirtyParams.current = { ...params, ...$dirtyParams.current, ...newParams };
-      set($dirtyParams.current);
+      set($dirtyParams.current, options);
     },
     [params, set]
   );
@@ -68,8 +68,8 @@ export function useSearchParam(key: string) {
   const [params, { merge }] = useSearchParams();
   const param = useMemo(() => params[key], [params, key]);
   const set = useCallback(
-    (value: string | undefined) => {
-      merge({ [key]: value });
+    (value: string | undefined, options?: NavigateOptions) => {
+      merge({ [key]: value }, options);
     },
     [merge, key]
   );

--- a/resources/schema/TicketField.json
+++ b/resources/schema/TicketField.json
@@ -6,13 +6,6 @@
     "ACL": {
       "type": "ACL"
     },
-    "title": {
-      "type": "String",
-      "v": 2,
-      "required": true,
-      "hidden": false,
-      "read_only": false
-    },
     "objectId": {
       "type": "String"
     },
@@ -33,6 +26,14 @@
       "hidden": false,
       "read_only": false
     },
+    "title": {
+      "type": "String",
+      "v": 2,
+      "required": true,
+      "hidden": false,
+      "read_only": false,
+      "comment": ""
+    },
     "active": {
       "type": "Boolean",
       "v": 2,
@@ -40,6 +41,13 @@
       "hidden": false,
       "read_only": false,
       "comment": ""
+    },
+    "visible": {
+      "type": "Boolean",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
     },
     "required": {
       "type": "Boolean",

--- a/resources/schema/TicketFieldVariant.json
+++ b/resources/schema/TicketFieldVariant.json
@@ -7,6 +7,13 @@
       "hidden": false,
       "read_only": false
     },
+    "titleForCustomerService": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
     "updatedAt": {
       "type": "Date"
     },


### PR DESCRIPTION
## 原始需求

> https://confluence.xindong.com/pages/viewpage.action?pageId=445030432

功能|子功能|描述
-|-|-
工单模板 | 工单字段可见性配置 | 支持客服对于工单字段的可见性进行配置<br />例如：<br />在用户提单的场景下，该模板中的角色ID 不需要用户填写，所以隐藏该字段。<br />但在客服提单的场景下，该模板中的角色ID 需要客服填写，所以需要显示该字段

## 主要改动

### Class schema

TicketField 新增一列 `visible`，表示该字段对用户是否可见。

TicketFieldVariant 新增一列 `titleForCustomerService`，表示该字段向客服显示的标题。

### 自定义字段配置页

新增「权限」配置项，可将设置为「仅限客服」或「用户可编辑」，对应 TicketField.visible。

新增「向客服展示的标题」配置项，对应 TicketFieldVariant.titleForCustomerService。

### API `GET /api/2/categories/:id/fields`

fix: 不再返回 active 为 `false` 的字段（close #469）
feat: 不返回 visible 为 `false` 的字段

## 其他改动

### `[GET|POST|PATCH] /api/2/ticket-fields`

variants 现在是一个数组。

### 新版前端

fix: 表单配置页的取消按钮无效
feat: useSearchParam(s) 的 setter 支持 NavigateOptions（但是并没有起作用，可能是 react-router 的 bug 😑 ）

## Deploy draft

重新导入 TicketField.json，并将已有数据的 visible 设置为 `true`。

重新导入 TicketFieldVariant.json，并将已有数据的 titleForCustomerService 设置为和 title 相同。
