### PR TITLE
feat(next/api): allow dev tier users to submit tickets under certain categories

### DIFF
--- a/next/api/src/config/index.ts
+++ b/next/api/src/config/index.ts
@@ -4,6 +4,8 @@ export { Config };
 
 export const config = {
   allowModifyEvaluation: boolean(process.env.ALLOW_MUTATE_EVALUATION),
+  categoriesAllowDevUserSubmitTicket:
+    process.env.CATEGORIES_ALLOW_DEV_USER_SUBMIT_TICKET?.split('\n') || [],
   enableLeanCloudIntegration: boolean(process.env.ENABLE_LEANCLOUD_INTEGRATION),
   gravatarURL: 'https://www.gravatar.com/avatar',
   host: getHost(),

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -187,7 +187,7 @@ export class User extends Model {
     return responses.map((res) => res.data);
   }
 
-  async hasDizLeanCloudApp(): Promise<boolean> {
+  async hasBizLeanCloudApp(): Promise<boolean> {
     await this.fetchAuthData();
     const accounts = await this.getLeanCloudAccounts();
     return accounts.some((account) => !!account.current_support_service);

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -187,16 +187,8 @@ export class User extends Model {
     return responses.map((res) => res.data);
   }
 
-  async canCreateTicket(): Promise<boolean> {
-    if (!config.enableLeanCloudIntegration) {
-      return true;
-    }
-    if (await this.isCustomerService()) {
-      return true;
-    }
-    if (!(await this.fetchAuthData())) {
-      return false;
-    }
+  async hasDizLeanCloudApp(): Promise<boolean> {
+    await this.fetchAuthData();
     const accounts = await this.getLeanCloudAccounts();
     return accounts.some((account) => !!account.current_support_service);
   }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -189,7 +189,7 @@ async function canCreateTicket(
   if (config.categoriesAllowDevUserSubmitTicket.includes(data.categoryId)) {
     return true;
   }
-  if (await user.hasDizLeanCloudApp()) {
+  if (await user.hasBizLeanCloudApp()) {
     return true;
   }
   if (await user.isCustomerService()) {

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -179,13 +179,33 @@ const ticketDataSchema = yup.object({
   appId: yup.string(), // LeanCloud app id
 });
 
+async function canCreateTicket(
+  user: User,
+  data: yup.InferType<typeof ticketDataSchema>
+): Promise<boolean> {
+  if (!config.enableLeanCloudIntegration) {
+    return true;
+  }
+  if (config.categoriesAllowDevUserSubmitTicket.includes(data.categoryId)) {
+    return true;
+  }
+  if (await user.hasDizLeanCloudApp()) {
+    return true;
+  }
+  if (await user.isCustomerService()) {
+    return true;
+  }
+  return false;
+}
+
 router.post('/', async (ctx) => {
   const currentUser = ctx.state.currentUser as User;
-  if (!(await currentUser.canCreateTicket())) {
+  const data = ticketDataSchema.validateSync(ctx.request.body);
+
+  if (!(await canCreateTicket(currentUser, data))) {
     return ctx.throw(403, 'This account is not qualified to create ticket');
   }
 
-  const data = ticketDataSchema.validateSync(ctx.request.body);
   const creator = new TicketCreator()
     .setAuthor(currentUser)
     .setTitle(data.title)


### PR DESCRIPTION
### 简要说明
允许开发版用户提交某些分类下的工单。

### 使用方式
在设置了 `ENABLE_LEANCLOUD_INTEGRATION` 环境变量的前提下，新增 `CATEGORIES_ALLOW_DEV_USER_SUBMIT_TICKET` 环境变量，值为分类 ID，多个 ID 请用换行符分隔。用户提交这些分类下的工单时不再判断该用户是否拥有商用版应用。

使用环境变量是因为这个功能是 LeanTicket 独有的，不想因此修改表结构。而且目前来看这样的分类不会太多，环境变量也能 hold 住。

### 其他改动
先判断用户是否有商用版应用，没有时再判断该用户是否为客服。之前是反过来的。
客服提工单的频率远低于用户提工单的频率，多数情况下可以少请求 _User 和 _Role 表一次，降低开销 :wise-me: