### PR TITLE
feat: MarkdownEditor

### DIFF
--- a/next/web/package-lock.json
+++ b/next/web/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^1.4.2",
         "@sentry/react": "^6.16.1",
         "@sentry/tracing": "^6.16.1",
+        "@toast-ui/react-editor": "^3.1.2",
         "antd": "^4.18.3",
         "axios": "^0.24.0",
         "classnames": "^2.3.1",
@@ -930,6 +931,32 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
+    "node_modules/@toast-ui/editor": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.1.2.tgz",
+      "integrity": "sha512-3If4pnDULrduyiWP9gLZKNqeK2FatzNa8APU6eV/bEDAXJqbCJFahNDivMPtR5k7iZMtkdE1ez1FphueHyjmUQ==",
+      "dependencies": {
+        "dompurify": "^2.3.3",
+        "prosemirror-commands": "^1.1.9",
+        "prosemirror-history": "^1.1.3",
+        "prosemirror-inputrules": "^1.1.3",
+        "prosemirror-keymap": "^1.1.4",
+        "prosemirror-model": "^1.14.1",
+        "prosemirror-state": "^1.3.4",
+        "prosemirror-view": "^1.18.7"
+      }
+    },
+    "node_modules/@toast-ui/react-editor": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/react-editor/-/react-editor-3.1.2.tgz",
+      "integrity": "sha512-MhqaGDwUV8lH7Te1YDkRcKsh22UM4HWxg8GO0lGqLQLEc27LZeiOUi6+B+D7tE+i+yQz6KvydlVpFzkOr1uaog==",
+      "dependencies": {
+        "@toast-ui/editor": "^3.1.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -1691,6 +1718,11 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
       "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
+    },
+    "node_modules/dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.42",
@@ -3389,6 +3421,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
+      "integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3597,6 +3634,79 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.1.tgz",
+      "integrity": "sha512-S/IkpXfpuLFsRynC2HQ5iYROUPiZskKS1+ClcWycGJvj4HMb/mVfeEkQrixYxgTl96EAh+RZQNWPC06GZXk5tQ==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "dependencies": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.3.3.tgz",
+      "integrity": "sha512-9NLVXy1Sfa2G6qPqhWMkEvwQQMTw7OyTqOZbJaGQWsCeH3hH5Cw+c5eNaLM1Uu75EyKLsEZhJ93XpHJBa6RX8A==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.23.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.6.tgz",
+      "integrity": "sha512-B4DAzriNpI/AVoW0Lu6SVfX00jZZQxOVwdBQEjWlRbCdT9V0pvk4GQJ3JTFaib+b6BcPdRZ3MjWXz2xvV1rblA==",
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/prr": {
@@ -4593,6 +4703,11 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.2.tgz",
+      "integrity": "sha512-ku6MFrwEVSVmXLvy3dYph3LAMNS0890K7fabn+0YIRQ2T96T9F4gkFf0vf0WW0JUraNWwGRtInEpH7yO4tbQZg=="
+    },
     "node_modules/rtl-css-js": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.5.tgz",
@@ -5220,6 +5335,11 @@
       "peerDependencies": {
         "vite": ">2.0.0-0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -5924,6 +6044,29 @@
         "mini-svg-data-uri": "^1.2.3"
       }
     },
+    "@toast-ui/editor": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.1.2.tgz",
+      "integrity": "sha512-3If4pnDULrduyiWP9gLZKNqeK2FatzNa8APU6eV/bEDAXJqbCJFahNDivMPtR5k7iZMtkdE1ez1FphueHyjmUQ==",
+      "requires": {
+        "dompurify": "^2.3.3",
+        "prosemirror-commands": "^1.1.9",
+        "prosemirror-history": "^1.1.3",
+        "prosemirror-inputrules": "^1.1.3",
+        "prosemirror-keymap": "^1.1.4",
+        "prosemirror-model": "^1.14.1",
+        "prosemirror-state": "^1.3.4",
+        "prosemirror-view": "^1.18.7"
+      }
+    },
+    "@toast-ui/react-editor": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/react-editor/-/react-editor-3.1.2.tgz",
+      "integrity": "sha512-MhqaGDwUV8lH7Te1YDkRcKsh22UM4HWxg8GO0lGqLQLEc27LZeiOUi6+B+D7tE+i+yQz6KvydlVpFzkOr1uaog==",
+      "requires": {
+        "@toast-ui/editor": "^3.1.2"
+      }
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -6550,6 +6693,11 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
       "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
+    },
+    "dompurify": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.42",
@@ -7685,6 +7833,11 @@
         "wrappy": "1"
       }
     },
+    "orderedmap": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
+      "integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7818,6 +7971,79 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
       "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w=="
+    },
+    "prosemirror-commands": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.2.1.tgz",
+      "integrity": "sha512-S/IkpXfpuLFsRynC2HQ5iYROUPiZskKS1+ClcWycGJvj4HMb/mVfeEkQrixYxgTl96EAh+RZQNWPC06GZXk5tQ==",
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-history": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.2.0.tgz",
+      "integrity": "sha512-B9v9xtf4fYbKxQwIr+3wtTDNLDZcmMMmGiI3TAPShnUzvo+Rmv1GiUrsQChY1meetHl7rhML2cppF3FTs7f7UQ==",
+      "requires": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "prosemirror-inputrules": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+      "integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-keymap": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.1.5.tgz",
+      "integrity": "sha512-8SZgPH3K+GLsHL2wKuwBD9rxhsbnVBTwpHCO4VUO5GmqUQlxd/2GtBVWTsyLq4Dp3N9nGgPd3+lZFKUDuVp+Vw==",
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "prosemirror-model": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.16.1.tgz",
+      "integrity": "sha512-r1/w0HDU40TtkXp0DyKBnFPYwd8FSlUSJmGCGFv4DeynfeSlyQF2FD0RQbVEMOe6P3PpUSXM6LZBV7W/YNZ4mA==",
+      "requires": {
+        "orderedmap": "^1.1.0"
+      }
+    },
+    "prosemirror-state": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-transform": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.3.3.tgz",
+      "integrity": "sha512-9NLVXy1Sfa2G6qPqhWMkEvwQQMTw7OyTqOZbJaGQWsCeH3hH5Cw+c5eNaLM1Uu75EyKLsEZhJ93XpHJBa6RX8A==",
+      "requires": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "prosemirror-view": {
+      "version": "1.23.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.23.6.tgz",
+      "integrity": "sha512-B4DAzriNpI/AVoW0Lu6SVfX00jZZQxOVwdBQEjWlRbCdT9V0pvk4GQJ3JTFaib+b6BcPdRZ3MjWXz2xvV1rblA==",
+      "requires": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
     },
     "prr": {
       "version": "1.0.1",
@@ -8502,6 +8728,11 @@
       "integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
       "dev": true
     },
+    "rope-sequence": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.2.tgz",
+      "integrity": "sha512-ku6MFrwEVSVmXLvy3dYph3LAMNS0890K7fabn+0YIRQ2T96T9F4gkFf0vf0WW0JUraNWwGRtInEpH7yO4tbQZg=="
+    },
     "rtl-css-js": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.5.tgz",
@@ -8955,6 +9186,11 @@
         "@babel/plugin-transform-react-jsx": "^7.14.3",
         "resolve": "^1.20.0"
       }
+    },
+    "w3c-keyname": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/next/web/package.json
+++ b/next/web/package.json
@@ -15,6 +15,7 @@
     "@headlessui/react": "^1.4.2",
     "@sentry/react": "^6.16.1",
     "@sentry/tracing": "^6.16.1",
+    "@toast-ui/react-editor": "^3.1.2",
     "antd": "^4.18.3",
     "axios": "^0.24.0",
     "classnames": "^2.3.1",

--- a/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
@@ -1,9 +1,13 @@
 import { useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { SiMarkdown } from 'react-icons/si';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import { Editor } from '@toast-ui/react-editor';
+import { useLocalStorage } from 'react-use';
 
 import { UpsertArticleData } from '@/api/article';
 import { Button, Checkbox, Form, FormInstance, Input, Popover } from '@/components/antd';
+import { useMarkdownEditor } from '@/components/MarkdownEditor';
 
 export interface EditArticleProps {
   initData?: UpsertArticleData;
@@ -31,6 +35,8 @@ export function EditArticleForm({
   const $antForm = useRef<FormInstance>(null!);
   const [comment, setComment] = useState('');
 
+  const [editor, getValue] = useMarkdownEditor(initData?.content ?? '');
+
   return (
     <div className="flex flex-col h-full">
       <div className="grow p-10 overflow-y-auto">
@@ -38,7 +44,12 @@ export function EditArticleForm({
           ref={$antForm}
           layout="vertical"
           onFinish={handleSubmit(({ ['public']: pblc, ...data }) =>
-            onSubmit({ ...data, private: !pblc, comment })
+            onSubmit({
+              ...data,
+              content: getValue() ?? '',
+              private: !pblc,
+              comment,
+            })
           )}
         >
           <Controller
@@ -48,35 +59,16 @@ export function EditArticleForm({
             defaultValue=""
             render={({ field, fieldState: { error } }) => (
               <Form.Item
-                label="标题"
-                htmlFor="title"
                 validateStatus={error ? 'error' : undefined}
                 help={error?.message}
                 style={{ marginBottom: 16 }}
               >
-                <Input {...field} id="title" autoFocus />
+                <Input {...field} id="title" autoFocus placeholder="标题" />
               </Form.Item>
             )}
           />
-          <Form.Item
-            label={
-              <span className="inline-flex items-center">
-                描述
-                <Popover placement="right" content="支持 Markdown 语法">
-                  <SiMarkdown className="ml-1 w-4 h-4" />
-                </Popover>
-              </span>
-            }
-            htmlFor="content"
-            style={{ marginBottom: 16 }}
-          >
-            <Controller
-              control={control}
-              name="content"
-              render={({ field }) => <Input.TextArea {...field} id="content" rows={8} />}
-            />
-          </Form.Item>
-          <Form.Item>
+          <Form.Item style={{ marginBottom: 16 }}>{editor}</Form.Item>
+          <Form.Item style={{ marginBottom: 0 }}>
             <Controller
               control={control}
               name="public"

--- a/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/EditArticleForm.tsx
@@ -35,11 +35,13 @@ export function EditArticleForm({
   const $antForm = useRef<FormInstance>(null!);
   const [comment, setComment] = useState('');
 
-  const [editor, getValue] = useMarkdownEditor(initData?.content ?? '');
+  const [editor, getValue] = useMarkdownEditor(initData?.content ?? '', {
+    height: 'calc(100vh - 220px)',
+  });
 
   return (
     <div className="flex flex-col h-full">
-      <div className="grow p-10 overflow-y-auto">
+      <div className="grow py-6 px-10 overflow-y-auto">
         <Form
           ref={$antForm}
           layout="vertical"

--- a/next/web/src/App/Admin/Settings/index.tsx
+++ b/next/web/src/App/Admin/Settings/index.tsx
@@ -70,7 +70,7 @@ const SettingRoutes = () => (
 export default function Setting() {
   return (
     <div className="h-full bg-white flex">
-      <SettingMenu className="w-[330px] bg-[#F8F9F9] shrink-0" />
+      <SettingMenu className="w-[300px] bg-[#F8F9F9] shrink-0" />
       <div className="grow overflow-auto border-l border-l-[#D8DCDE]">
         <div className="h-full min-w-[770px]">
           <SettingRoutes />

--- a/next/web/src/api/article.ts
+++ b/next/web/src/api/article.ts
@@ -71,6 +71,7 @@ export interface UpsertArticleData {
   title: string;
   content: string;
   private?: boolean;
+  comment?: string;
 }
 
 export async function createArticle(data: UpsertArticleData) {

--- a/next/web/src/components/MarkdownEditor/index.tsx
+++ b/next/web/src/components/MarkdownEditor/index.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react';
+import { Editor, EditorProps } from '@toast-ui/react-editor';
+import '@toast-ui/editor/dist/i18n/zh-cn';
+import { useLocalStorage } from 'react-use';
+import { storage } from '@/leancloud';
+
+export interface MarkdownEditorProps
+  extends Omit<EditorProps, 'hooks' | 'toolbarItems' | 'initialValue' | 'ref'> {}
+
+const toolbarItems = [
+  ['heading', 'bold', 'italic', 'strike'],
+  ['ul', 'ol', 'indent', 'outdent'],
+  ['table', 'image', 'link'],
+  ['hr', 'quote'],
+  ['code', 'codeblock'],
+];
+
+const hooks: EditorProps['hooks'] = {
+  addImageBlobHook: (blob, cb) => {
+    storage
+      .upload((blob as File).name ?? 'filename', blob)
+      .then((result) => cb(result.url))
+      .catch((error) => alert(error.message));
+  },
+};
+
+export function useMarkdownEditor(initialValue: string, props: MarkdownEditorProps = {}) {
+  const $editorRef = useRef<Editor>(null);
+  const getValue = useCallback(() => $editorRef.current?.getInstance().getMarkdown(), []);
+  // 本想记住用户的选择的，发现少事件
+  const [editorMode = 'markdown', setEditorMode] = useLocalStorage<'markdown' | 'wysiwyg'>(
+    'TapDesk:editorMode'
+  );
+
+  const {
+    height = 'calc(100vh - 180px)',
+    initialEditType = editorMode,
+    previewStyle = 'vertical',
+    ...rest
+  } = props;
+
+  const editor = (
+    <Editor
+      {...props}
+      ref={$editorRef}
+      initialValue={initialValue}
+      height={height}
+      initialEditType={initialEditType}
+      previewStyle={previewStyle}
+      useCommandShortcut={true}
+      usageStatistics={false}
+      hooks={hooks}
+      toolbarItems={toolbarItems}
+      language="zh-CN"
+    />
+  );
+
+  return [editor, getValue, $editorRef] as const;
+}

--- a/next/web/src/components/MarkdownEditor/index.tsx
+++ b/next/web/src/components/MarkdownEditor/index.tsx
@@ -33,15 +33,16 @@ export function useMarkdownEditor(initialValue: string, props: MarkdownEditorPro
   );
 
   const {
-    height = 'calc(100vh - 180px)',
+    height = '500px',
     initialEditType = editorMode,
     previewStyle = 'vertical',
+    autofocus = false,
     ...rest
   } = props;
 
   const editor = (
     <Editor
-      {...props}
+      {...rest}
       ref={$editorRef}
       initialValue={initialValue}
       height={height}
@@ -52,6 +53,7 @@ export function useMarkdownEditor(initialValue: string, props: MarkdownEditorPro
       hooks={hooks}
       toolbarItems={toolbarItems}
       language="zh-CN"
+      autofocus={autofocus}
     />
   );
 


### PR DESCRIPTION
分别对比了用 https://ui.toast.com/tui-editor 与  https://github.com/RIP21/react-simplemde-editor 实现的效果，

最终选了 tui-editor，主要原因是支持所见既所得模式（后者不仅仅是缺少该模式，包括图片上传 URL 插入这些按钮的逻辑，对非技术背景用户来说要求还是有一点点高）。虽然后者的自动保存草稿等功能非常实用，但相对来说还是比较容易自己实现的。

剩余 Todo 的事情：

- 保存草稿
- 上传图片的时候需要有个 loading 效果
