### PR TITLE
feat(article): upvote and downvote count for revisions

### DIFF
--- a/Deploy.md
+++ b/Deploy.md
@@ -90,7 +90,7 @@ OpsLog 没有索引，在自用的 LeanTicket 上 40000+ 的数据量已经出�
 
 ### `f400cdc73c0328bb74bf934a17c370c127b4000e`
 
-重新导入 notification.json 。并确保 notification 表有这个索引： 
+重新导入 notification.json 。并确保 notification 表有这个索引：
 
 - user（正序）联合 latestActionAt（倒序）
 
@@ -173,7 +173,6 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 
 已删除「动态内容」功能，可以删除 DynamicContent class。
 
-
 ## 2022-01-21
 
 ### `994965592e35bddb846b894876888aef9577a6f9`
@@ -194,7 +193,15 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 
 ### `TBD`
 
+重新导入 FAQ.json，FAQRevision.json。
+
 导入 FAQFeedback.json，确保 FAQFeedback 有以下两个索引：
 
-- revision（倒序）author（倒序），唯一
-- FAQ（倒序）updatedAt（倒序）
+- revision（倒序）author（倒序），唯一，不允许为空
+- revision（倒序）type（倒序）
+
+## 2022-02-15
+
+### `TBD`
+
+创建定时任务 analyzeArticles `58 * * * *`

--- a/api/next-shim.js
+++ b/api/next-shim.js
@@ -2,6 +2,7 @@ const AV = require('leanengine')
 
 const { tickDelayNotify } = require('../next/api/dist')
 const { execTimeTriggers } = require('../next/api/dist/ticket/automation/time-trigger')
+const { analyzeArticles } = require('../next/api/dist/article/stats')
 const events = require('../next/api/dist/events').default
 
 AV.Cloud.define('delayNotify', () => {
@@ -12,5 +13,7 @@ AV.Cloud.define('delayNotify', () => {
 AV.Cloud.define('tickAutomation', { fetchUser: false, internal: true }, () => {
   execTimeTriggers()
 })
+
+AV.Cloud.define('analyzeArticles', { fetchUser: false, internal: true }, analyzeArticles)
 
 module.exports = { events }

--- a/next/api/package-lock.json
+++ b/next/api/package-lock.json
@@ -22,7 +22,7 @@
         "jira-client": "^8.0.0",
         "koa": "^2.13.4",
         "koa-bodyparser": "^4.3.0",
-        "leancloud-storage": "^4.12.0",
+        "leancloud-storage": "^4.12.2",
         "leanengine": "^3.8.0",
         "lodash": "^4.17.21",
         "mailgun.js": "^4.1.4",
@@ -3387,9 +3387,9 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/leancloud-storage": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.12.0.tgz",
-      "integrity": "sha512-lm/4BVhCzKdG0YfgCV8BGIg9OpwYMLHAPNtfTkJU0Kd/OsE6vCsdU+HXdfrqcGBU4XmVKqjin0LYn25k3avZdQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.12.2.tgz",
+      "integrity": "sha512-GsyzkNufQoZ5f75vt3tgwhkhfxQ2ZR88Kq3Kt6HoWtsY13+L0Y6IBmGcLsNvN4NSKB2Qd01GNk2m9b9KFELHlA==",
       "dependencies": {
         "@leancloud/adapter-types": "^5.0.0",
         "@leancloud/platform-adapters-browser": "^1.5.2",
@@ -7860,9 +7860,9 @@
       "requires": {}
     },
     "leancloud-storage": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.12.0.tgz",
-      "integrity": "sha512-lm/4BVhCzKdG0YfgCV8BGIg9OpwYMLHAPNtfTkJU0Kd/OsE6vCsdU+HXdfrqcGBU4XmVKqjin0LYn25k3avZdQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.12.2.tgz",
+      "integrity": "sha512-GsyzkNufQoZ5f75vt3tgwhkhfxQ2ZR88Kq3Kt6HoWtsY13+L0Y6IBmGcLsNvN4NSKB2Qd01GNk2m9b9KFELHlA==",
       "requires": {
         "@leancloud/adapter-types": "^5.0.0",
         "@leancloud/platform-adapters-browser": "^1.5.2",

--- a/next/api/package.json
+++ b/next/api/package.json
@@ -28,7 +28,7 @@
     "jira-client": "^8.0.0",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
-    "leancloud-storage": "^4.12.0",
+    "leancloud-storage": "^4.12.2",
     "leanengine": "^3.8.0",
     "lodash": "^4.17.21",
     "mailgun.js": "^4.1.4",

--- a/next/api/src/article/stats.ts
+++ b/next/api/src/article/stats.ts
@@ -1,0 +1,35 @@
+import { Query } from 'leancloud-storage';
+import { ArticleFeedback } from '@/model/ArticleFeedback';
+import { ArticleRevision } from '@/model/ArticleRevision';
+
+export const analyzeArticles = async () => {
+  const articlesIterator = {
+    [Symbol.asyncIterator]() {
+      return new Query('FAQ').notEqualTo('archived', true).scan(undefined, { useMasterKey: true });
+    },
+  };
+  for await (const article of articlesIterator) {
+    console.log('Start process', article.id, article.get('question'));
+    if (article.get('revision')) {
+      const revision = ArticleRevision.fromAVObject(article.get('revision'));
+      const [upvote, downvote] = await Promise.all(
+        [1, -1].map((type) =>
+          ArticleFeedback.query()
+            .where('revision', '==', revision.toPointer())
+            .where('type', '==', type)
+            .count({ useMasterKey: true })
+        )
+      );
+      console.log('up/down:', upvote, downvote);
+      if (upvote + downvote !== 0) {
+        await revision.update(
+          {
+            upvote,
+            downvote,
+          },
+          { useMasterKey: true }
+        );
+      }
+    }
+  }
+};

--- a/next/api/src/article/stats.ts
+++ b/next/api/src/article/stats.ts
@@ -14,7 +14,7 @@ export const analyzeArticles = async () => {
       const revision = ArticleRevision.fromAVObject(article.get('revision'));
       const [upvote, downvote] = await Promise.all(
         [1, -1].map((type) =>
-          ArticleFeedback.query()
+          ArticleFeedback.queryBuilder()
             .where('revision', '==', revision.toPointer())
             .where('type', '==', type)
             .count({ useMasterKey: true })

--- a/next/api/src/model/Article.ts
+++ b/next/api/src/model/Article.ts
@@ -1,13 +1,14 @@
 import mem from 'mem';
 import QuickLRU from 'quick-lru';
+import { Error as LCError } from 'leancloud-storage';
 
-import { ACLBuilder, field, Model, ModifyOptions, serialize } from '@/orm';
+import { ACLBuilder, field, Model, ModifyOptions, pointerId, pointTo, serialize } from '@/orm';
 import { User } from './User';
 import { ArticleRevision } from './ArticleRevision';
 import { ArticleFeedback, FeedbackType } from './ArticleFeedback';
 
 export class Article extends Model {
-  protected static className = 'FAQ';
+  public static className = 'FAQ';
 
   @field('question')
   @serialize()
@@ -25,6 +26,13 @@ export class Article extends Model {
   @field()
   deletedAt?: Date;
 
+  @pointerId(() => ArticleRevision)
+  @serialize()
+  revisionId?: string;
+
+  @pointTo(() => ArticleRevision)
+  revision?: ArticleRevision;
+
   async delete(this: Article, options?: ModifyOptions) {
     await this.update(
       {
@@ -37,6 +45,7 @@ export class Article extends Model {
   }
 
   async createRevision(
+    this: Article,
     author: User,
     updatedArticle: Article,
     previousArticle?: Article,
@@ -61,10 +70,18 @@ export class Article extends Model {
       updatedArticle.content !== previousArticle?.content ||
       updatedArticle.title !== previousArticle?.title;
     if (contentChanged) {
-      await doCreateRevision({
+      const revision = await doCreateRevision({
         content: updatedArticle.content,
         title: updatedArticle.title,
       });
+      this.update(
+        {
+          revisionId: revision.id,
+        },
+        {
+          useMasterKey: true,
+        }
+      );
     }
 
     const metaChanged =
@@ -78,50 +95,28 @@ export class Article extends Model {
     }
   }
 
-  private async getLatestRevision() {
-    const revision = await ArticleRevision.queryBuilder()
-      .where('FAQ', '==', this.toPointer())
-      .where('meta', '!=', true)
-      .orderBy('createdAt')
-      .first({ useMasterKey: true });
-    if (!revision) {
+  async feedback(type: FeedbackType, author: User) {
+    console.log(this);
+    const { revisionId } = this;
+    if (!revisionId) {
       throw new Error('Revision not found');
     }
-    return revision;
-  }
-
-  async feedback(type: FeedbackType, author: User) {
-    const revision = await this.getLatestRevision();
-    try {
-      return await ArticleFeedback.create(
-        {
-          type,
-          revisionId: revision.id,
-          articleId: this.id,
-          authorId: author.id,
-        },
-        { useMasterKey: true }
-      );
-    } catch (error) {
-      if (error instanceof Error) {
-        if ((error as any).code === 137) {
-          const feedback = await ArticleFeedback.queryBuilder()
-            .where('revision', '==', revision.toPointer())
-            .where('author', '==', author.toPointer())
-            .first({ useMasterKey: true });
-          if (!feedback) {
-            throw new Error('Deplucated value detected but no matched feedback.');
-          }
-          return await feedback.update(
-            {
-              type,
-            },
-            { useMasterKey: true }
-          );
-        }
-      }
-      throw error;
-    }
+    await ArticleFeedback.upsert(
+      {
+        type,
+        revisionId,
+        articleId: this.id,
+        authorId: author.id,
+      },
+      (queryBuilder) =>
+        queryBuilder
+          .where('revision', '==', ArticleRevision.ptr(revisionId))
+          .where('author', '==', author.toPointer()),
+      {
+        type,
+      },
+      { useMasterKey: true }
+    );
   }
 }
 

--- a/next/api/src/model/Article.ts
+++ b/next/api/src/model/Article.ts
@@ -8,7 +8,7 @@ import { ArticleRevision } from './ArticleRevision';
 import { ArticleFeedback, FeedbackType } from './ArticleFeedback';
 
 export class Article extends Model {
-  public static className = 'FAQ';
+  static readonly className = 'FAQ';
 
   @field('question')
   @serialize()
@@ -96,7 +96,6 @@ export class Article extends Model {
   }
 
   async feedback(type: FeedbackType, author: User) {
-    console.log(this);
     const { revisionId } = this;
     if (!revisionId) {
       throw new Error('Revision not found');

--- a/next/api/src/model/ArticleRevision.ts
+++ b/next/api/src/model/ArticleRevision.ts
@@ -34,6 +34,14 @@ export class ArticleRevision extends Model {
   @serialize()
   comment?: string;
 
+  @field()
+  @serialize()
+  upvote?: number;
+
+  @field()
+  @serialize()
+  downvote?: number;
+
   @pointerId(() => User)
   @serialize()
   authorId!: string;

--- a/next/api/src/model/Notification.ts
+++ b/next/api/src/model/Notification.ts
@@ -35,7 +35,7 @@ export class Notification extends Model {
   @field()
   latestActionAt?: Date;
 
-  static async upsert(ticketId: string, userIds: string[], latestAction: LatestAction) {
+  static async upsertSome(ticketId: string, userIds: string[], latestAction: LatestAction) {
     userIds = _.uniq(userIds);
 
     const notifications = await this.queryBuilder()

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -308,7 +308,7 @@ export class Ticket extends Model {
       userIds.push(this.assigneeId);
     }
     userIds = userIds.filter((id) => id !== operator.id);
-    await Notification.upsert(this.id, userIds, latestAction);
+    await Notification.upsertSome(this.id, userIds, latestAction);
   }
 
   async resetUnreadCount(this: Ticket, user: User) {

--- a/next/api/src/notification/index.ts
+++ b/next/api/src/notification/index.ts
@@ -269,7 +269,7 @@ notification.register({
   },
   changeAssignee: ({ ticket, to }) => {
     if (to) {
-      NotificationModel.upsert(ticket.id, [to.id], 'changeAssignee').catch((error) => {
+      NotificationModel.upsertSome(ticket.id, [to.id], 'changeAssignee').catch((error) => {
         // TODO: Sentry
         console.error(error);
       });
@@ -277,7 +277,7 @@ notification.register({
   },
   ticketEvaluation: ({ ticket, to }) => {
     if (to) {
-      NotificationModel.upsert(ticket.id, [to.id], 'ticketEvaluation').catch((error) => {
+      NotificationModel.upsertSome(ticket.id, [to.id], 'ticketEvaluation').catch((error) => {
         // TODO: Sentry
         console.error(error);
       });

--- a/next/api/src/response/article-revision.ts
+++ b/next/api/src/response/article-revision.ts
@@ -1,10 +1,11 @@
 import { ArticleRevision } from '@/model/ArticleRevision';
+import { User } from '@/model/User';
 import htmlify from '@/utils/htmlify';
 import xss from '@/utils/xss';
 import { UserResponse } from './user';
 
 export class ArticleRevisionListItemResponse {
-  constructor(readonly revision: ArticleRevision) {}
+  constructor(readonly revision: ArticleRevision, readonly includeRating = false) {}
 
   toJSON() {
     return {
@@ -14,6 +15,8 @@ export class ArticleRevisionListItemResponse {
       title: this.revision.title,
       author: this.revision.author ? new UserResponse(this.revision.author) : undefined,
       comment: this.revision.comment,
+      upvote: this.includeRating ? this.revision.upvote : undefined,
+      downvote: this.includeRating ? this.revision.downvote : undefined,
       createdAt: this.revision.createdAt.toISOString(),
       updatedAt: this.revision.updatedAt.toISOString(),
     };

--- a/next/api/src/response/article.ts
+++ b/next/api/src/response/article.ts
@@ -11,6 +11,12 @@ export class ArticleResponse {
       content: this.article.content,
       contentSafeHTML: xss.process(this.article.contentHTML),
       private: !!this.article.private,
+      revision: this.article.revision
+        ? {
+            upvote: this.article.revision?.upvote,
+            downvote: this.article.revision?.downvote,
+          }
+        : undefined,
       createdAt: this.article.createdAt.toISOString(),
       updatedAt: this.article.updatedAt.toISOString(),
     };

--- a/next/web/src/App/Admin/Settings/Articles/FeedbackSummary.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/FeedbackSummary.tsx
@@ -1,0 +1,21 @@
+import { ArticleRevisionFeedbackSummary } from '@/api/article-revision';
+import { BsHandThumbsUp, BsHandThumbsDown } from 'react-icons/bs';
+
+export function FeedbackSummary({ revision }: { revision: ArticleRevisionFeedbackSummary }) {
+  return (
+    <span>
+      {revision.upvote !== undefined && (
+        <span className="text-success">
+          <BsHandThumbsUp className="inline-block mr-1" />
+          {revision.upvote}
+        </span>
+      )}
+      {revision.downvote !== undefined && (
+        <span className="ml-2 text-danger">
+          <BsHandThumbsDown className="inline-block mr-1" />
+          {revision.downvote}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/next/web/src/App/Admin/Settings/Articles/Revision.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/Revision.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import { usePage, usePageSize } from '@/utils/usePage';
 import { useSearchParam } from '@/utils/useSearchParams';
 import { QueryResult } from '@/components/common';
+import { FeedbackSummary } from './FeedbackSummary';
 
 const { Column } = Table;
 const { Title } = Typography;
@@ -118,6 +119,13 @@ export function ArticleRevisions() {
             title="修改时间"
             dataIndex="createdAt"
             render={(value) => new Date(value).toLocaleString()}
+          />
+          <Column
+            title="反馈"
+            dataIndex="id"
+            render={(id, revision: ArticleRevisionListItem) => (
+              <FeedbackSummary revision={revision} />
+            )}
           />
           {/* <Column
             title="操作"

--- a/next/web/src/App/Admin/Settings/Articles/index.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/index.tsx
@@ -32,11 +32,12 @@ import { EditArticleForm } from './EditArticleForm';
 // We should move them to @component
 import { CategoryPath, useGetCategoryPath } from '../../Tickets/TicketView/TicketList';
 import { useSearchParam } from '@/utils/useSearchParams';
+import { FeedbackSummary } from './FeedbackSummary';
 
 const { Column } = Table;
 const { Title } = Typography;
 
-const PrivateQueryValue: { [key: string]: boolean| undefined } = {
+const PrivateQueryValue: { [key: string]: boolean | undefined } = {
   true: true,
   false: false,
   unset: undefined,
@@ -110,6 +111,13 @@ export function Articles() {
             title="修改日期"
             dataIndex="updatedAt"
             render={(value) => new Date(value).toLocaleString()}
+          />
+          <Column
+            title="最新版本评价"
+            dataIndex="id"
+            render={(_, article: Article) =>
+              article.revision ? <FeedbackSummary revision={article.revision} /> : null
+            }
           />
         </Table>
       )}

--- a/next/web/src/api/article-revision.ts
+++ b/next/web/src/api/article-revision.ts
@@ -2,7 +2,12 @@ import { http } from '@/leancloud';
 import { UseQueryOptions, useQuery } from 'react-query';
 import { UserSchema } from './user';
 
-export interface ArticleRevisionListItem {
+export interface ArticleRevisionFeedbackSummary {
+  upvote?: number;
+  downvote?: number;
+}
+
+export interface ArticleRevisionListItem extends ArticleRevisionFeedbackSummary {
   id: string;
   meta?: boolean;
   private?: boolean;

--- a/next/web/src/api/article.ts
+++ b/next/web/src/api/article.ts
@@ -9,6 +9,10 @@ export interface Article {
   content: string;
   contentSafeHTML: string;
   private: boolean;
+  revision?: {
+    upvote?: number;
+    downvote?: number;
+  };
   createdAt: string;
   updatedAt: string;
 }

--- a/resources/schema/FAQ.json
+++ b/resources/schema/FAQ.json
@@ -43,6 +43,15 @@
       "hidden": false,
       "read_only": false
     },
+    "revision": {
+      "type": "Pointer",
+      "v": 2,
+      "className": "FAQRevision",
+      "required": false,
+      "hidden": false,
+      "read_only": false,
+      "comment": "最近一次有内容的修改记录"
+    },
     "answer": {
       "type": "String",
       "v": 2,

--- a/resources/schema/FAQRevision.json
+++ b/resources/schema/FAQRevision.json
@@ -56,6 +56,20 @@
       "hidden": false,
       "read_only": false
     },
+    "upvote": {
+      "type": "Number",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "downvote": {
+      "type": "Number",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
     "comment": {
       "type": "String",
       "v": 2,


### PR DESCRIPTION
最终选择了最简单可靠的方案：每小时统计一次当前上线的文章的所有反馈数量记录到当前版本数据里。（之前还考虑过记录每小时新增的反馈数量、PV、UV，这样可以看到变化趋势，但感觉这个功能可能用量不会太多还是选了简单的）。

具体的数据库变动：

- 为 Revision 增加了 upvote 与 downvote 字段
- 为 Article 增加了 revision 字段，冗余存储最近一次对内容的 revision（读优化）。

部署到了 demo 环境。