### PR TITLE
feat: empty content placeholder

### DIFF
--- a/modules/Ticket/ReplyCard.js
+++ b/modules/Ticket/ReplyCard.js
@@ -177,6 +177,20 @@ function useTruncateReply() {
   }
 }
 
+function ReplyContent({ children }) {
+  if (!children) {
+    return (
+      <p className="text-muted">
+        <em>No description provided.</em>
+      </p>
+    )
+  }
+  return <div className="markdown-body" dangerouslySetInnerHTML={{ __html: children }} />
+}
+ReplyContent.propTypes = {
+  children: PropTypes.string,
+}
+
 export function ReplyCard({ data, onDeleted, ticketId, onEdit }) {
   const { t } = useTranslation()
   const { isCustomerService, currentUser, addNotification } = useContext(AppContext)
@@ -256,10 +270,7 @@ export function ReplyCard({ data, onDeleted, ticketId, onEdit }) {
       </Card.Header>
       <Card.Body ref={containerRef} className={css.content}>
         <BaiduTranslate enabled={translationEnabled}>
-          <div
-            className="markdown-body"
-            dangerouslySetInnerHTML={{ __html: myxss.process(data.content_HTML) }}
-          />
+          <ReplyContent>{myxss.process(data.content_HTML)}</ReplyContent>
         </BaiduTranslate>
         {imageFiles.length > 0 && (
           <div>


### PR DESCRIPTION
之前恢复了允许工单描述为空的逻辑（方便已经填写自定义字段的用户省略描述），这样没有描述就显得空空的，所以加了个占位提示。

模仿 GitHub 的效果：
![image](https://user-images.githubusercontent.com/33412425/152726169-8d40441b-fe03-4baf-8ff6-430976aacc46.png)
