### PR TITLE
feat: do not validate locale anymore

### DIFF
--- a/api/ticketField/index.js
+++ b/api/ticketField/index.js
@@ -54,7 +54,6 @@ router.get(
       locale = locale.toLowerCase()
       return locale === 'zh' ? 'zh-cn' : locale
     })
-    .custom((value) => value === 'default' || LOCALES.includes(value))
     .optional(),
   catchError(async (req, res) => {
     let { size, skip, search, ids, includeVariant, locale } = req.query


### PR DESCRIPTION
https://xindong.slack.com/archives/C01UB1M7BBK/p1643273821029000

### 解决方案

不再验证 locale 参数。这东西本来也不应该限制的太严格。
目前不支持 locale 会 fallback 到默认 locale。