### PR TITLE
feat(next/api): HasMany relation

### DIFF
--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -10,8 +10,8 @@ import {
   pointerId,
   pointerIds,
   pointTo,
+  hasManyThroughPointer,
   hasManyThroughPointerArray,
-  hasOne,
   serialize,
 } from '@/orm';
 import { TicketUpdater, UpdateOptions } from '@/ticket/TicketUpdater';
@@ -188,8 +188,8 @@ export class Ticket extends Model {
   @field()
   privateTags?: Tag[];
 
-  @hasOne(() => Notification)
-  notification?: Notification;
+  @hasManyThroughPointer(() => Notification)
+  notifications?: Notification[];
 
   getUrl(): string {
     return `${config.host}/tickets/${this.nid}`;

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -75,20 +75,8 @@ export function belongsTo(
   };
 }
 
-export function hasOne(getRelatedModel: ModelGetter, pointerKey?: string) {
-  return (target: Model, name: string) => {
-    const model = target.constructor as typeof Model;
-    if (pointerKey === undefined) {
-      pointerKey = model.getClassName().toLowerCase();
-    }
-    model.setRelation({
-      type: RelationType.HasOne,
-      name,
-      model,
-      getRelatedModel,
-      pointerKey,
-    });
-  };
+export function hasOne(...args: any[]): any {
+  throw new Error('not implemented');
 }
 
 export function pointTo(

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -86,10 +86,6 @@ export function belongsToThroughPointer(
 // alias
 export const pointTo = belongsToThroughPointer;
 
-export function hasOne(...args: any[]): any {
-  throw new Error('not implemented');
-}
-
 export function hasMany(
   getRelatedModel: ModelGetter,
   foreignKey?: string,

--- a/next/api/src/orm/helpers.ts
+++ b/next/api/src/orm/helpers.ts
@@ -4,6 +4,13 @@ import _ from 'lodash';
 import { Field, Model, SerializedField } from './model';
 import { ModelGetter, RelationType } from './relation';
 
+function lowercaseFirstChar(str: string): string {
+  if (str.length) {
+    return str.slice(0, 1).toLowerCase() + str.slice(1);
+  }
+  return '';
+}
+
 export function field(config?: string | Partial<Omit<Field, 'localKey'>>) {
   return (target: Model, localKey: string) => {
     const model = target.constructor as typeof Model;
@@ -81,6 +88,44 @@ export const pointTo = belongsToThroughPointer;
 
 export function hasOne(...args: any[]): any {
   throw new Error('not implemented');
+}
+
+export function hasMany(
+  getRelatedModel: ModelGetter,
+  foreignKey?: string,
+  foreignKeyField?: string
+) {
+  return (target: Model, field: string) => {
+    const model = target.constructor as typeof Model;
+    foreignKey ??= lowercaseFirstChar(model.getClassName()) + 'Id';
+    model.setRelation({
+      type: RelationType.HasMany,
+      model,
+      field,
+      getRelatedModel,
+      foreignKey,
+      foreignKeyField: foreignKeyField ?? foreignKey,
+    });
+  };
+}
+
+export function hasManyThroughPointer(
+  getRelatedModel: ModelGetter,
+  foreignPointerKey?: string,
+  foreignKeyField?: string
+) {
+  return (target: Model, field: string) => {
+    const model = target.constructor as typeof Model;
+    foreignPointerKey ??= lowercaseFirstChar(model.getClassName());
+    model.setRelation({
+      type: RelationType.HasManyThroughPointer,
+      model,
+      field,
+      getRelatedModel,
+      foreignPointerKey,
+      foreignKeyField: foreignKeyField ?? foreignPointerKey + 'Id',
+    });
+  };
 }
 
 export function hasManyThroughIdArray(getRelatedModel: ModelGetter, idArrayField?: string) {

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -12,8 +12,7 @@ import { TypeCommands } from './command';
 
 type RelationKey<T> = Extract<KeysOfType<Required<T>, Model | Model[]>, string>;
 
-export interface ReloadOptions<M extends Model, K extends RelationKey<M>> extends AuthOptions {
-  data?: M[K];
+export interface ReloadOptions extends AuthOptions {
   onQuery?: (query: QueryBuilder<any>) => void;
 }
 
@@ -159,7 +158,7 @@ export abstract class Model {
 
   static setRelation(relation: Relation) {
     this.relations ??= {};
-    this.relations[relation.name] = relation;
+    this.relations[relation.field] = relation;
   }
 
   static getRelation(name: string): Relation | undefined {
@@ -328,16 +327,13 @@ export abstract class Model {
   reload<M extends Model, K extends RelationKey<M>>(
     this: M,
     key: K,
-    options?: ReloadOptions<M, K>
+    options?: ReloadOptions
   ): Promise<M[K]> {
     if (!this.reloadTasks[key]) {
       this.reloadTasks[key] = (async () => {
         try {
           const preloader = preloaderFactory(this.constructor as any, key);
           if (options) {
-            if (options.data) {
-              preloader.data = [options.data as any];
-            }
             preloader.queryModifier = options.onQuery;
           }
           await preloader.load([this], options);
@@ -353,7 +349,7 @@ export abstract class Model {
   load<M extends Model, K extends RelationKey<M>>(
     this: M,
     key: K,
-    options?: ReloadOptions<M, K>
+    options?: ReloadOptions
   ): Promise<M[K]> {
     if (this[key] !== undefined) {
       return Promise.resolve(this[key]);

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -12,7 +12,6 @@ export type ModelGetter = () => typeof Model;
 export enum RelationType {
   BelongsTo,
   PointTo,
-  HasOne,
   HasManyThroughIdArray,
   HasManyThroughPointerArray,
   HasManyThroughRelation,
@@ -29,14 +28,6 @@ export interface BelongsTo {
 export interface PointTo extends Omit<BelongsTo, 'type'> {
   type: RelationType.PointTo;
   includeKey: string;
-}
-
-export interface HasOne {
-  name: string;
-  type: RelationType.HasOne;
-  model: typeof Model;
-  getRelatedModel: ModelGetter;
-  pointerKey: string;
 }
 
 export interface HasManyThroughIdArray {
@@ -63,7 +54,6 @@ export interface HasManyThroughRelation {
 export type Relation =
   | BelongsTo
   | PointTo
-  | HasOne
   | HasManyThroughIdArray
   | HasManyThroughPointerArray
   | HasManyThroughRelation;

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -11,49 +11,57 @@ export type ModelGetter = () => typeof Model;
 
 export enum RelationType {
   BelongsTo,
-  PointTo,
+  BelongsToThroughPointer,
   HasManyThroughIdArray,
   HasManyThroughPointerArray,
   HasManyThroughRelation,
 }
 
 export interface BelongsTo {
-  name: string;
   type: RelationType.BelongsTo;
   model: typeof Model;
+  field: string;
   getRelatedModel: ModelGetter;
-  getRelatedId: (instance: any) => string | undefined;
+  relatedIdField: string;
 }
 
-export interface PointTo extends Omit<BelongsTo, 'type'> {
-  type: RelationType.PointTo;
-  includeKey: string;
+export interface BelongsToThroughPointer {
+  type: RelationType.BelongsToThroughPointer;
+  model: typeof Model;
+  field: string;
+  getRelatedModel: ModelGetter;
+  pointerKey: string;
+  relatedIdField: string;
 }
 
 export interface HasManyThroughIdArray {
-  name: string;
   type: RelationType.HasManyThroughIdArray;
   model: typeof Model;
+  field: string;
+  idArrayField: string;
   getRelatedModel: ModelGetter;
-  getRelatedIds: (instance: any) => string[] | undefined;
 }
 
-export interface HasManyThroughPointerArray extends Omit<HasManyThroughIdArray, 'type'> {
+export interface HasManyThroughPointerArray {
   type: RelationType.HasManyThroughPointerArray;
-  includeKey: string;
+  model: typeof Model;
+  field: string;
+  pointerArrayKey: string;
+  getRelatedModel: ModelGetter;
+  idArrayField: string;
 }
 
 export interface HasManyThroughRelation {
-  name: string;
   type: RelationType.HasManyThroughRelation;
   model: typeof Model;
+  field: string;
   getRelatedModel: ModelGetter;
   relatedKey: string;
 }
 
 export type Relation =
   | BelongsTo
-  | PointTo
+  | BelongsToThroughPointer
   | HasManyThroughIdArray
   | HasManyThroughPointerArray
   | HasManyThroughRelation;

--- a/next/api/src/orm/relation.ts
+++ b/next/api/src/orm/relation.ts
@@ -12,6 +12,8 @@ export type ModelGetter = () => typeof Model;
 export enum RelationType {
   BelongsTo,
   BelongsToThroughPointer,
+  HasMany,
+  HasManyThroughPointer,
   HasManyThroughIdArray,
   HasManyThroughPointerArray,
   HasManyThroughRelation,
@@ -32,6 +34,24 @@ export interface BelongsToThroughPointer {
   getRelatedModel: ModelGetter;
   pointerKey: string;
   relatedIdField: string;
+}
+
+export interface HasMany {
+  type: RelationType.HasMany;
+  model: typeof Model;
+  field: string;
+  getRelatedModel: ModelGetter;
+  foreignKey: string;
+  foreignKeyField: string;
+}
+
+export interface HasManyThroughPointer {
+  type: RelationType.HasManyThroughPointer;
+  model: typeof Model;
+  field: string;
+  getRelatedModel: ModelGetter;
+  foreignPointerKey: string;
+  foreignKeyField: string;
 }
 
 export interface HasManyThroughIdArray {
@@ -62,6 +82,8 @@ export interface HasManyThroughRelation {
 export type Relation =
   | BelongsTo
   | BelongsToThroughPointer
+  | HasMany
+  | HasManyThroughPointer
   | HasManyThroughIdArray
   | HasManyThroughPointerArray
   | HasManyThroughRelation;

--- a/next/api/src/response/ticket.ts
+++ b/next/api/src/response/ticket.ts
@@ -42,7 +42,7 @@ export class TicketListItemResponse extends BaseTicketResponse {
   toJSON(options?: TicketResponseOptions) {
     return {
       ...super.toJSON(options),
-      unreadCount: this.ticket.notification?.unreadCount,
+      unreadCount: this.ticket.notifications?.reduce((acc, cur) => acc + cur.unreadCount, 0),
     };
   }
 }

--- a/next/api/src/response/ticket.ts
+++ b/next/api/src/response/ticket.ts
@@ -42,7 +42,8 @@ export class TicketListItemResponse extends BaseTicketResponse {
   toJSON(options?: TicketResponseOptions) {
     return {
       ...super.toJSON(options),
-      unreadCount: this.ticket.notifications?.reduce((acc, cur) => acc + cur.unreadCount, 0),
+      // 因为限定 notification.user 为当前用户，所以 notifications 最多只有一个元素
+      unreadCount: this.ticket.notifications?.[0]?.unreadCount,
     };
   }
 }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -130,7 +130,7 @@ router.get(
       query.preload('files');
     }
     if (params.includeUnreadCount) {
-      query.preload('notification', {
+      query.preload('notifications', {
         onQuery: (query) => {
           return query.where('user', '==', currentUser.toPointer());
         },


### PR DESCRIPTION
ORM 的 Relation 依赖 Model instance 上的属性，感觉不太好，最好还是直接依赖数据库中的数据。

尝试改了一下，发现 Model instance 并不总是和已保存的 AV.Object 一一对应（比如反序列化后的 instance 就没有对应的 AV.Object），所以不好改。

目前 Relation 还是依赖部分 Model instance 上的属性，在定义 Relation 时需要保证相关的 Model 定义了 Relation 所需的属性，算是增加了定义时的负担，但提升了一点点使用上的灵活性（反序列化后的 Model 依然可以进行 load）。

这个 PR 重写了各 Relation 的定义，删除了一些 Preloader 上没使用的功能，简化了装饰器的定义。还把之前错误定义的 Ticket `hasOne` Notification 改成了 `hasManyThroughPointer`。可以只看 4e723c89a54d334ee4bf8a78ab61ab3e3fafc859 这个提交。