### PR TITLE
feat(next): search tickets by tag

### DIFF
--- a/next/api/src/controller/user.ts
+++ b/next/api/src/controller/user.ts
@@ -7,7 +7,7 @@ import {
   ResponseBody,
   UseMiddlewares,
 } from '@/common/http';
-import { TrimPipe } from '@/common/pipe';
+import { ParseCsvPipe, TrimPipe } from '@/common/pipe';
 import { auth, customerServiceOnly } from '@/middleware';
 import { User } from '@/model/User';
 import { UserSearchResult } from '@/response/user';
@@ -20,9 +20,14 @@ export class UserController {
   findAll(
     @CurrentUser() currentUser: User,
     @Pagination() [page, pageSize]: [number, number],
-    @Query('q', TrimPipe) q?: string
+    @Query('id', ParseCsvPipe) ids: string[] | undefined,
+    @Query('q', TrimPipe) q: string | undefined
   ) {
     const query = User.queryBuilder().paginate(page, pageSize);
+
+    if (ids && ids.length) {
+      query.where('objectId', 'in', ids);
+    }
 
     if (q) {
       query.where((query) => {

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/TagSelect.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/TagSelect.tsx
@@ -1,0 +1,81 @@
+import { useTagMetadatas } from '@/api/tag-metadata';
+import { Select } from '@/components/antd';
+import { useMemo } from 'react';
+
+const EMPTY_VALUE = '';
+
+export interface TagSelectValue {
+  tagKey?: string;
+  tagValue?: string;
+  privateTagKey?: string;
+  privateTagValue?: string;
+}
+
+export interface TagSelectProps {
+  value?: TagSelectValue;
+  onChange: (value: TagSelectValue) => void;
+}
+
+export function TagSelect({ value, onChange }: TagSelectProps) {
+  const { data, isLoading } = useTagMetadatas();
+
+  const options = useMemo(
+    () => [
+      { label: '任何', value: EMPTY_VALUE },
+      ...(data
+        ?.filter((t) => t.type === 'select')
+        .map((t) => ({ label: t.key, value: t.key, private: t.private })) ?? []),
+    ],
+    [data]
+  );
+
+  const isPrivate = !!(value && (value.privateTagKey || value.privateTagValue));
+  const tagKey = isPrivate ? value?.privateTagKey : value?.tagKey;
+  const tagValue = isPrivate ? value?.privateTagValue : value?.privateTagKey;
+
+  const tag = useMemo(() => {
+    return data?.find((t) => t.key === tagKey);
+  }, [data, tagKey]);
+
+  const valueOptions = useMemo(
+    () => [
+      { label: '任何', value: EMPTY_VALUE },
+      ...(tag?.values?.map((v) => ({ label: v, value: v })) ?? []),
+    ],
+    [tag]
+  );
+
+  const handleChange = (key?: string, value?: string, isPrivate = false) => {
+    onChange({
+      tagKey: isPrivate ? undefined : key,
+      tagValue: isPrivate ? undefined : value,
+      privateTagKey: isPrivate ? key : undefined,
+      privateTagValue: isPrivate ? value : undefined,
+    });
+  };
+
+  return (
+    <>
+      <Select
+        className="w-full"
+        loading={isLoading}
+        options={options}
+        value={tagKey ?? EMPTY_VALUE}
+        onChange={(key, option: any) =>
+          handleChange(key === EMPTY_VALUE ? undefined : key, undefined, option.private)
+        }
+      />
+      {tag && (
+        <div className="pl-2 border-l border-gray-300 border-dashed">
+          <div className="my-2 text-[#475867] text-sm font-medium">标签值</div>
+          <Select
+            className="w-full"
+            options={valueOptions}
+            value={tagValue ?? EMPTY_VALUE}
+            onChange={(value) => handleChange(tag.key, value, tag.private)}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/index.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/antd';
 import { Filters } from '../useTicketFilter';
 import { AssigneeSelect } from './AssigneeSelect';
 import { GroupSelect } from './GroupSelect';
+import { TagSelect } from './TagSelect';
 import { CreatedAtSelect } from './CreatedAtSelect';
 import { CategorySelect } from './CategorySelect';
 import { StatusSelect } from './StatusSelect';
@@ -42,7 +43,17 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
     onChange(tempFilters);
   };
 
-  const { assigneeId, groupId, createdAt, rootCategoryId, status } = tempFilters;
+  const {
+    assigneeId,
+    groupId,
+    tagKey,
+    tagValue,
+    privateTagKey,
+    privateTagValue,
+    createdAt,
+    rootCategoryId,
+    status,
+  } = tempFilters;
 
   return (
     <div
@@ -60,6 +71,13 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
 
         <Field title="客服组">
           <GroupSelect value={groupId} onChange={(groupId) => merge({ groupId })} />
+        </Field>
+
+        <Field title="标签">
+          <TagSelect
+            value={{ tagKey, tagValue, privateTagKey, privateTagValue }}
+            onChange={merge}
+          />
         </Field>
 
         <Field title="创建时间">

--- a/next/web/src/App/Admin/Tickets/Filter/useTicketFilter.ts
+++ b/next/web/src/App/Admin/Tickets/Filter/useTicketFilter.ts
@@ -5,16 +5,33 @@ import { useSearchParams } from '@/utils/useSearchParams';
 export interface Filters {
   assigneeId?: string[];
   groupId?: string[];
+  tagKey?: string;
+  tagValue?: string;
+  privateTagKey?: string;
+  privateTagValue?: string;
   createdAt?: string;
   rootCategoryId?: string;
   status?: number[];
 }
 
 export function useLocalFilters() {
-  const [{ assigneeId, groupId, createdAt, rootCategoryId, status }, { merge }] = useSearchParams();
+  const [
+    {
+      assigneeId,
+      groupId,
+      tagKey,
+      tagValue,
+      privateTagKey,
+      privateTagValue,
+      createdAt,
+      rootCategoryId,
+      status,
+    },
+    { merge },
+  ] = useSearchParams();
 
   const filters = useMemo(() => {
-    const filters: Filters = {};
+    const filters: Filters = { tagKey, tagValue, privateTagKey, privateTagValue };
 
     if (assigneeId) {
       filters.assigneeId = assigneeId.split(',');
@@ -40,11 +57,22 @@ export function useLocalFilters() {
     }
 
     return filters;
-  }, [assigneeId, groupId, createdAt, rootCategoryId, status]);
+  }, [
+    assigneeId,
+    groupId,
+    tagKey,
+    tagValue,
+    privateTagKey,
+    privateTagValue,
+    createdAt,
+    rootCategoryId,
+    status,
+  ]);
 
   const set = useCallback(
     (filters: Filters) => {
-      let params = {
+      const params: Record<string, string | undefined> = {
+        ...filters,
         assigneeId: filters.assigneeId?.map((id) => (id === null ? 'null' : id)).join(','),
         groupId: filters.groupId?.map((id) => (id === null ? 'null' : id)).join(','),
         createdAt: filters.createdAt,

--- a/next/web/src/api/ticket.ts
+++ b/next/web/src/api/ticket.ts
@@ -9,18 +9,9 @@ export interface TicketSchema {
   nid: number;
   title: string;
   categoryId: string;
-  author: {
-    id: string;
-    nickname: string;
-  };
-  assignee?: {
-    id: string;
-    nickname: string;
-  };
-  group?: {
-    id: string;
-    name: string;
-  };
+  authorId: string;
+  assigneeId?: string;
+  groupId?: string;
   status: number;
   createdAt: string;
   updatedAt: string;

--- a/next/web/src/api/ticket.ts
+++ b/next/web/src/api/ticket.ts
@@ -28,6 +28,10 @@ export interface FetchTicketsOptions {
     createdAt?: string;
     rootCategoryId?: string;
     status?: number | number[];
+    tagKey?: string;
+    tagValue?: string;
+    privateTagKey?: string;
+    privateTagValue?: string;
   };
 }
 
@@ -41,38 +45,38 @@ async function fetchTickets({
   pageSize = 10,
   orderKey = 'createdAt',
   orderType = 'desc',
-  filters,
+  filters = {},
 }: FetchTicketsOptions = {}): Promise<FetchTicketsResult> {
   const params: any = {
     page,
     pageSize,
     count: 1,
     orderBy: `${orderKey}-${orderType}`,
+    rootCategoryId: filters.rootCategoryId,
+    tagKey: filters.tagKey,
+    tagValue: filters.tagValue,
+    privateTagKey: filters.privateTagKey,
+    privateTagValue: filters.privateTagValue,
   };
 
-  if (filters) {
-    if (filters.assigneeId) {
-      params.assigneeId = castArray(filters.assigneeId).join(',');
+  if (filters.assigneeId) {
+    params.assigneeId = castArray(filters.assigneeId).join(',');
+  }
+  if (filters.groupId) {
+    params.groupId = castArray(filters.groupId).join(',');
+  }
+  if (filters.createdAt) {
+    const dateRange = decodeDateRange(filters.createdAt);
+    if (dateRange && (dateRange.from || dateRange.to)) {
+      // "2021-08-01..2021-08-31", "2021-08-01..*", etc.
+      params.createdAt = [
+        dateRange.from?.toISOString() ?? '*',
+        dateRange.to?.toISOString() ?? '*',
+      ].join('..');
     }
-    if (filters.groupId) {
-      params.groupId = castArray(filters.groupId).join(',');
-    }
-    if (filters.createdAt) {
-      const dateRange = decodeDateRange(filters.createdAt);
-      if (dateRange && (dateRange.from || dateRange.to)) {
-        // "2021-08-01..2021-08-31", "2021-08-01..*", etc.
-        params.createdAt = [
-          dateRange.from?.toISOString() ?? '*',
-          dateRange.to?.toISOString() ?? '*',
-        ].join('..');
-      }
-    }
-    if (filters.rootCategoryId) {
-      params.rootCategoryId = filters.rootCategoryId;
-    }
-    if (filters.status) {
-      params.status = castArray(filters.status).join(',');
-    }
+  }
+  if (filters.status) {
+    params.status = castArray(filters.status).join(',');
   }
 
   const { headers, data } = await http.get<TicketSchema[]>('/api/2/tickets', { params });

--- a/next/web/src/api/ticket.ts
+++ b/next/web/src/api/ticket.ts
@@ -45,7 +45,7 @@ export interface FetchTicketsResult {
   totalCount: number;
 }
 
-export async function fetchTickets({
+async function fetchTickets({
   page = 1,
   pageSize = 10,
   orderKey = 'createdAt',
@@ -56,7 +56,6 @@ export async function fetchTickets({
     page,
     pageSize,
     count: 1,
-    include: 'author,assignee,group',
     orderBy: `${orderKey}-${orderType}`,
   };
 

--- a/next/web/src/api/user.ts
+++ b/next/web/src/api/user.ts
@@ -2,6 +2,8 @@ import { UseQueryOptions, useQuery } from 'react-query';
 
 import { http } from '@/leancloud';
 
+export * from './customer-service';
+
 export interface UserSchema {
   id: string;
   username: string;
@@ -9,7 +11,22 @@ export interface UserSchema {
   avatarUrl: string;
 }
 
-export * from './customer-service';
+interface FetchUserOptions {
+  id?: string | string[];
+}
+
+async function fetchUsers({ id }: FetchUserOptions = {}): Promise<UserSchema[]> {
+  const params: Record<string, string> = {};
+  if (id) {
+    if (Array.isArray(id)) {
+      params.id = id.join(',');
+    } else {
+      params.id = id;
+    }
+  }
+  const { data } = await http.get('/api/2/users', { params });
+  return data;
+}
 
 export interface UserSearchResult extends UserSchema {
   email?: string;
@@ -19,6 +36,17 @@ async function searchUser(q: string): Promise<UserSchema[]> {
   const { data } = await http.get('/api/2/users', { params: { q } });
   return data;
 }
+
+export interface UseUsersOptions extends FetchUserOptions {
+  queryOptions?: UseQueryOptions<UserSchema[], Error>;
+}
+
+export const useUsers = ({ queryOptions, ...options }: UseUsersOptions = {}) =>
+  useQuery({
+    queryKey: ['users', options],
+    queryFn: () => fetchUsers(options),
+    ...queryOptions,
+  });
 
 export function useSearchUser(q: string, options?: UseQueryOptions<UserSearchResult[], Error>) {
   return useQuery({


### PR DESCRIPTION
支持通过标签搜索工单。

其实本来想先做关键词搜索功能的，所以重构了下 TicketList 和 TicketTable，不再通过 include author/assignee/group 的方式获取创建者、负责人、客服组等信息，方便切换到全文搜索。但后来发现工作量比较大，就先做通过标签搜索的功能了。不过这部分也提交上来了。

堆了一些代码实现的，考虑到可能切换 codebase，就先这样吧。或者重构的时候再说 🏃 