### PR TITLE
feat(next): search tickets

### DIFF
--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -23,7 +23,7 @@ const router = new Router().use(auth);
 
 const statuses = [50, 120, 160, 220, 250, 280];
 
-const includeSchema = {
+const includeSchema = yup.object({
   includeAuthor: yup.bool(),
   includeAssignee: yup.bool(),
   includeCategory: yup.bool(), // TODO
@@ -31,10 +31,9 @@ const includeSchema = {
   includeFiles: yup.bool(),
   includeCategoryPath: yup.bool(),
   includeUnreadCount: yup.bool(),
-};
+});
 
-const findTicketsSchema = yup.object({
-  where: yup.object(),
+const ticketFiltersSchema = yup.object({
   authorId: yup.string(),
   assigneeId: yup.csv(yup.string().required()),
   categoryId: yup.csv(yup.string().required()),
@@ -44,15 +43,20 @@ const findTicketsSchema = yup.object({
   'evaluation.star': yup.number().oneOf([0, 1]),
   createdAtFrom: yup.date(),
   createdAtTo: yup.date(),
-  page: yup.number().min(1).default(1),
-  pageSize: yup.number().min(0).max(100).default(10),
-  count: yup.bool().default(false),
-  includeMetaKeys: yup.csv(yup.string()),
   tagKey: yup.string(),
   tagValue: yup.string(),
   privateTagKey: yup.string(),
   privateTagValue: yup.string(),
-  ...includeSchema,
+
+  // pagination
+  page: yup.number().min(1).default(1),
+  pageSize: yup.number().min(0).max(100).default(10),
+});
+
+const findTicketsSchema = includeSchema.concat(ticketFiltersSchema).shape({
+  where: yup.object(),
+  count: yup.bool().default(false),
+  includeMetaKeys: yup.csv(yup.string().required()),
 });
 
 function addPointersCondition(
@@ -111,7 +115,7 @@ router.get(
     if (params.status) {
       query.where('status', 'in', params.status);
     }
-    if (params['evaluation.star']) {
+    if (params['evaluation.star'] !== undefined) {
       query.where('evaluation.star', '==', params['evaluation.star']);
     }
     if (params.createdAtFrom) {
@@ -120,6 +124,25 @@ router.get(
     if (params.createdAtTo) {
       query.where('createdAt', '<=', params.createdAtTo);
     }
+    if (params.tagKey) {
+      query.where('tags.key', '==', params.tagKey);
+    }
+    if (params.tagValue) {
+      query.where('tags.value', '==', params.tagValue);
+    }
+    if (params.privateTagKey) {
+      if (!(await currentUser.isCustomerService())) {
+        ctx.throw(403);
+      }
+      query.where('privateTags.key', '==', params.privateTagKey);
+    }
+    if (params.privateTagValue) {
+      if (!(await currentUser.isCustomerService())) {
+        ctx.throw(403);
+      }
+      query.where('privateTags.value', '==', params.privateTagValue);
+    }
+
     if (sort) {
       sort.forEach(({ key, order }) => query.orderBy(key, order));
     }
@@ -145,24 +168,6 @@ router.get(
         },
       });
     }
-    if (params.tagKey) {
-      query.where('tags.key', '==', params.tagKey);
-    }
-    if (params.tagValue) {
-      query.where('tags.value', '==', params.tagValue);
-    }
-    if (params.privateTagKey) {
-      if (!(await currentUser.isCustomerService())) {
-        ctx.throw(403);
-      }
-      query.where('privateTags.key', '==', params.privateTagKey);
-    }
-    if (params.privateTagValue) {
-      if (!(await currentUser.isCustomerService())) {
-        ctx.throw(403);
-      }
-      query.where('privateTags.value', '==', params.privateTagValue);
-    }
 
     query.skip((params.page - 1) * params.pageSize).limit(params.pageSize);
 
@@ -181,9 +186,118 @@ router.get(
 
     ctx.body = tickets.map((ticket) =>
       new TicketListItemResponse(ticket).toJSON({
-        includeMetaKeys: _.compact(params.includeMetaKeys),
+        includeMetaKeys: params.includeMetaKeys,
       })
     );
+  }
+);
+
+const searchTicketParamsSchema = ticketFiltersSchema.shape({
+  keyword: yup.string().required(),
+});
+
+router.get(
+  '/search',
+  sort('orderBy', ['status', 'createdAt', 'updatedAt', 'latestCustomerServiceReplyAt']),
+  parseRange('createdAt'),
+  async (ctx) => {
+    const currentUser = ctx.state.currentUser as User;
+    const params = searchTicketParamsSchema.validateSync(ctx.query);
+    const sortFields = sort.get(ctx);
+
+    const categoryIds = new Set(params.categoryId);
+    if (params.rootCategoryId) {
+      categoryIds.add(params.rootCategoryId);
+      const subCategories = await CategoryService.getSubCategories(params.rootCategoryId);
+      subCategories.forEach((c) => categoryIds.add(c.id));
+    }
+
+    const conditions = [`(title:${params.keyword} OR content:${params.keyword})`];
+
+    const addEqCondition = (field: string, value: string | number | (string | number)[]) => {
+      if (Array.isArray(value)) {
+        if (value.includes('null')) {
+          const nonNullValue = value.filter((v) => v !== 'null');
+          if (nonNullValue.length) {
+            if (nonNullValue.length === 1) {
+              conditions.push(`(_missing_:${field} OR ${field}:${nonNullValue[0]})`);
+            } else {
+              conditions.push(`(_missing_:${field} OR ${field}:(${nonNullValue.join(' OR ')}))`);
+            }
+          } else {
+            conditions.push(`_missing_:${field}`);
+          }
+        } else {
+          if (value.length === 1) {
+            conditions.push(`${field}:${value[0]}`);
+          } else {
+            conditions.push(`${field}:(${value.join(' OR ')})`);
+          }
+        }
+      } else {
+        if (value === 'null') {
+          conditions.push(`_missing_:${field}`);
+        } else {
+          conditions.push(`${field}:${value}`);
+        }
+      }
+    };
+
+    if (params.authorId) {
+      addEqCondition('author.objectId', params.authorId);
+    }
+    if (params.assigneeId) {
+      addEqCondition('assignee.objectId', params.assigneeId);
+    }
+    if (params.groupId) {
+      addEqCondition('group.objectId', params.groupId);
+    }
+    if (categoryIds.size) {
+      addEqCondition('category.objectId', Array.from(categoryIds));
+    }
+    if (params.status) {
+      addEqCondition('status', params.status);
+    }
+    if (params['evaluation.star'] !== undefined) {
+      addEqCondition('evaluation.star', params['evaluation.star']);
+    }
+    if (params.createdAtFrom || params.createdAtTo) {
+      const from = params.createdAtFrom?.toISOString() ?? '*';
+      const to = params.createdAtTo?.toISOString() ?? '*';
+      conditions.push(`createdAt:[${from} TO ${to}]`);
+    }
+    if (params.tagKey) {
+      addEqCondition('tags.key', params.tagKey);
+    }
+    if (params.tagValue) {
+      addEqCondition('tags.value', params.tagValue);
+    }
+    if (params.privateTagKey) {
+      addEqCondition('privateTags.key', params.privateTagKey);
+    }
+    if (params.privateTagValue) {
+      addEqCondition('privateTags.value', params.privateTagValue);
+    }
+
+    const queryString = conditions.join(' AND ');
+    console.log(queryString);
+
+    const searchQuery = new AV.SearchQuery('Ticket');
+    searchQuery.queryString(queryString);
+    sortFields?.forEach(({ key, order }) => {
+      if (order === 'asc') {
+        searchQuery.addAscending(key);
+      } else {
+        searchQuery.addDescending(key);
+      }
+    });
+    searchQuery.skip((params.page - 1) * params.pageSize).limit(params.pageSize);
+
+    const ticketObjects = await searchQuery.find(currentUser.getAuthOptions());
+    const tickets = ticketObjects.map((o) => Ticket.fromAVObject(o as AV.Object));
+
+    ctx.set('X-Total-Count', searchQuery.hits().toString());
+    ctx.body = tickets.map((t) => new TicketListItemResponse(t));
   }
 );
 
@@ -281,7 +395,7 @@ router.param('id', async (id, ctx, next) => {
   return next();
 });
 
-const getTicketSchema = yup.object({ ...includeSchema });
+const getTicketSchema = includeSchema;
 
 router.get('/:id', include, async (ctx) => {
   const currentUser = ctx.state.currentUser as User;

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -198,7 +198,7 @@ const searchTicketParamsSchema = ticketFiltersSchema.shape({
 
 router.get(
   '/search',
-  sort('orderBy', ['status', 'createdAt', 'updatedAt', 'latestCustomerServiceReplyAt']),
+  sort('orderBy', ['status', 'createdAt', 'updatedAt']),
   parseRange('createdAt'),
   async (ctx) => {
     const currentUser = ctx.state.currentUser as User;

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -280,7 +280,6 @@ router.get(
     }
 
     const queryString = conditions.join(' AND ');
-    console.log(queryString);
 
     const searchQuery = new AV.SearchQuery('Ticket');
     searchQuery.queryString(queryString);

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/EvaluationStarSelect.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/EvaluationStarSelect.tsx
@@ -1,0 +1,22 @@
+import { Select } from '@/components/antd';
+
+const { Option } = Select;
+
+export interface EvaluationStarSelectProps {
+  value?: number;
+  onChange: (value: number | undefined) => void;
+}
+
+export function EvaluationStarSelect({ value, onChange }: EvaluationStarSelectProps) {
+  return (
+    <Select
+      className="w-full"
+      value={value?.toString() ?? ''}
+      onChange={(v) => onChange(v ? parseInt(v) : undefined)}
+    >
+      <Option value="">全部</Option>
+      <Option value="1">只看好评</Option>
+      <Option value="0">只看差评</Option>
+    </Select>
+  );
+}

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/TagSelect.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/TagSelect.tsx
@@ -22,16 +22,19 @@ export function TagSelect({ value, onChange }: TagSelectProps) {
   const options = useMemo(
     () => [
       { label: '任何', value: EMPTY_VALUE },
-      ...(data
-        ?.filter((t) => t.type === 'select')
-        .map((t) => ({ label: t.key, value: t.key, private: t.private })) ?? []),
+      ...(data ?? [])
+        .filter((t) => t.type === 'select')
+        .map((t) => ({
+          label: t.key,
+          value: t.key,
+        })),
     ],
     [data]
   );
 
   const isPrivate = !!(value && (value.privateTagKey || value.privateTagValue));
   const tagKey = isPrivate ? value?.privateTagKey : value?.tagKey;
-  const tagValue = isPrivate ? value?.privateTagValue : value?.privateTagKey;
+  const tagValue = isPrivate ? value?.privateTagValue : value?.tagValue;
 
   const tag = useMemo(() => {
     return data?.find((t) => t.key === tagKey);
@@ -61,9 +64,10 @@ export function TagSelect({ value, onChange }: TagSelectProps) {
         loading={isLoading}
         options={options}
         value={tagKey ?? EMPTY_VALUE}
-        onChange={(key, option: any) =>
-          handleChange(key === EMPTY_VALUE ? undefined : key, undefined, option.private)
-        }
+        onChange={(key) => {
+          const tag = data?.find((t) => t.key === key);
+          handleChange(key === EMPTY_VALUE ? undefined : key, undefined, tag?.private);
+        }}
       />
       {tag && (
         <div className="pl-2 border-l border-gray-300 border-dashed">

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/index.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/index.tsx
@@ -1,7 +1,8 @@
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import cx from 'classnames';
 
-import { Button } from '@/components/antd';
+import { Button, Input } from '@/components/antd';
+import { UserSelect } from '@/components/common';
 import { Filters } from '../useTicketFilter';
 import { AssigneeSelect } from './AssigneeSelect';
 import { GroupSelect } from './GroupSelect';
@@ -9,6 +10,7 @@ import { TagSelect } from './TagSelect';
 import { CreatedAtSelect } from './CreatedAtSelect';
 import { CategorySelect } from './CategorySelect';
 import { StatusSelect } from './StatusSelect';
+import { EvaluationStarSelect } from './EvaluationStarSelect';
 
 function Field({ title, children }: PropsWithChildren<{ title: string }>) {
   return (
@@ -44,6 +46,8 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
   };
 
   const {
+    keyword,
+    authorId,
     assigneeId,
     groupId,
     tagKey,
@@ -53,6 +57,7 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
     createdAt,
     rootCategoryId,
     status,
+    star,
   } = tempFilters;
 
   return (
@@ -64,6 +69,24 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
     >
       <div className="grow p-4">
         <div className="h-7 text-sm font-medium">过滤</div>
+
+        <Field title="关键词">
+          <Input
+            autoFocus
+            value={keyword}
+            onChange={(e) => merge({ keyword: e.target.value || undefined })}
+            onKeyDown={(e) => e.key === 'Enter' && handleChange()}
+          />
+        </Field>
+
+        <Field title="用户">
+          <UserSelect
+            allowClear
+            className="w-full"
+            value={authorId}
+            onChange={(authorId) => merge({ authorId: authorId as string })}
+          />
+        </Field>
 
         <Field title="客服">
           <AssigneeSelect value={assigneeId} onChange={(assigneeId) => merge({ assigneeId })} />
@@ -93,6 +116,10 @@ export function FilterForm({ className, filters, onChange }: FilterFormProps) {
 
         <Field title="状态">
           <StatusSelect value={status} onChange={(status) => merge({ status })} />
+        </Field>
+
+        <Field title="评价">
+          <EvaluationStarSelect value={star} onChange={(star) => merge({ star })} />
         </Field>
       </div>
 

--- a/next/web/src/App/Admin/Tickets/Filter/useTicketFilter.ts
+++ b/next/web/src/App/Admin/Tickets/Filter/useTicketFilter.ts
@@ -3,6 +3,8 @@ import { useCallback, useMemo } from 'react';
 import { useSearchParams } from '@/utils/useSearchParams';
 
 export interface Filters {
+  keyword?: string;
+  authorId?: string;
   assigneeId?: string[];
   groupId?: string[];
   tagKey?: string;
@@ -12,11 +14,14 @@ export interface Filters {
   createdAt?: string;
   rootCategoryId?: string;
   status?: number[];
+  star?: number;
 }
 
 export function useLocalFilters() {
   const [
     {
+      keyword,
+      authorId,
       assigneeId,
       groupId,
       tagKey,
@@ -26,12 +31,20 @@ export function useLocalFilters() {
       createdAt,
       rootCategoryId,
       status,
+      star,
     },
     { merge },
   ] = useSearchParams();
 
   const filters = useMemo(() => {
-    const filters: Filters = { tagKey, tagValue, privateTagKey, privateTagValue };
+    const filters: Filters = {
+      keyword,
+      authorId,
+      tagKey,
+      tagValue,
+      privateTagKey,
+      privateTagValue,
+    };
 
     if (assigneeId) {
       filters.assigneeId = assigneeId.split(',');
@@ -56,8 +69,17 @@ export function useLocalFilters() {
         .filter((n) => !Number.isNaN(n));
     }
 
+    if (star) {
+      const starNum = parseInt(star);
+      if (!Number.isNaN(starNum)) {
+        filters.star = starNum;
+      }
+    }
+
     return filters;
   }, [
+    keyword,
+    authorId,
     assigneeId,
     groupId,
     tagKey,
@@ -67,6 +89,7 @@ export function useLocalFilters() {
     createdAt,
     rootCategoryId,
     status,
+    star,
   ]);
 
   const set = useCallback(
@@ -78,6 +101,7 @@ export function useLocalFilters() {
         createdAt: filters.createdAt,
         rootCategoryId: filters.rootCategoryId,
         status: filters.status?.join(','),
+        star: filters.star?.toString(),
       };
       merge(params);
     },

--- a/next/web/src/api/user.ts
+++ b/next/web/src/api/user.ts
@@ -11,12 +11,17 @@ export interface UserSchema {
   avatarUrl: string;
 }
 
-interface FetchUserOptions {
-  id?: string | string[];
+export interface UserSearchResult extends UserSchema {
+  email?: string;
 }
 
-async function fetchUsers({ id }: FetchUserOptions = {}): Promise<UserSchema[]> {
-  const params: Record<string, string> = {};
+interface FetchUserOptions {
+  id?: string | string[];
+  q?: string;
+}
+
+async function fetchUsers({ id, q }: FetchUserOptions = {}): Promise<UserSearchResult[]> {
+  const params: Record<string, string | undefined> = { q };
   if (id) {
     if (Array.isArray(id)) {
       params.id = id.join(',');
@@ -28,17 +33,8 @@ async function fetchUsers({ id }: FetchUserOptions = {}): Promise<UserSchema[]> 
   return data;
 }
 
-export interface UserSearchResult extends UserSchema {
-  email?: string;
-}
-
-async function searchUser(q: string): Promise<UserSchema[]> {
-  const { data } = await http.get('/api/2/users', { params: { q } });
-  return data;
-}
-
 export interface UseUsersOptions extends FetchUserOptions {
-  queryOptions?: UseQueryOptions<UserSchema[], Error>;
+  queryOptions?: UseQueryOptions<UserSearchResult[], Error>;
 }
 
 export const useUsers = ({ queryOptions, ...options }: UseUsersOptions = {}) =>
@@ -47,11 +43,3 @@ export const useUsers = ({ queryOptions, ...options }: UseUsersOptions = {}) =>
     queryFn: () => fetchUsers(options),
     ...queryOptions,
   });
-
-export function useSearchUser(q: string, options?: UseQueryOptions<UserSearchResult[], Error>) {
-  return useQuery({
-    queryKey: ['searchUserResult', q],
-    queryFn: () => searchUser(q),
-    ...options,
-  });
-}

--- a/next/web/src/components/common/UserSelect.tsx
+++ b/next/web/src/components/common/UserSelect.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 import { RefSelectProps } from 'antd/lib/select';
 
-import { useSearchUser } from '@/api/user';
+import { useUsers } from '@/api/user';
 import { Select, SelectProps, Spin } from '@/components/antd';
 import { Retry } from './Retry';
 
@@ -17,17 +17,23 @@ export const UserSelect = forwardRef<RefSelectProps, UserSelectProps>(
     useDebounce(() => setDebouncedKeyword(keyword), 500, [keyword]);
 
     const q = useMemo(() => debouncedKeyword.trim(), [debouncedKeyword]);
-    const { data, isLoading, error, refetch } = useSearchUser(q, {
-      enabled: q !== '',
+    const userId = props.value ?? undefined;
+    const { data, isLoading, error, refetch } = useUsers({
+      q,
+      id: q ? undefined : userId,
+      queryOptions: {
+        enabled: q !== '' || userId !== undefined,
+        staleTime: 1000 * 60,
+      },
     });
 
     const options = useMemo(() => {
       return [
         ...(extraOptions ?? []),
-        ...(data?.map((u) => ({
+        ...(data ?? []).map((u) => ({
           label: `${u.nickname}${u.email ? ` (${u.email})` : ''}`,
           value: u.id,
-        })) ?? []),
+        })),
       ];
     }, [data, extraOptions]);
 


### PR DESCRIPTION
## 主要改动
支持通过关键字搜索工单。

新增 API `GET /api/2/tickets/search`，底层使用 LeanCloud 的「全文搜索」功能，支持 `GET /api/2/tickets` 的全部过滤条件的同时，还支持通过标题（title）和描述（content）中的关键词搜索工单。

前端判断过滤条件中是否包含关键词，包含则使用 `GET /api/2/tickets/search` 进行搜索，否则使用 `GET /api/2/tickets`。

### 与旧版的差别
不支持通过 nid 进行搜索。~~考虑到这个功能实在是太离谱了~~ 因为全文搜索只支持为 10 个字段创建索引，目前没有为 privateTags 创建索引，导致无法通过私有标签进行搜索。所以想把 nid 的索引让给 privateTags。

还不支持高亮显示关键词，这个后续再加罢 🏃 

## 其他改动
- 支持通过创建者（authorId）搜索工单
- 支持通过评价（evaluation.star）搜索工单

旧版的关键词搜索是 @fareco 做的，有时间的话也看一眼吧 :lespect: