### PR TITLE
feat(next/api): queues for stage environment

### DIFF
--- a/next/api/src/queue/index.ts
+++ b/next/api/src/queue/index.ts
@@ -3,5 +3,8 @@ import Bull from 'bull';
 const QUEUE_REDIS = process.env.REDIS_URL_QUEUE ?? 'redis://127.0.0.1:6379';
 
 export function createQueue<T>(name: string, options?: Bull.QueueOptions): Bull.Queue<T> {
+  if (process.env.NODE_ENV === 'stage') {
+    name += '_stg';
+  }
   return new Bull<T>(name, QUEUE_REDIS, options);
 }


### PR DESCRIPTION
解决预备环境也会消费队列中的任务的问题。

直接禁止预备环境消费也不好，这样就不能做测试了。所以改为预备环境使用单独的队列。