### PR TITLE
feat(next): support category template configuration

### DIFF
--- a/next/api/src/controller/category.ts
+++ b/next/api/src/controller/category.ts
@@ -48,16 +48,10 @@ const createCategorySchema = z.object({
   articleIds: z.array(z.string()).optional(),
   groupId: z.string().optional(),
   formId: z.string().optional(),
+  template: z.string().optional(),
 });
 
-const updateCategorySchema = z.object({
-  name: z.string().optional(),
-  description: z.string().optional(),
-  parentId: z.string().optional(),
-  noticeIds: z.array(z.string()).optional(),
-  articleIds: z.array(z.string()).optional(),
-  groupId: z.string().optional(),
-  formId: z.string().optional(),
+const updateCategorySchema = createCategorySchema.partial().extend({
   position: z.number().optional(),
   active: z.boolean().optional(),
 });
@@ -116,6 +110,7 @@ export class CategoryController {
         noticeIds: data.noticeIds?.length === 0 ? undefined : data.noticeIds,
         groupId: data.groupId,
         formId: data.formId,
+        qTemplate: data.template,
       },
       currentUser.getAuthOptions()
     );
@@ -202,6 +197,7 @@ export class CategoryController {
       FAQIds: data.articleIds?.length === 0 ? null : data.articleIds,
       groupId: data.groupId,
       formId: data.formId,
+      qTemplate: data.template,
       order: data.position ?? deletedAt?.getTime(),
       deletedAt,
     };

--- a/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
+++ b/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
@@ -94,6 +94,7 @@ export interface CategoryFormData {
   articleIds?: string[];
   groupId?: string;
   formId?: string;
+  template?: string;
 }
 
 export interface CategoryFormProps {
@@ -261,6 +262,16 @@ export function CategoryForm({
         render={({ field }) => (
           <Form.Item label="关联工单表单" htmlFor="category_form_form_id" style={FORM_ITEM_STYLE}>
             <TicketFormSelect {...field} id="category_form_form_id" />
+          </Form.Item>
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="template"
+        render={({ field }) => (
+          <Form.Item label="问题描述模板" htmlFor="category_form_template" style={FORM_ITEM_STYLE}>
+            <TextArea {...field} id="category_form_template" rows={5} />
           </Form.Item>
         )}
       />

--- a/next/web/src/App/Admin/Settings/Categories/index.tsx
+++ b/next/web/src/App/Admin/Settings/Categories/index.tsx
@@ -475,6 +475,7 @@ export function CategoryDetail() {
       'articleIds',
       'groupId',
       'formId',
+      'template',
     ]);
   }, [category]);
 

--- a/next/web/src/api/category.ts
+++ b/next/web/src/api/category.ts
@@ -136,6 +136,7 @@ export interface CreateCategoryData {
   articleIds?: string[];
   groupId?: string;
   formId?: string;
+  template?: string;
 }
 
 async function createCategory(data: CreateCategoryData) {


### PR DESCRIPTION
https://xindong.slack.com/archives/C01RY5JHB47/p1646386748768599

next 前端是直接 serve 的静态文件，拿不到云引擎的环境变量，所以就先不判断用的哪种模板了，都允许配置。