### PR TITLE
feat: metaData trigger condition

### DIFF
--- a/api/Ticket.js
+++ b/api/Ticket.js
@@ -61,6 +61,7 @@ function ticketObjectToEventTicket(ticket) {
     title: ticket.get('title'),
     content: ticket.get('content'),
     status: ticket.get('status'),
+    metaData: ticket.get('metaData'),
     createdAt: ticket.createdAt.toISOString(),
     updatedAt: ticket.updatedAt.toISOString(),
   }

--- a/api/ticket/api.js
+++ b/api/ticket/api.js
@@ -81,6 +81,7 @@ function getEventTicket(ticket) {
     title: ticket.title,
     content: ticket.content,
     status: ticket.status,
+    metaData: ticket.metaData,
     createdAt: ticket.created_at.toISOString(),
     updatedAt: ticket.updated_at.toISOString(),
   }

--- a/api/ticket/model.js
+++ b/api/ticket/model.js
@@ -43,6 +43,12 @@ class Ticket {
 
     /**
      * @readonly
+     * @type {object}
+     */
+    this.metaData = object.get('metaData')
+
+    /**
+     * @readonly
      */
     this.created_at = object.createdAt
 

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -181,6 +181,7 @@ export class Ticket extends Model {
   joinedCustomerServices?: TinyUserInfo[];
 
   @field()
+  @serialize()
   metaData?: Record<string, any>;
 
   @field()

--- a/next/api/src/ticket/automation/condition/metaData.ts
+++ b/next/api/src/ticket/automation/condition/metaData.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import _ from 'lodash';
+
+import { Condition, ConditionFactory } from '.';
+
+interface MetaDataCondition {
+  path: string;
+  value: any;
+}
+
+const is: ConditionFactory<MetaDataCondition> = ({ path, value }) => {
+  return {
+    test: (ctx) => {
+      const metaData = ctx.getMetaData();
+      if (!metaData) {
+        return false;
+      }
+      return _.isEqual(_.get(metaData, path), value);
+    },
+  };
+};
+
+const schema = z.object({
+  op: z.literal('is'),
+  path: z.string(),
+  value: z.any(),
+});
+
+export default function (options: unknown): Condition {
+  const { path, value } = schema.parse(options);
+  return is({ path, value });
+}

--- a/next/api/src/ticket/automation/context.ts
+++ b/next/api/src/ticket/automation/context.ts
@@ -115,6 +115,10 @@ export class Context {
     this.updater.addPrivateTag(tag);
   }
 
+  getMetaData() {
+    return this.ticket.metaData;
+  }
+
   async finish() {
     await this.updater.update(systemUser, { ignoreTrigger: true });
   }

--- a/next/api/src/ticket/automation/time-trigger/condition/index.ts
+++ b/next/api/src/ticket/automation/time-trigger/condition/index.ts
@@ -8,6 +8,7 @@ import authorId from '../../condition/authorId';
 import assigneeId from '../../condition/assigneeId';
 import groupId from '../../condition/groupId';
 import status from '../../condition/status';
+import metaData from '../../condition/metaData';
 
 import { TimeTriggerContext } from '../context';
 import sinceCreated from './sinceCreated';
@@ -22,6 +23,7 @@ const factories: Record<string, ConditionFactory<unknown, TimeTriggerContext>> =
   assigneeId,
   groupId,
   status,
+  metaData,
   sinceCreated,
   sinceUpdated,
   sinceAssigned,

--- a/next/api/src/ticket/automation/trigger/condition/index.ts
+++ b/next/api/src/ticket/automation/trigger/condition/index.ts
@@ -6,6 +6,7 @@ import content from '../../condition/content';
 import categoryId from '../../condition/categoryId';
 import groupId from '../../condition/groupId';
 import status from '../../condition/status';
+import metaData from '../../condition/metaData';
 
 import { TriggerContext } from '../context';
 import ticket from './ticket';
@@ -22,6 +23,7 @@ const factories: Record<string, ConditionFactory<unknown, TriggerContext>> = {
   assigneeId,
   groupId,
   status,
+  metaData,
   currentUserId,
   any: any(condition),
   all: all(condition),

--- a/next/web/src/App/Admin/Settings/Automations/TimeTriggers/conditions/index.ts
+++ b/next/web/src/App/Admin/Settings/Automations/TimeTriggers/conditions/index.ts
@@ -5,6 +5,7 @@ import { AssigneeId } from '../../conditions/AssigneeId';
 import { GroupId } from '../../conditions/GroupId';
 import { Status } from '../../conditions/Status';
 import { NumberValue } from '../../conditions/NumberValue';
+import { MetaData } from '../../conditions/MetaData'
 
 export default {
   title: {
@@ -46,5 +47,9 @@ export default {
   sinceAssigned: {
     label: '小时数-自工单被分配负责人开始',
     component: NumberValue,
+  },
+  metaData: {
+    label: 'metaData',
+    component: MetaData,
   },
 };

--- a/next/web/src/App/Admin/Settings/Automations/Triggers/conditions/index.ts
+++ b/next/web/src/App/Admin/Settings/Automations/Triggers/conditions/index.ts
@@ -2,6 +2,7 @@ import { StringValue } from '../../conditions/StringValue';
 import { CategoryId } from '../../conditions/CategoryId';
 import { GroupId } from '../../conditions/GroupId';
 import { Status } from '../../conditions/Status';
+import { MetaData } from '../../conditions/MetaData';
 
 import { Ticket } from './Ticket';
 import { AuthorId } from './AuthorId';
@@ -44,5 +45,9 @@ export default {
   currentUserId: {
     label: '当前用户',
     component: CurrentUserId,
+  },
+  metaData: {
+    label: 'metaData',
+    component: MetaData,
   },
 };

--- a/next/web/src/App/Admin/Settings/Automations/conditions/MetaData.tsx
+++ b/next/web/src/App/Admin/Settings/Automations/conditions/MetaData.tsx
@@ -1,0 +1,84 @@
+import { forwardRef, useEffect, useRef, useState } from 'react';
+import { Controller } from 'react-hook-form';
+import { TextAreaRef } from 'antd/lib/input/TextArea';
+
+import { Form, Input, Select } from '@/components/antd';
+
+const { TextArea } = Input;
+const { Option } = Select;
+
+interface JSONInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const JSONInput = forwardRef<TextAreaRef, JSONInputProps>(({ value, onChange }, ref) => {
+  const [tempValue, setTempValue] = useState(() => {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '';
+    }
+  });
+  const $onChange = useRef(onChange);
+  $onChange.current = onChange;
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      try {
+        $onChange.current(JSON.parse(tempValue));
+      } catch {
+        $onChange.current('');
+      }
+    }, 500);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [tempValue]);
+
+  return (
+    <TextArea
+      ref={ref}
+      placeholder="请填写 JSON 字符串"
+      value={tempValue}
+      onChange={(e) => setTempValue(e.target.value)}
+    />
+  );
+});
+
+export function MetaData({ path }: { path: string }) {
+  return (
+    <>
+      <Controller
+        name={`${path}.path`}
+        rules={{ required: true }}
+        render={({ field, fieldState: { error } }) => (
+          <Form.Item validateStatus={error ? 'error' : undefined}>
+            <Input {...field} placeholder="path" style={{ width: 200 }} />
+          </Form.Item>
+        )}
+      />
+
+      <Controller
+        name={`${path}.op`}
+        rules={{ required: true }}
+        defaultValue="is"
+        render={({ field }) => (
+          <Select {...field} style={{ width: 200 }}>
+            <Option value="is">是</Option>
+          </Select>
+        )}
+      />
+
+      <Controller
+        name={`${path}.value`}
+        rules={{ required: true }}
+        render={({ field, fieldState: { error } }) => (
+          <Form.Item className="w-full" validateStatus={error ? 'error' : undefined}>
+            <JSONInput {...field} />
+          </Form.Item>
+        )}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
https://xindong.slack.com/archives/C01RY5JHB47/p1646810532737339
此为第二步：增加判断 metaData 的触发器条件。

通过 lodash 的 get 方法获取 metaData 中指定 path 的数据，通过 isEqual 判断是否相等。