### PR TITLE
feat: article revision

### DIFF
--- a/Deploy.md
+++ b/Deploy.md
@@ -90,7 +90,9 @@ OpsLog 没有索引，在自用的 LeanTicket 上 40000+ 的数据量已经出�
 
 ### `f400cdc73c0328bb74bf934a17c370c127b4000e`
 
-重新导入 notification.json 。并确保 notification 表有这个索引： user.$id*1_latestActionAt*-1
+重新导入 notification.json 。并确保 notification 表有这个索引： 
+
+- user（正序）联合 latestActionAt（倒序）
 
 ## 2021-10-29
 
@@ -136,7 +138,8 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 
 ### `a862e9fb042178ba2e3304aecdb2ec647f913ac7`
 
-重新导入 Ticket（为 Ticket 增加 latestCustomerServiceReplyAt 与 firstCustomerServiceReplyAt，创建索引 latestCustomerServiceReplyAt\_-1）
+重新导入 Ticket（为 Ticket 增加 latestCustomerServiceReplyAt 与 firstCustomerServiceReplyAt）。
+为 Ticket 创建索引 latestCustomerServiceReplyAt （倒序）
 
 ## 2021-12-28
 
@@ -170,5 +173,5 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 
 导入 FAQ.json FAQRevision.jaon，确保 FAQRevision 有以下两个索引：
 
-- `FAQ.$id_-1_createdAt_-1`
-- `FAQ.$id_-1_meta_-1_createdAt_-1`
+- FAQ（倒序）createdAt（倒序）
+- FAQ（倒序）meta（倒序）createdAt（倒序）

--- a/Deploy.md
+++ b/Deploy.md
@@ -70,6 +70,7 @@
 ### `0a3eaddba44500c70bcc19afc655106a217c82ae`
 
 修改了 Redis 中 Category 的格式，部署后需要清除 Category 的缓存：
+
 ```sh
 > lean cache
 > del categories
@@ -89,8 +90,7 @@ OpsLog 没有索引，在自用的 LeanTicket 上 40000+ 的数据量已经出�
 
 ### `f400cdc73c0328bb74bf934a17c370c127b4000e`
 
-重新导入 notification.json 。并确保 notification 表有这个索引： user.$id_1_latestActionAt_-1
-
+重新导入 notification.json 。并确保 notification 表有这个索引： user.$id*1_latestActionAt*-1
 
 ## 2021-10-29
 
@@ -136,7 +136,7 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 
 ### `a862e9fb042178ba2e3304aecdb2ec647f913ac7`
 
-重新导入 Ticket（为 Ticket 增加 latestCustomerServiceReplyAt 与 firstCustomerServiceReplyAt，创建索引 latestCustomerServiceReplyAt_-1）
+重新导入 Ticket（为 Ticket 增加 latestCustomerServiceReplyAt 与 firstCustomerServiceReplyAt，创建索引 latestCustomerServiceReplyAt\_-1）
 
 ## 2021-12-28
 
@@ -163,3 +163,12 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 ### `bc6fdb6d7f69e937425dd68c369e2690829e86b0`
 
 已删除 ticket filter 功能，可以删除 TicketFilter class。
+
+## 2022-01-18
+
+### `TBD`
+
+导入 FAQ.json FAQRevision.jaon，确保 FAQRevision 有以下两个索引：
+
+- `FAQ.$id_-1_createdAt_-1`
+- `FAQ.$id_-1_meta_-1_createdAt_-1`

--- a/docs/api2.yml
+++ b/docs/api2.yml
@@ -156,6 +156,27 @@ components:
         updatedAt:
           type: string
           format: date-time
+    Revision:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        comment:
+          type: string
+        meta:
+          type: boolean
+        private:
+          type: boolean
+        author:
+          $ref: '#/components/schemas/User'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 security:
   - Session token: []
 paths:
@@ -535,6 +556,26 @@ paths:
         schema:
           type: string
         required: true
+      - name: page
+        in: query
+        schema:
+          type: integer
+        description: 页数，范围：[1, Infinity)
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+        description: 每页数量，范围：[0, 100]，默认为 20
+      - name: meta
+        in: query
+        schema:
+          type: boolean
+        description: 为真时仅返回发布、撤销发布记录，为假时仅返回内容修改记录
+      - name: count
+        in: query
+        schema:
+          type: boolean
+        description: 为 `true` 时通过 x-total-count 返回符合条件的工单数量
     get:
       tags: ['Knowladge base']
       summary: 获取文章修改记录
@@ -546,4 +587,4 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Category'
+                  $ref: '#/components/schemas/Revision'

--- a/docs/api2.yml
+++ b/docs/api2.yml
@@ -527,3 +527,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Category'
+
+  /api/2/articles/{id}/revisions:
+    parameters:
+      - name: id
+        in: path
+        schema:
+          type: string
+        required: true
+    get:
+      tags: ['Knowladge base']
+      summary: 获取文章修改记录
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Category'

--- a/next/api/src/model/Article.ts
+++ b/next/api/src/model/Article.ts
@@ -2,7 +2,7 @@ import mem from 'mem';
 import QuickLRU from 'quick-lru';
 
 import { ACLBuilder, field, Model, ModifyOptions, serialize } from '@/orm';
-import { User } from '@sentry/node';
+import { User } from './User';
 import { ArticleRevision } from './ArticleRevision';
 
 export class Article extends Model {

--- a/next/api/src/model/ArticleRevision.ts
+++ b/next/api/src/model/ArticleRevision.ts
@@ -22,6 +22,18 @@ export class ArticleRevision extends Model {
   @serialize()
   content?: string;
 
+  @field('archived')
+  @serialize()
+  private?: boolean;
+
+  @field()
+  @serialize()
+  meta?: boolean;
+
+  @field()
+  @serialize()
+  comment?: string;
+
   @pointerId(() => User)
   @serialize()
   authorId!: string;

--- a/next/api/src/model/ArticleRevision.ts
+++ b/next/api/src/model/ArticleRevision.ts
@@ -1,0 +1,35 @@
+import { field, Model, pointerId, pointTo, serialize } from '@/orm';
+import { Article } from './Article';
+import { TinyUserInfo, User } from './User';
+
+export interface TinyArticleRevision {
+  objectId: string;
+  title: string;
+  content?: string;
+  author: TinyUserInfo;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class ArticleRevision extends Model {
+  protected static className = 'FAQRevision';
+
+  @field('question')
+  @serialize()
+  title!: string;
+
+  @field('answer')
+  @serialize()
+  content?: string;
+
+  @pointerId(() => User)
+  @serialize()
+  authorId!: string;
+
+  @pointTo(() => User)
+  author?: User;
+
+  @pointerId(() => Article, 'FAQ')
+  @serialize()
+  articleId!: string;
+}

--- a/next/api/src/response/article-revision.ts
+++ b/next/api/src/response/article-revision.ts
@@ -1,0 +1,27 @@
+import { ArticleRevision } from '@/model/ArticleRevision';
+import xss from '@/utils/xss';
+import { UserResponse } from './user';
+
+export class ArticleRevisionListItemResponse {
+  constructor(readonly revision: ArticleRevision) {}
+
+  toJSON() {
+    return {
+      id: this.revision.id,
+      title: this.revision.title,
+      author: this.revision.author ? new UserResponse(this.revision.author) : undefined,
+      createdAt: this.revision.createdAt.toISOString(),
+      updatedAt: this.revision.updatedAt.toISOString(),
+    };
+  }
+}
+
+export class ArticleRevisionResponse extends ArticleRevisionListItemResponse {
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      content: this.revision.content,
+      contentSafeHTML: this.revision.content ? xss.process(this.revision.content) : undefined,
+    };
+  }
+}

--- a/next/api/src/response/article-revision.ts
+++ b/next/api/src/response/article-revision.ts
@@ -1,4 +1,5 @@
 import { ArticleRevision } from '@/model/ArticleRevision';
+import htmlify from '@/utils/htmlify';
 import xss from '@/utils/xss';
 import { UserResponse } from './user';
 
@@ -8,8 +9,11 @@ export class ArticleRevisionListItemResponse {
   toJSON() {
     return {
       id: this.revision.id,
+      meta: this.revision.meta,
+      private: this.revision.private,
       title: this.revision.title,
       author: this.revision.author ? new UserResponse(this.revision.author) : undefined,
+      comment: this.revision.comment,
       createdAt: this.revision.createdAt.toISOString(),
       updatedAt: this.revision.updatedAt.toISOString(),
     };
@@ -21,7 +25,9 @@ export class ArticleRevisionResponse extends ArticleRevisionListItemResponse {
     return {
       ...super.toJSON(),
       content: this.revision.content,
-      contentSafeHTML: this.revision.content ? xss.process(this.revision.content) : undefined,
+      contentSafeHTML: this.revision.content
+        ? xss.process(htmlify(this.revision.content))
+        : undefined,
     };
   }
 }

--- a/next/api/src/router/article.ts
+++ b/next/api/src/router/article.ts
@@ -48,9 +48,9 @@ router.get('/', pagination(20), boolean('private'), async (ctx) => {
 });
 
 const createArticalSchema = yup.object({
-  title: yup.string(),
-  content: yup.string(),
-  private: yup.boolean().optional(),
+  title: yup.string().required(),
+  content: yup.string().required(),
+  private: yup.boolean(),
 });
 router.post('/', auth, customerServiceOnly, async (ctx) => {
   const currentUser = ctx.state.currentUser as User;
@@ -107,7 +107,7 @@ router.get('/:id/categories', auth, customerServiceOnly, async (ctx) => {
 });
 
 const getRevisionsSchema = yup.object({
-  meta: yup.boolean().optional(),
+  meta: yup.boolean(),
 });
 router.get('/:id/revisions', auth, customerServiceOnly, pagination(100), async (ctx) => {
   const article = ctx.state.article as Article;
@@ -118,7 +118,7 @@ router.get('/:id/revisions', auth, customerServiceOnly, pagination(100), async (
   const query = ArticleRevision.queryBuilder()
     .where('FAQ', '==', article.toPointer())
     .orderBy('createdAt', 'desc')
-    .skip((page - 1) * pageSize)
+    .paginate(page, pageSize)
     .limit(pageSize)
     .preload('author');
 
@@ -161,10 +161,10 @@ const getACL = (prvt: boolean) => {
 };
 
 const updateArticalSchema = yup.object({
-  title: yup.string().optional(),
-  content: yup.string().optional(),
-  private: yup.boolean().optional(),
-  comment: yup.string().optional(),
+  title: yup.string(),
+  content: yup.string(),
+  private: yup.boolean(),
+  comment: yup.string(),
 });
 router.patch('/:id', auth, customerServiceOnly, async (ctx) => {
   const currentUser = ctx.state.currentUser as User;

--- a/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
@@ -1,27 +1,35 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { SiMarkdown } from 'react-icons/si';
 
-import { CreateArticleData } from '@/api/article';
+import { UpsertArticleData } from '@/api/article';
 import { Button, Checkbox, Form, FormInstance, Input, Popover } from '@/components/antd';
 
 export interface EditArticleProps {
-  initData?: CreateArticleData;
+  initData?: UpsertArticleData;
   submitting?: boolean;
-  onSubmit: (data: CreateArticleData) => void;
+  onSubmit: (data: UpsertArticleData) => void;
   onCancel?: () => void;
+  acceptComment?: boolean;
 }
 
-interface FormData extends Omit<CreateArticleData, 'private'> {
+interface FormData extends Omit<UpsertArticleData, 'private'> {
   public: boolean;
 }
 
-export function EditArticleForm({ initData, submitting, onSubmit, onCancel }: EditArticleProps) {
+export function EditArticleForm({
+  initData,
+  submitting,
+  onSubmit,
+  onCancel,
+  acceptComment = true,
+}: EditArticleProps) {
   const { control, handleSubmit } = useForm<FormData>({
     defaultValues: { ...initData, public: !initData?.private },
   });
 
   const $antForm = useRef<FormInstance>(null!);
+  const [comment, setComment] = useState('');
 
   return (
     <div className="flex flex-col h-full">
@@ -30,7 +38,7 @@ export function EditArticleForm({ initData, submitting, onSubmit, onCancel }: Ed
           ref={$antForm}
           layout="vertical"
           onFinish={handleSubmit(({ ['public']: pblc, ...data }) =>
-            onSubmit({ ...data, private: !pblc })
+            onSubmit({ ...data, private: !pblc, comment })
           )}
         >
           <Controller
@@ -87,6 +95,14 @@ export function EditArticleForm({ initData, submitting, onSubmit, onCancel }: Ed
         <Button className="mr-4" disabled={submitting} type="link" onClick={onCancel}>
           取消
         </Button>
+        {acceptComment && (
+          <Input
+            className="!mr-6"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="为此次改动添加注释"
+          />
+        )}
       </div>
     </div>
   );

--- a/next/web/src/App/Admin/Settings/Articles/Revision.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/Revision.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumb, Spin, Table, Tag, Typography } from 'antd';
+import { Breadcrumb, Radio, Spin, Table, Tag, Typography } from 'antd';
 import {
   ArticleRevisionListItem,
   useArticleRevision,
@@ -7,19 +7,28 @@ import {
 import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { usePage, usePageSize } from '@/utils/usePage';
+import { useSearchParam } from '@/utils/useSearchParams';
 
 const { Column } = Table;
 const { Title } = Typography;
+
+const MetaQueryValue: { [key: string]: boolean | undefined } = {
+  true: true,
+  false: false,
+  unset: undefined,
+};
 
 export function ArticleRevisions() {
   const { id: articleId } = useParams();
   const [page, { set: setPage }] = usePage();
   const [pageSize = 20, setPageSize] = usePageSize();
+  const [metaFilter = 'unset', setMetaFilter] = useSearchParam('meta');
 
   const { data: revisions, totalCount, isLoading } = useArticleRevisions(articleId!, {
     page,
     pageSize,
     count: 1,
+    meta: MetaQueryValue[metaFilter],
     queryOptions: {
       keepPreviousData: true,
     },
@@ -39,6 +48,20 @@ export function ArticleRevisions() {
         </Breadcrumb>
       </div>
       <Title level={2}>历史</Title>
+
+      <div className="flex flex-row mb-4">
+        <div className="grow">
+          <Radio.Group
+            value={metaFilter}
+            onChange={(e) => setMetaFilter(e.target.value)}
+            size="small"
+          >
+            <Radio.Button value="unset">全部</Radio.Button>
+            <Radio.Button value="false">内容变更</Radio.Button>
+            <Radio.Button value="true">发布记录</Radio.Button>
+          </Radio.Group>
+        </div>
+      </div>
 
       {isLoading && <div className="h-80 my-40 text-center" children={<Spin />} />}
 

--- a/next/web/src/App/Admin/Settings/Articles/Revision.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/Revision.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { usePage, usePageSize } from '@/utils/usePage';
 import { useSearchParam } from '@/utils/useSearchParams';
+import { QueryResult } from '@/components/common';
 
 const { Column } = Table;
 const { Title } = Typography;
@@ -132,39 +133,39 @@ export function ArticleRevisions() {
 export function ArticleRevisionDetail() {
   const { id: articleId, rid: revisionId } = useParams();
 
-  const { data: revision, isLoading } = useArticleRevision(articleId!, revisionId!);
-
-  {
-    isLoading && <div className="h-80 my-40 text-center" children={<Spin />} />;
-  }
+  const result = useArticleRevision(articleId!, revisionId!);
 
   return (
-    <div className="p-10">
-      <div className="flex justify-center mb-1">
-        <Breadcrumb className="grow">
-          <Breadcrumb.Item>
-            <Link to="../../..">文章</Link>
-          </Breadcrumb.Item>
-          <Breadcrumb.Item>
-            <Link to="../..">{articleId}</Link>
-          </Breadcrumb.Item>
-          <Breadcrumb.Item>
-            <Link to="..">历史</Link>
-          </Breadcrumb.Item>
-          <Breadcrumb.Item className="text-gray-300">{revisionId}</Breadcrumb.Item>
-        </Breadcrumb>
-      </div>
-      <Title level={2}>{revision?.title}</Title>
-      {revision && (
+    <QueryResult className="p-10" result={result}>
+      {({ data: revision }) => (
         <>
-          {revision.contentSafeHTML && (
-            <div
-              className="markdown-body"
-              dangerouslySetInnerHTML={{ __html: revision.contentSafeHTML }}
-            />
+          <div className="flex justify-center mb-1">
+            <Breadcrumb className="grow">
+              <Breadcrumb.Item>
+                <Link to="../../..">文章</Link>
+              </Breadcrumb.Item>
+              <Breadcrumb.Item>
+                <Link to="../..">{articleId}</Link>
+              </Breadcrumb.Item>
+              <Breadcrumb.Item>
+                <Link to="..">历史</Link>
+              </Breadcrumb.Item>
+              <Breadcrumb.Item className="text-gray-300">{revisionId}</Breadcrumb.Item>
+            </Breadcrumb>
+          </div>
+          <Title level={2}>{revision?.title}</Title>
+          {revision && (
+            <>
+              {revision.contentSafeHTML && (
+                <div
+                  className="markdown-body"
+                  dangerouslySetInnerHTML={{ __html: revision.contentSafeHTML }}
+                />
+              )}
+            </>
           )}
         </>
       )}
-    </div>
+    </QueryResult>
   );
 }

--- a/next/web/src/App/Admin/Settings/Articles/Revision.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/Revision.tsx
@@ -1,0 +1,147 @@
+import { Breadcrumb, Spin, Table, Tag, Typography } from 'antd';
+import {
+  ArticleRevisionListItem,
+  useArticleRevision,
+  useArticleRevisions,
+} from '@/api/article-revision';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+import { usePage, usePageSize } from '@/utils/usePage';
+
+const { Column } = Table;
+const { Title } = Typography;
+
+export function ArticleRevisions() {
+  const { id: articleId } = useParams();
+  const [page, { set: setPage }] = usePage();
+  const [pageSize = 20, setPageSize] = usePageSize();
+
+  const { data: revisions, totalCount, isLoading } = useArticleRevisions(articleId!, {
+    page,
+    pageSize,
+    count: 1,
+    queryOptions: {
+      keepPreviousData: true,
+    },
+  });
+
+  return (
+    <div className="p-10">
+      <div className="flex justify-center mb-1">
+        <Breadcrumb className="grow">
+          <Breadcrumb.Item>
+            <Link to="../../..">文章</Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item>
+            <Link to="../..">{articleId}</Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item className="text-gray-300">历史</Breadcrumb.Item>
+        </Breadcrumb>
+      </div>
+      <Title level={2}>历史</Title>
+
+      {isLoading && <div className="h-80 my-40 text-center" children={<Spin />} />}
+
+      {revisions && (
+        <Table
+          dataSource={revisions}
+          rowKey="id"
+          pagination={{
+            pageSize,
+            onShowSizeChange: (page, size) => {
+              setPage(page);
+              setPageSize(size);
+            },
+            current: page,
+            onChange: setPage,
+            total: totalCount,
+          }}
+        >
+          <Column
+            title="变更"
+            dataIndex="id"
+            render={(id, revision: ArticleRevisionListItem) =>
+              revision.meta ? (
+                <>
+                  {revision.private ? '撤销发布' : '发布'}{' '}
+                  {revision.comment && (
+                    <span className="text-gray-400 text-sm">{revision.comment}</span>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div>
+                    <Link to={revision.id}>
+                      <Tag>
+                        <code>{revision.id.slice(17)}</code>
+                      </Tag>
+                      {revision.title}
+                    </Link>
+                  </div>
+                  {revision.comment && (
+                    <span className="text-gray-400 text-sm">{revision.comment}</span>
+                  )}
+                </>
+              )
+            }
+          />
+          <Column
+            title="修改者"
+            dataIndex="author"
+            render={(_, revision: ArticleRevisionListItem) => revision.author.nickname}
+          />
+          <Column
+            title="修改时间"
+            dataIndex="createdAt"
+            render={(value) => new Date(value).toLocaleString()}
+          />
+          {/* <Column
+            title="操作"
+            dataIndex="id"
+            render={() => <Button size="small">恢复到该版本</Button>}
+          /> */}
+        </Table>
+      )}
+    </div>
+  );
+}
+
+export function ArticleRevisionDetail() {
+  const { id: articleId, rid: revisionId } = useParams();
+
+  const { data: revision, isLoading } = useArticleRevision(articleId!, revisionId!);
+
+  {
+    isLoading && <div className="h-80 my-40 text-center" children={<Spin />} />;
+  }
+
+  return (
+    <div className="p-10">
+      <div className="flex justify-center mb-1">
+        <Breadcrumb className="grow">
+          <Breadcrumb.Item>
+            <Link to="../../..">文章</Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item>
+            <Link to="../..">{articleId}</Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item>
+            <Link to="..">历史</Link>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item className="text-gray-300">{revisionId}</Breadcrumb.Item>
+        </Breadcrumb>
+      </div>
+      <Title level={2}>{revision?.title}</Title>
+      {revision && (
+        <>
+          {revision.contentSafeHTML && (
+            <div
+              className="markdown-body"
+              dangerouslySetInnerHTML={{ __html: revision.contentSafeHTML }}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/next/web/src/App/Admin/Settings/Articles/index.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/index.tsx
@@ -100,7 +100,7 @@ export function Articles() {
           <Column
             title="状态"
             dataIndex="private"
-            render={(title, article: Article) => <ArticleStatus article={article} />}
+            render={(_, article: Article) => <ArticleStatus article={article} />}
           />
           <Column
             title="创建日期"
@@ -186,6 +186,7 @@ export function NewArticle() {
       submitting={isLoading}
       onSubmit={mutate}
       onCancel={() => navigate('..')}
+      acceptComment={false}
     />
   );
 }
@@ -283,25 +284,27 @@ export function ArticleDetail() {
         </Breadcrumb>
         <div>
           <TogglePrivateButton size="small" article={article} />{' '}
-          {article.private ? (
-            <Dropdown.Button
-              size="small"
-              onClick={() => navigate('edit')}
-              overlay={
-                <Menu>
-                  <Menu.Item key="1" danger onClick={() => deleteAtcl(id!)}>
-                    删除
-                  </Menu.Item>
-                </Menu>
-              }
-            >
-              编辑
-            </Dropdown.Button>
-          ) : (
-            <Button size="small" onClick={() => navigate('edit')}>
-              编辑
-            </Button>
-          )}
+          <Dropdown.Button
+            size="small"
+            onClick={() => navigate('edit')}
+            overlay={
+              <Menu>
+                <Menu.Item key="0">
+                  <Link to="./revisions">历史</Link>
+                </Menu.Item>
+                {article.private && (
+                  <>
+                    <Menu.Divider />
+                    <Menu.Item key="1" danger onClick={() => deleteAtcl(id!)}>
+                      删除
+                    </Menu.Item>
+                  </>
+                )}
+              </Menu>
+            }
+          >
+            编辑
+          </Dropdown.Button>
         </div>
       </div>
       <Title level={2}>{article.title}</Title>

--- a/next/web/src/App/Admin/Settings/Articles/index.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/index.tsx
@@ -10,8 +10,7 @@ import {
   Empty,
   Menu,
   message,
-  Popover,
-  Select,
+  Radio,
   Spin,
   Table,
   Tag,
@@ -32,19 +31,19 @@ import { CategorySchema } from '@/api/category';
 import { EditArticleForm } from './EditArticleForm';
 // We should move them to @component
 import { CategoryPath, useGetCategoryPath } from '../../Tickets/TicketView/TicketList';
+import { useSearchParam } from '@/utils/useSearchParams';
 
 const { Column } = Table;
-const { Option } = Select;
 const { Title } = Typography;
 
-const PrivateQueryValue = {
+const PrivateQueryValue: { [key: string]: boolean| undefined } = {
   true: true,
   false: false,
   unset: undefined,
 };
 
 export function Articles() {
-  const [filter, setFilter] = useState<'true' | 'false' | 'unset'>('unset');
+  const [filter = 'unset', setFilter] = useSearchParam('status');
   const [page, { set: setPage }] = usePage();
   const [pageSize = 20, setPageSize] = usePageSize();
   const { data: articles, totalCount, isLoading } = useArticles({
@@ -60,17 +59,17 @@ export function Articles() {
   return (
     <div className="px-10 pt-10">
       <h1 className="text-[#2f3941] text-[26px] font-normal">文章</h1>
-      <div className="flex flex-row mb-4">
+      <div className="flex flex-row items-center mb-4">
         <div className="grow">
-          <Select value={filter} onChange={setFilter}>
-            <Option value="unset">全部</Option>
-            <Option value="true">未发布</Option>
-            <Option value="false">已发布</Option>
-          </Select>
+          <Radio.Group value={filter} onChange={(e) => setFilter(e.target.value)} size="small">
+            <Radio.Button value="unset">全部</Radio.Button>
+            <Radio.Button value="true">未发布</Radio.Button>
+            <Radio.Button value="false">已发布</Radio.Button>
+          </Radio.Group>
         </div>
         <Link to="new">
           <Button type="primary" ghost>
-            新增文章
+            创建文章
           </Button>
         </Link>
       </div>

--- a/next/web/src/App/Admin/Settings/index.tsx
+++ b/next/web/src/App/Admin/Settings/index.tsx
@@ -16,6 +16,7 @@ import TriggerDetail from './Automations/Triggers/Detail';
 import TimeTriggers from './Automations/TimeTriggers';
 import NewTimeTrigger from './Automations/TimeTriggers/New';
 import TimeTriggerDetail from './Automations/TimeTriggers/Detail';
+import { ArticleRevisionDetail, ArticleRevisions } from './Articles/Revision';
 
 const SettingRoutes = () => (
   <Routes>
@@ -57,6 +58,10 @@ const SettingRoutes = () => (
       <Route path=":id">
         <Route index element={<ArticleDetail />} />
         <Route path="edit" element={<EditArticle />} />
+        <Route path="revisions">
+          <Route index element={<ArticleRevisions />} />
+          <Route path=":rid" element={<ArticleRevisionDetail />} />
+        </Route>
       </Route>
     </Route>
   </Routes>

--- a/next/web/src/api/article-revision.ts
+++ b/next/web/src/api/article-revision.ts
@@ -16,6 +16,7 @@ export interface ArticleRevisionListItem {
 export interface FetchArticleRevisionsOptions {
   page?: number;
   pageSize?: number;
+  meta?: boolean;
   count?: any;
 }
 
@@ -50,7 +51,7 @@ export function useArticleRevisions(
   { queryOptions, ...options }: UseArticleRevisionsOptions = {}
 ) {
   const { data, ...results } = useQuery({
-    queryKey: ['articles', id, 'revisions'],
+    queryKey: ['articles', id, 'revisions', options],
     queryFn: () => fetchArticleRevisions(id, options),
     ...queryOptions,
   });

--- a/next/web/src/api/article-revision.ts
+++ b/next/web/src/api/article-revision.ts
@@ -1,0 +1,87 @@
+import { http } from '@/leancloud';
+import { UseQueryOptions, useQuery } from 'react-query';
+import { UserSchema } from './user';
+
+export interface ArticleRevisionListItem {
+  id: string;
+  meta?: boolean;
+  private?: boolean;
+  title?: string;
+  author: UserSchema;
+  comment?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FetchArticleRevisionsOptions {
+  page?: number;
+  pageSize?: number;
+  count?: any;
+}
+
+export interface FetchArticleRevisionsResult {
+  data: ArticleRevisionListItem[];
+  totalCount?: number;
+}
+
+export async function fetchArticleRevisions(
+  articleId: string,
+  options: FetchArticleRevisionsOptions
+): Promise<FetchArticleRevisionsResult> {
+  const { data, headers } = await http.get<ArticleRevisionListItem[]>(
+    `/api/2/articles/${articleId}/revisions`,
+    {
+      params: options,
+    }
+  );
+  const totalCount = headers['x-total-count'];
+  return {
+    data,
+    totalCount: totalCount ? parseInt(totalCount) : undefined,
+  };
+}
+
+export interface UseArticleRevisionsOptions extends FetchArticleRevisionsOptions {
+  queryOptions?: UseQueryOptions<FetchArticleRevisionsResult, Error>;
+}
+
+export function useArticleRevisions(
+  id: string,
+  { queryOptions, ...options }: UseArticleRevisionsOptions = {}
+) {
+  const { data, ...results } = useQuery({
+    queryKey: ['articles', id, 'revisions'],
+    queryFn: () => fetchArticleRevisions(id, options),
+    ...queryOptions,
+  });
+
+  return {
+    ...results,
+    data: data?.data,
+    totalCount: data?.totalCount,
+  };
+}
+
+export interface ArticleRevision extends ArticleRevisionListItem {
+  content?: string;
+  contentSafeHTML?: string;
+}
+
+export async function fetchArticleRevision(articleId: string, revisionId: string) {
+  const { data } = await http.get<ArticleRevision>(
+    `/api/2/articles/${articleId}/revisions/${revisionId}`
+  );
+  return data;
+}
+
+export function useArticleRevision(
+  articleId: string,
+  revisionId: string,
+  options?: UseQueryOptions<ArticleRevision, Error>
+) {
+  return useQuery({
+    queryKey: ['articles', articleId, 'revisions', revisionId],
+    queryFn: () => fetchArticleRevision(articleId, revisionId),
+    ...options,
+  });
+}

--- a/next/web/src/api/article.ts
+++ b/next/web/src/api/article.ts
@@ -67,17 +67,19 @@ export function useArticle(id: string, options?: UseQueryOptions<Article, Error>
   });
 }
 
-export interface CreateArticleData {
+export interface UpsertArticleData {
   title: string;
   content: string;
   private?: boolean;
 }
 
-export async function createArticle(data: CreateArticleData) {
+export async function createArticle(data: UpsertArticleData) {
   await http.post('/api/2/articles', data);
 }
 
-export type UpdateArticleData = Partial<CreateArticleData>;
+export interface UpdateArticleData extends Partial<UpsertArticleData> {
+  comment?: string;
+}
 
 export async function updateArticle(id: string, data: UpdateArticleData) {
   await http.patch(`/api/2/articles/${id}`, data);

--- a/resources/schema/FAQ.json
+++ b/resources/schema/FAQ.json
@@ -33,22 +33,15 @@
       "required": true,
       "hidden": false
     },
-    "priority_ios": {
-      "type": "Number",
-      "v": 2,
-      "required": false,
-      "auto_increment": false,
-      "hidden": false
-    },
     "createdAt": {
       "type": "Date"
     },
-    "priority_android": {
-      "type": "Number",
+    "deletedAt": {
+      "type": "Date",
       "v": 2,
       "required": false,
-      "auto_increment": false,
-      "hidden": false
+      "hidden": false,
+      "read_only": false
     },
     "answer": {
       "type": "String",
@@ -56,5 +49,26 @@
       "required": false,
       "hidden": false
     }
-  }
+  },
+  "permissions": {
+    "create": {
+      "*": true
+    },
+    "find": {
+      "*": true
+    },
+    "get": {
+      "*": true
+    },
+    "update": {
+      "*": true
+    },
+    "delete": {
+      "*": true
+    },
+    "add_fields": {
+      "*": true
+    }
+  },
+  "indexes": []
 }

--- a/resources/schema/FAQRevision.json
+++ b/resources/schema/FAQRevision.json
@@ -1,0 +1,124 @@
+{
+  "schema": {
+    "archived": {
+      "type": "Boolean"
+    },
+    "updatedAt": {
+      "type": "Date"
+    },
+    "meta": {
+      "type": "Boolean"
+    },
+    "private": {
+      "type": "Boolean"
+    },
+    "ACL": {
+      "type": "ACL",
+      "default": {
+        "*": {
+          "read": true,
+          "write": true
+        }
+      }
+    },
+    "FAQ": {
+      "type": "Pointer",
+      "v": 2,
+      "className": "FAQ",
+      "required": true,
+      "hidden": false,
+      "read_only": false
+    },
+    "objectId": {
+      "type": "String"
+    },
+    "question": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false,
+      "comment": ""
+    },
+    "createdAt": {
+      "type": "Date"
+    },
+    "author": {
+      "type": "Pointer",
+      "v": 2,
+      "className": "_User",
+      "required": true,
+      "hidden": false,
+      "read_only": false,
+      "comment": ""
+    },
+    "answer": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "comment": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "archive": {
+      "type": "Boolean",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    }
+  },
+  "permissions": {
+    "create": {
+      "roles": [],
+      "users": []
+    },
+    "find": {
+      "*": true
+    },
+    "get": {
+      "*": true
+    },
+    "update": {
+      "roles": [],
+      "users": []
+    },
+    "delete": {
+      "roles": [],
+      "users": []
+    },
+    "add_fields": {
+      "roles": [],
+      "users": []
+    }
+  },
+  "indexes": [
+    {
+      "v": 2,
+      "key": {
+        "FAQ.$id": -1,
+        "createdAt": -1
+      },
+      "name": "-user-FAQ.$id_-1_createdAt_-1",
+      "ns": "-.FAQRevision",
+      "background": true
+    },
+    {
+      "v": 2,
+      "key": {
+        "FAQ.$id": -1,
+        "meta": -1,
+        "createdAt": -1
+      },
+      "name": "-user-FAQ.$id_-1_meta_-1_createdAt_-1",
+      "ns": "-.FAQRevision",
+      "background": true
+    }
+  ]
+}


### PR DESCRIPTION
没做完，但先发出来求合（因为发现有冲突了（已解决））。

目前完成的功能是完整可用的。之后会继续做：

- Revision 改造成双向链表，支持向前向后看版本。
- Revision 增加 diff 视图
- Revision 详情页支持回滚
- 增加 FAQFeedback（评价实际关联到 Revision）。
- Article 增加 tag 属性（支持过滤）