### PR TITLE
refactor(next/api): model relation type

### DIFF
--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -8,6 +8,7 @@ import {
   HasManyThroughPointerArray,
   ModelGetter,
   PointTo,
+  RelationType,
 } from './relation';
 
 export function field(config?: string | Partial<Omit<Field, 'localKey'>>) {
@@ -65,8 +66,8 @@ export function belongsTo(
     }
     const model = target.constructor as typeof Model;
     model.setRelation({
+      type: RelationType.BelongsTo,
       name,
-      type: 'belongsTo',
       model,
       getRelatedModel,
       getRelatedId,
@@ -81,8 +82,8 @@ export function hasOne(getRelatedModel: ModelGetter, pointerKey?: string) {
       pointerKey = model.getClassName().toLowerCase();
     }
     model.setRelation({
+      type: RelationType.HasOne,
       name,
-      type: 'hasOne',
       model,
       getRelatedModel,
       pointerKey,
@@ -105,8 +106,8 @@ export function pointTo(
     }
     const model = target.constructor as typeof Model;
     model.setRelation({
+      type: RelationType.PointTo,
       name,
-      type: 'pointTo',
       model,
       getRelatedModel,
       getRelatedId,
@@ -129,8 +130,8 @@ export function hasManyThroughIdArray(
     }
     const model = target.constructor as typeof Model;
     model.setRelation({
+      type: RelationType.HasManyThroughIdArray,
       name,
-      type: 'hasManyThroughIdArray',
       model,
       getRelatedModel,
       getRelatedIds,
@@ -153,8 +154,8 @@ export function hasManyThroughPointerArray(
     }
     const model = target.constructor as typeof Model;
     model.setRelation({
+      type: RelationType.HasManyThroughPointerArray,
       name,
-      type: 'hasManyThroughPointerArray',
       model,
       getRelatedModel,
       getRelatedIds,
@@ -167,8 +168,8 @@ export function hasManyThroughRelation(getRelatedModel: ModelGetter, relatedKey?
   return (target: Model, name: string) => {
     const model = target.constructor as typeof Model;
     model.setRelation({
+      type: RelationType.HasManyThroughRelation,
       name,
-      type: 'hasManyThroughRelation',
       model,
       getRelatedModel,
       relatedKey: relatedKey ?? name,

--- a/next/api/src/orm/preloader.ts
+++ b/next/api/src/orm/preloader.ts
@@ -14,7 +14,7 @@ import {
 } from './relation';
 import { AuthOptions, AVQuery, QueryBuilder } from './query';
 
-export interface BeforeQueryConntext {
+export interface BeforeQueryContext {
   avQuery: AVQuery;
 }
 
@@ -29,7 +29,7 @@ export interface Item extends Record<string, any> {
 export interface Preloader {
   data?: Item[];
   queryModifier?: (query: QueryBuilder<any>) => void;
-  beforeQuery?: (ctx: BeforeQueryConntext) => void | Promise<void>;
+  beforeQuery?: (ctx: BeforeQueryContext) => void | Promise<void>;
   afterQuery?: (ctx: AfterQueryContext) => void | Promise<void>;
   load: (items: Item[], options?: AuthOptions) => Promise<void>;
 }
@@ -85,7 +85,7 @@ class PointToPreloader {
 
   constructor(private relation: PointTo) {}
 
-  beforeQuery({ avQuery }: BeforeQueryConntext) {
+  beforeQuery({ avQuery }: BeforeQueryContext) {
     avQuery.include(this.relation.includeKey);
   }
 
@@ -209,7 +209,7 @@ class HasManyThroughPointerArrayPreloader {
 
   constructor(private relation: HasManyThroughPointerArray) {}
 
-  beforeQuery({ avQuery }: BeforeQueryConntext) {
+  beforeQuery({ avQuery }: BeforeQueryContext) {
     avQuery.include(this.relation.includeKey);
   }
 

--- a/next/api/src/orm/preloader.ts
+++ b/next/api/src/orm/preloader.ts
@@ -10,6 +10,7 @@ import {
   HasOne,
   PointTo,
   RelationName,
+  RelationType,
 } from './relation';
 import { AuthOptions, AVQuery, QueryBuilder } from './query';
 
@@ -107,7 +108,7 @@ class PointToPreloader {
       });
     } else {
       // 退化成 BelongsToPreloader
-      const preloader = new BelongsToPreloader({ ...this.relation, type: 'belongsTo' });
+      const preloader = new BelongsToPreloader({ ...this.relation, type: RelationType.BelongsTo });
       preloader.queryModifier = this.queryModifier;
       await preloader.load(items, options);
     }
@@ -233,7 +234,7 @@ class HasManyThroughPointerArrayPreloader {
       // 退化成 HasManyThroughIdArrayPreloader
       const preloader = new HasManyThroughIdArrayPreloader({
         ...this.relation,
-        type: 'hasManyThroughIdArray',
+        type: RelationType.HasManyThroughIdArray,
       });
       preloader.queryModifier = this.queryModifier;
       await preloader.load(items, options);
@@ -274,17 +275,17 @@ export function preloaderFactory<M extends typeof Model, N extends RelationName<
     throw new Error(`Cannot create preloader, relation ${name} is not exists`);
   }
   switch (relation.type) {
-    case 'belongsTo':
+    case RelationType.BelongsTo:
       return new BelongsToPreloader(relation);
-    case 'pointTo':
+    case RelationType.PointTo:
       return new PointToPreloader(relation);
-    case 'hasOne':
+    case RelationType.HasOne:
       return new HasOnePreloader(relation);
-    case 'hasManyThroughIdArray':
+    case RelationType.HasManyThroughIdArray:
       return new HasManyThroughIdArrayPreloader(relation);
-    case 'hasManyThroughPointerArray':
+    case RelationType.HasManyThroughPointerArray:
       return new HasManyThroughPointerArrayPreloader(relation);
-    case 'hasManyThroughRelation':
+    case RelationType.HasManyThroughRelation:
       return new HasManyThroughRelationPreloader(relation);
   }
 }

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -3,28 +3,37 @@ import { Model } from './model';
 import { KeysOfType } from './utils';
 
 export type RelationName<M extends typeof Model> = Extract<
-  KeysOfType<InstanceType<M>, Model | Model[] | undefined>,
+  KeysOfType<Required<InstanceType<M>>, Model | Model[]>,
   string
 >;
 
 export type ModelGetter = () => typeof Model;
 
+export enum RelationType {
+  BelongsTo,
+  PointTo,
+  HasOne,
+  HasManyThroughIdArray,
+  HasManyThroughPointerArray,
+  HasManyThroughRelation,
+}
+
 export interface BelongsTo {
   name: string;
-  type: 'belongsTo';
+  type: RelationType.BelongsTo;
   model: typeof Model;
   getRelatedModel: ModelGetter;
   getRelatedId: (instance: any) => string | undefined;
 }
 
 export interface PointTo extends Omit<BelongsTo, 'type'> {
-  type: 'pointTo';
+  type: RelationType.PointTo;
   includeKey: string;
 }
 
 export interface HasOne {
   name: string;
-  type: 'hasOne';
+  type: RelationType.HasOne;
   model: typeof Model;
   getRelatedModel: ModelGetter;
   pointerKey: string;
@@ -32,20 +41,20 @@ export interface HasOne {
 
 export interface HasManyThroughIdArray {
   name: string;
-  type: 'hasManyThroughIdArray';
+  type: RelationType.HasManyThroughIdArray;
   model: typeof Model;
   getRelatedModel: ModelGetter;
   getRelatedIds: (instance: any) => string[] | undefined;
 }
 
 export interface HasManyThroughPointerArray extends Omit<HasManyThroughIdArray, 'type'> {
-  type: 'hasManyThroughPointerArray';
+  type: RelationType.HasManyThroughPointerArray;
   includeKey: string;
 }
 
 export interface HasManyThroughRelation {
   name: string;
-  type: 'hasManyThroughRelation';
+  type: RelationType.HasManyThroughRelation;
   model: typeof Model;
   getRelatedModel: ModelGetter;
   relatedKey: string;


### PR DESCRIPTION
Preloader 的设计不太合理，导致重构范围比较大。先把 relation type 的修改发出来。