### PR TITLE
feat(next/api): category service

### DIFF
--- a/next/api/src/controller/category.ts
+++ b/next/api/src/controller/category.ts
@@ -13,9 +13,10 @@ import {
 import { ParseBoolPipe } from '@/common/pipe';
 import { auth, customerServiceOnly } from '@/middleware';
 import { getPublicArticle } from '@/model/Article';
-import { Category, CategoryManager } from '@/model/Category';
+import { Category } from '@/model/Category';
 import { TicketForm } from '@/model/TicketForm';
 import { ArticleResponse } from '@/response/article';
+import { CategoryService } from '@/service/category';
 import {
   CategoryResponse,
   CategoryFieldResponse,
@@ -24,7 +25,7 @@ import {
 
 class FindCategoryPipe {
   static async transform(id: string): Promise<Category> {
-    const category = await CategoryManager.find(id);
+    const category = await CategoryService.get(id);
     if (!category) {
       throw new HttpError(404, `Category ${id} is not exist`);
     }
@@ -37,7 +38,7 @@ export class CategoryController {
   @Get()
   @ResponseBody(CategoryResponse)
   async findAll(@Query('active', new ParseBoolPipe({ keepUndefined: true })) active?: boolean) {
-    const categories = await CategoryManager.get();
+    const categories = await CategoryService.getAll();
     if (active !== undefined) {
       return active
         ? categories.filter((c) => c.deletedAt === undefined)
@@ -49,7 +50,7 @@ export class CategoryController {
   @Get('groups')
   @UseMiddlewares(auth, customerServiceOnly)
   async findGroups() {
-    const categories = await CategoryManager.get();
+    const categories = await CategoryService.getAll();
     return categories
       .filter((c) => c.groupId)
       .map((c) => ({

--- a/next/api/src/model/Category.ts
+++ b/next/api/src/model/Category.ts
@@ -1,8 +1,5 @@
-import mem from 'mem';
 import _ from 'lodash';
-import QuickLRU from 'quick-lru';
 
-import { redis } from '@/cache';
 import { Model, field, pointerIds, pointerId, pointTo, serialize } from '@/orm';
 import { Article } from './Article';
 import { Group } from './Group';
@@ -68,109 +65,5 @@ export class Category extends Model {
       objectId: this.id,
       name: this.name,
     };
-  }
-}
-
-class RedisCache {
-  static CACHE_KEY = 'categories';
-  static CACHE_TTL = 60 * 5; // 5 min;
-
-  private static async fetch(): Promise<Category[] | undefined> {
-    const data = await redis.hvals(RedisCache.CACHE_KEY);
-    if (data.length) {
-      return data.map((item) => Category.fromJSON(JSON.parse(item)));
-    }
-  }
-
-  private static async set(categories: Category[]) {
-    const p = redis.pipeline();
-    p.del(RedisCache.CACHE_KEY);
-    categories.forEach((c) => p.hset(RedisCache.CACHE_KEY, c.id, JSON.stringify(c)));
-    p.expire(RedisCache.CACHE_KEY, RedisCache.CACHE_TTL);
-    await p.exec();
-  }
-
-  static async get(): Promise<Category[]> {
-    const cached = await RedisCache.fetch();
-    if (cached) {
-      return cached;
-    }
-
-    const categories = await Category.queryBuilder().limit(1000).find();
-    RedisCache.set(categories).catch((error) => {
-      // TODO(sdjdd): Sentry
-      console.error(`[Cache] Set ${RedisCache.CACHE_KEY} failed:`, error);
-    });
-    return categories;
-  }
-}
-
-const getCategoryMap = mem((categories: Category[]) => _.keyBy(categories, 'id'), {
-  cache: new QuickLRU({ maxSize: 1 }),
-});
-
-export class CategoryManager {
-  private static getTask?: Promise<Category[]>;
-
-  static get(): Promise<Category[]> {
-    if (!CategoryManager.getTask) {
-      const timer = setTimeout(() => delete CategoryManager.getTask, 5000);
-      CategoryManager.getTask = (async () => {
-        try {
-          return await RedisCache.get();
-        } catch (error) {
-          clearTimeout(timer);
-          delete CategoryManager.getTask;
-          throw error;
-        }
-      })();
-    }
-    return CategoryManager.getTask;
-  }
-
-  static async find(id: string): Promise<Category | undefined> {
-    const categories = await CategoryManager.get();
-    return categories.find((c) => c.id === id);
-  }
-
-  // TODO: 还有进一步优化的空间
-  static async getCategoryPath(id: string): Promise<Category[]> {
-    const categories = await CategoryManager.get();
-    const categoryMap = getCategoryMap(categories);
-    const path: Category[] = [];
-    let category = categoryMap[id];
-    while (category) {
-      path.push(category);
-      if (!category.parentId) {
-        break;
-      }
-      category = categoryMap[category.parentId];
-    }
-
-    return path.reverse();
-  }
-
-  static async getSubCategories(id: string | string[]): Promise<Category[]> {
-    let categories = await this.get();
-    const parentIds = _.castArray(id);
-    const result: Category[] = [];
-
-    while (parentIds.length) {
-      const parentId = parentIds.shift()!;
-      const rest: Category[] = [];
-
-      for (const category of categories) {
-        if (category.parentId === parentId) {
-          result.push(category);
-          parentIds.push(category.id);
-        } else {
-          rest.push(category);
-        }
-      }
-
-      categories = rest;
-    }
-
-    return result;
   }
 }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -5,7 +5,7 @@ import { config } from '@/config';
 import * as yup from '@/utils/yup';
 import { SortItem, auth, include, parseRange, sort } from '@/middleware';
 import { Model, QueryBuilder } from '@/orm';
-import { Category, CategoryManager } from '@/model/Category';
+import { Category } from '@/model/Category';
 import { Group } from '@/model/Group';
 import { Organization } from '@/model/Organization';
 import { Reply } from '@/model/Reply';
@@ -16,6 +16,7 @@ import { TicketResponse, TicketListItemResponse } from '@/response/ticket';
 import { ReplyResponse } from '@/response/reply';
 import { Vacation } from '@/model/Vacation';
 import { TicketCreator, TicketUpdater } from '@/ticket';
+import { CategoryService } from '@/service/category';
 
 const router = new Router().use(auth);
 
@@ -82,7 +83,7 @@ router.get(
     const categoryIds = new Set(params.categoryId);
     if (params.rootCategoryId) {
       categoryIds.add(params.rootCategoryId);
-      const subCategories = await CategoryManager.getSubCategories(params.rootCategoryId);
+      const subCategories = await CategoryService.getSubCategories(params.rootCategoryId);
       subCategories.forEach((c) => categoryIds.add(c.id));
     }
 
@@ -152,7 +153,7 @@ router.get(
     }
 
     if (params.includeCategoryPath) {
-      await Promise.all(tickets.map((ticket) => ticket.loadCategoryPath()));
+      await Ticket.fillCategoryPath(tickets);
     }
 
     ctx.body = tickets.map((ticket) =>

--- a/next/api/src/service/category.ts
+++ b/next/api/src/service/category.ts
@@ -1,0 +1,83 @@
+import { redis } from '@/cache';
+import { Category } from '@/model/Category';
+import _ from 'lodash';
+
+class CategoryCache {
+  static readonly CACHE_KEY = 'categories';
+  static readonly CACHE_TTL = 60 * 5; // 5 min
+
+  static async setAll(categories: Category[]) {
+    const pl = redis.pipeline();
+    pl.del(CategoryCache.CACHE_KEY);
+    categories.forEach((c) => pl.hset(CategoryCache.CACHE_KEY, c.id, JSON.stringify(c)));
+    pl.expire(CategoryCache.CACHE_KEY, CategoryCache.CACHE_TTL);
+    await pl.exec();
+  }
+
+  static async getAll(): Promise<Category[] | undefined> {
+    const datas = await redis.hvals(CategoryCache.CACHE_KEY);
+    if (datas.length) {
+      return datas.map((data) => Category.fromJSON(JSON.parse(data)));
+    }
+  }
+
+  static async get(id: string): Promise<Category | undefined> {
+    const data = await redis.hget(CategoryCache.CACHE_KEY, id);
+    if (data) {
+      return Category.fromJSON(JSON.parse(data));
+    }
+  }
+
+  static async clear() {
+    await redis.del(CategoryCache.CACHE_KEY);
+  }
+}
+
+export class CategoryService {
+  static async getAll(): Promise<Category[]> {
+    const cached = await CategoryCache.getAll();
+    if (cached) {
+      return cached;
+    }
+
+    const categories = await Category.queryBuilder().limit(1000).find();
+    CategoryCache.setAll(categories).catch((error) => {
+      // TODO(sdjdd): Sentry
+      console.error(`[Cache] set categories failed:`, error);
+    });
+    return categories;
+  }
+
+  static async get(id: string): Promise<Category | undefined> {
+    const cached = await CategoryCache.get(id);
+    if (cached) {
+      return cached;
+    }
+
+    const category = await Category.find(id);
+    if (category) {
+      CategoryCache.clear().catch((error) => {
+        // TODO(sdjdd): Sentry
+        console.error(`[Cache] clear categories failed:`, error);
+      });
+      return category;
+    }
+  }
+
+  static async getSubCategories(id: string | string[]): Promise<Category[]> {
+    const parentIds = _.castArray(id);
+    const categories = await CategoryService.getAll();
+    const categoriesByParentId = _.groupBy(categories, 'parentId');
+    const subCategories: Category[] = [];
+
+    while (parentIds.length) {
+      const parentId = parentIds.shift()!;
+      categoriesByParentId[parentId]?.forEach((child) => {
+        parentIds.push(child.id);
+        subCategories.push(child);
+      });
+    }
+
+    return subCategories;
+  }
+}

--- a/next/api/src/service/category.ts
+++ b/next/api/src/service/category.ts
@@ -72,9 +72,9 @@ export class CategoryService {
 
     while (parentIds.length) {
       const parentId = parentIds.shift()!;
-      categoriesByParentId[parentId]?.forEach((child) => {
-        parentIds.push(child.id);
-        subCategories.push(child);
+      categoriesByParentId[parentId]?.forEach((category) => {
+        parentIds.push(category.id);
+        subCategories.push(category);
       });
     }
 


### PR DESCRIPTION
准备用 REST API 替换底层存储接口实现的分类管理。提前搞一个 category service 来做分类的 CRUD，屏蔽缓存相关的细节。

目前的功能和原 CategoryManager 相同。还去掉了本地缓存：凭我的直觉 5 秒的本地缓存没啥大用，还带来了多实例下的数据不一致，索性就不要了。