### PR TITLE
feat(next/api): use commas to split env

### DIFF
--- a/next/api/src/config/index.ts
+++ b/next/api/src/config/index.ts
@@ -5,7 +5,7 @@ export { Config };
 export const config = {
   allowModifyEvaluation: boolean(process.env.ALLOW_MUTATE_EVALUATION),
   categoriesAllowDevUserSubmitTicket:
-    process.env.CATEGORIES_ALLOW_DEV_USER_SUBMIT_TICKET?.split('\n') || [],
+    process.env.CATEGORIES_ALLOW_DEV_USER_SUBMIT_TICKET?.split(',') || [],
   enableLeanCloudIntegration: boolean(process.env.ENABLE_LEANCLOUD_INTEGRATION),
   gravatarURL: 'https://www.gravatar.com/avatar',
   host: getHost(),


### PR DESCRIPTION
还是用逗号分隔吧，不然没法 `$(lean env)` 这么玩了。