### PR TITLE
feat(next): dynamic content management

### DIFF
--- a/next/api/src/controller/dynamic-content.ts
+++ b/next/api/src/controller/dynamic-content.ts
@@ -44,6 +44,7 @@ const localeSchema = z
 
 const variantSchema = z.object({
   locale: localeSchema,
+  active: z.boolean().optional(),
   content: z.string(),
 });
 
@@ -59,10 +60,11 @@ const updateDynamicContentSchema = createDynamicContentSchema
   })
   .partial();
 
-const updateVariantSchema = z.object({
-  content: z.string().optional(),
-  active: z.boolean().optional(),
-});
+const updateVariantSchema = variantSchema
+  .omit({
+    locale: true,
+  })
+  .partial();
 
 type CreateDynamicContentData = z.infer<typeof createDynamicContentSchema>;
 
@@ -193,7 +195,7 @@ export class DynamicContentController {
       ...data,
       ACL,
       dynamicContentId: dc.id,
-      active: true,
+      active: data.active ?? true,
     });
 
     return {

--- a/next/api/src/controller/dynamic-content.ts
+++ b/next/api/src/controller/dynamic-content.ts
@@ -1,0 +1,273 @@
+import { z } from 'zod';
+import AV from 'leancloud-storage';
+import { Context } from 'koa';
+
+import {
+  Body,
+  Controller,
+  Ctx,
+  CurrentUser,
+  Delete,
+  Get,
+  HttpError,
+  Param,
+  Patch,
+  Post,
+  Query,
+  ResponseBody,
+  StatusCode,
+  UseMiddlewares,
+} from '@/common/http';
+import { LOCALES } from '@/i18n/locales';
+import { FindModelPipe, ParseIntPipe, ZodValidationPipe } from '@/common/pipe';
+import { User } from '@/model/User';
+import { auth, customerServiceOnly } from '@/middleware';
+import { ACLBuilder, AuthOptions } from '@/orm';
+import { DynamicContent } from '@/model/DynamicContent';
+import { DynamicContentVariant } from '@/model/DynamicContentVariant';
+import { DynamicContentResponse } from '@/response/dynamic-content';
+import { DynamicContentVariantResponse } from '@/response/dynamic-content-variant';
+
+const dynamicContentNameSchema = z.string().regex(/^[a-zA-Z0-9_]+$/);
+
+const localeSchema = z
+  .string()
+  .transform((s) => s.toLowerCase())
+  .superRefine((s, ctx) => {
+    if (!LOCALES.includes(s)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_enum_value,
+        options: LOCALES,
+      });
+    }
+  });
+
+const variantSchema = z.object({
+  locale: localeSchema,
+  content: z.string(),
+});
+
+const createDynamicContentSchema = z.object({
+  name: dynamicContentNameSchema,
+  defaultLocale: localeSchema,
+  content: z.string(),
+});
+
+const updateDynamicContentSchema = createDynamicContentSchema
+  .omit({
+    content: true,
+  })
+  .partial();
+
+const updateVariantSchema = z.object({
+  content: z.string().optional(),
+  active: z.boolean().optional(),
+});
+
+type CreateDynamicContentData = z.infer<typeof createDynamicContentSchema>;
+
+type UpdateDynamicContentData = z.infer<typeof updateDynamicContentSchema>;
+
+type CreateVariantData = z.infer<typeof variantSchema>;
+
+type UpdateVariantData = z.infer<typeof updateVariantSchema>;
+
+@Controller('dynamic-contents')
+@UseMiddlewares(auth, customerServiceOnly)
+export class DynamicContentController {
+  @Post()
+  @StatusCode(201)
+  async create(
+    @CurrentUser() currentUser: User,
+    @Body(new ZodValidationPipe(createDynamicContentSchema)) data: CreateDynamicContentData
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    await this.assertNoNameConflict(data.name, authOptions);
+
+    const ACL = new ACLBuilder().allow('*', 'read').allowCustomerService('write');
+    const dc = await DynamicContent.create(
+      {
+        ACL,
+        name: data.name,
+        defaultLocale: data.defaultLocale,
+      },
+      authOptions
+    );
+    await DynamicContentVariant.create(
+      {
+        ACL,
+        dynamicContentId: dc.id,
+        active: true,
+        locale: data.defaultLocale,
+        content: data.content,
+      },
+      authOptions
+    );
+
+    return {
+      id: dc.id,
+    };
+  }
+
+  @Patch(':id')
+  async update(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
+    @Body(new ZodValidationPipe(updateDynamicContentSchema)) data: UpdateDynamicContentData
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    if (data.name && data.name !== dc.name) {
+      await this.assertNoNameConflict(data.name, authOptions);
+    }
+    if (data.defaultLocale) {
+      const dcv = await DynamicContentVariant.queryBuilder()
+        .where('dynamicContent', '==', dc.toPointer())
+        .where('locale', '==', data.defaultLocale)
+        .first(authOptions);
+      if (!dcv) {
+        throw new HttpError(422, `variant with locale ${data.defaultLocale} does not exist`);
+      }
+    }
+    await dc.update(data, authOptions);
+    return {};
+  }
+
+  @Get()
+  @ResponseBody(DynamicContentResponse)
+  async find(
+    @Ctx() ctx: Context,
+    @CurrentUser() currentUser: User,
+    @Query('page', new ParseIntPipe({ min: 1 })) page = 1,
+    @Query('pageSize', new ParseIntPipe({ min: 0, max: 100 })) pageSize = 10
+  ) {
+    const [dcs, count] = await DynamicContent.queryBuilder()
+      .orderBy('createdAt', 'desc')
+      .skip((page - 1) * pageSize)
+      .limit(pageSize)
+      .findAndCount(currentUser.getAuthOptions());
+
+    ctx.set('x-total-count', count.toString());
+    return dcs;
+  }
+
+  @Get(':id')
+  @ResponseBody(DynamicContentResponse)
+  findOne(@Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent) {
+    return dc;
+  }
+
+  @Delete(':id')
+  async delete(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    const variants = await DynamicContentVariant.queryBuilder()
+      .where('dynamicContent', '==', dc.toPointer())
+      .find(authOptions);
+    const objects = [
+      AV.Object.createWithoutData('DynamicContent', dc.id),
+      ...variants.map(({ id }) => AV.Object.createWithoutData('DynamicContentVariant', id)),
+    ];
+    await AV.Object.destroyAll(objects, authOptions);
+    return {};
+  }
+
+  @Post(':id/variants')
+  async createVariant(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
+    @Body(new ZodValidationPipe(variantSchema)) data: CreateVariantData
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    const sameLocaleVariant = await DynamicContentVariant.queryBuilder()
+      .where('dynamicContent', '==', dc.toPointer())
+      .where('locale', '==', data.locale)
+      .first(authOptions);
+    if (sameLocaleVariant) {
+      throw new HttpError(409, `variant with locale "${data.locale}" already exists`);
+    }
+
+    const ACL = new ACLBuilder().allow('*', 'read').allowCustomerService('write');
+    const variant = await DynamicContentVariant.create({
+      ...data,
+      ACL,
+      dynamicContentId: dc.id,
+      active: true,
+    });
+
+    return {
+      id: variant.id,
+    };
+  }
+
+  @Get(':id/variants')
+  async findVariants(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent
+  ) {
+    const variants = await DynamicContentVariant.queryBuilder()
+      .where('dynamicContent', '==', dc.toPointer())
+      .find(currentUser.getAuthOptions());
+    return variants.map((v) => new DynamicContentVariantResponse(dc, v));
+  }
+
+  @Get(':id/variants/:vid')
+  async findVariant(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
+    @Param('vid') vid: string
+  ) {
+    const variant = await this.findVariantOrFail(dc.id, vid, currentUser.getAuthOptions());
+    return new DynamicContentVariantResponse(dc, variant);
+  }
+
+  @Patch(':id/variants/:vid')
+  async updateVariant(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
+    @Param('vid') vid: string,
+    @Body(new ZodValidationPipe(updateVariantSchema)) data: UpdateVariantData
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    const variant = await this.findVariantOrFail(dc.id, vid, authOptions);
+    if (data.active === false && variant.locale === dc.defaultLocale) {
+      throw new HttpError(400, 'cannot inactive default variant');
+    }
+    await variant.update(data, authOptions);
+    return {};
+  }
+
+  @Delete(':id/variants/:vid')
+  async deleteVariant(
+    @CurrentUser() currentUser: User,
+    @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
+    @Param('vid') vid: string
+  ) {
+    const authOptions = currentUser.getAuthOptions();
+    const variant = await this.findVariantOrFail(dc.id, vid, authOptions);
+    if (variant.locale === dc.defaultLocale) {
+      throw new HttpError(400, 'cannot delete default variant');
+    }
+    await variant.delete(authOptions);
+    return {};
+  }
+
+  private async assertNoNameConflict(name: string, options: AuthOptions) {
+    const dc = await DynamicContent.queryBuilder().where('name', '==', name).first(options);
+    if (dc) {
+      throw new HttpError(409, `name ${name} already exists`);
+    }
+  }
+
+  private async findVariantOrFail(dcId: string, variantId: string, options?: AuthOptions) {
+    const variant = await DynamicContentVariant.queryBuilder()
+      .where('dynamicContent', '==', DynamicContent.ptr(dcId))
+      .where('objectId', '==', variantId)
+      .first(options);
+    if (!variant) {
+      throw new HttpError(404, `variant ${variantId} does not exist`);
+    }
+    return variant;
+  }
+}

--- a/next/api/src/controller/dynamic-content.ts
+++ b/next/api/src/controller/dynamic-content.ts
@@ -129,6 +129,9 @@ export class DynamicContentController {
       if (!dcv) {
         throw new HttpError(422, `variant with locale ${data.defaultLocale} does not exist`);
       }
+      if (!dcv.active) {
+        throw new HttpError(422, `variant ${dcv.locale} is inactive`);
+      }
     }
     await dc.update(data, authOptions);
     return {};

--- a/next/api/src/controller/dynamic-content.ts
+++ b/next/api/src/controller/dynamic-content.ts
@@ -204,24 +204,24 @@ export class DynamicContentController {
   }
 
   @Get(':id/variants')
-  async findVariants(
+  @ResponseBody(DynamicContentVariantResponse)
+  findVariants(
     @CurrentUser() currentUser: User,
     @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent
   ) {
-    const variants = await DynamicContentVariant.queryBuilder()
+    return DynamicContentVariant.queryBuilder()
       .where('dynamicContent', '==', dc.toPointer())
       .find(currentUser.getAuthOptions());
-    return variants.map((v) => new DynamicContentVariantResponse(dc, v));
   }
 
   @Get(':id/variants/:vid')
-  async findVariant(
+  @ResponseBody(DynamicContentVariantResponse)
+  findVariant(
     @CurrentUser() currentUser: User,
     @Param('id', new FindModelPipe(DynamicContent)) dc: DynamicContent,
     @Param('vid') vid: string
   ) {
-    const variant = await this.findVariantOrFail(dc.id, vid, currentUser.getAuthOptions());
-    return new DynamicContentVariantResponse(dc, variant);
+    return this.findVariantOrFail(dc.id, vid, currentUser.getAuthOptions());
   }
 
   @Patch(':id/variants/:vid')

--- a/next/api/src/controller/ticket-field.ts
+++ b/next/api/src/controller/ticket-field.ts
@@ -26,23 +26,7 @@ import {
 import { auth, customerServiceOnly } from '@/middleware';
 import { FIELD_TYPES, OPTION_TYPES, TicketField } from '@/model/TicketField';
 import { TicketFieldResponse } from '@/response/ticket-field';
-
-const LOCALES = [
-  'zh-cn',
-  'zh-tw',
-  'zh-hk',
-  'en',
-  'ja',
-  'ko',
-  'id',
-  'th',
-  'de',
-  'fr',
-  'ru',
-  'es',
-  'pt',
-  'tr',
-];
+import { LOCALES } from '@/i18n/locales';
 
 const localeSchema = z
   .string()

--- a/next/api/src/i18n/locales.ts
+++ b/next/api/src/i18n/locales.ts
@@ -1,0 +1,16 @@
+export const LOCALES = [
+  'zh-cn',
+  'zh-tw',
+  'zh-hk',
+  'en',
+  'ja',
+  'ko',
+  'id',
+  'th',
+  'de',
+  'fr',
+  'ru',
+  'es',
+  'pt',
+  'tr',
+];

--- a/next/api/src/model/DynamicContent.ts
+++ b/next/api/src/model/DynamicContent.ts
@@ -1,0 +1,13 @@
+import { field, hasManyThroughPointer, Model } from '@/orm';
+import { DynamicContentVariant } from './DynamicContentVariant';
+
+export class DynamicContent extends Model {
+  @field()
+  name!: string;
+
+  @field()
+  defaultLocale!: string;
+
+  @hasManyThroughPointer(() => DynamicContentVariant)
+  variants?: DynamicContentVariant[];
+}

--- a/next/api/src/model/DynamicContentVariant.ts
+++ b/next/api/src/model/DynamicContentVariant.ts
@@ -1,0 +1,16 @@
+import { field, Model, pointerId } from '@/orm';
+import { DynamicContent } from './DynamicContent';
+
+export class DynamicContentVariant extends Model {
+  @pointerId(() => DynamicContent)
+  dynamicContentId!: string;
+
+  @field()
+  locale!: string;
+
+  @field()
+  content!: string;
+
+  @field()
+  active!: boolean;
+}

--- a/next/api/src/response/dynamic-content-variant.ts
+++ b/next/api/src/response/dynamic-content-variant.ts
@@ -1,0 +1,18 @@
+import { DynamicContent } from '@/model/DynamicContent';
+import { DynamicContentVariant } from '@/model/DynamicContentVariant';
+
+export class DynamicContentVariantResponse {
+  constructor(readonly dc: DynamicContent, readonly variant: DynamicContentVariant) {}
+
+  toJSON() {
+    return {
+      id: this.variant.id,
+      locale: this.variant.locale,
+      content: this.variant.content,
+      active: this.variant.active,
+      default: this.dc.defaultLocale === this.variant.locale,
+      createdAt: this.variant.createdAt,
+      updatedAt: this.variant.updatedAt,
+    };
+  }
+}

--- a/next/api/src/response/dynamic-content-variant.ts
+++ b/next/api/src/response/dynamic-content-variant.ts
@@ -1,8 +1,7 @@
-import { DynamicContent } from '@/model/DynamicContent';
 import { DynamicContentVariant } from '@/model/DynamicContentVariant';
 
 export class DynamicContentVariantResponse {
-  constructor(readonly dc: DynamicContent, readonly variant: DynamicContentVariant) {}
+  constructor(readonly variant: DynamicContentVariant) {}
 
   toJSON() {
     return {
@@ -10,7 +9,6 @@ export class DynamicContentVariantResponse {
       locale: this.variant.locale,
       content: this.variant.content,
       active: this.variant.active,
-      default: this.dc.defaultLocale === this.variant.locale,
       createdAt: this.variant.createdAt,
       updatedAt: this.variant.updatedAt,
     };

--- a/next/api/src/response/dynamic-content.ts
+++ b/next/api/src/response/dynamic-content.ts
@@ -1,0 +1,15 @@
+import { DynamicContent } from '@/model/DynamicContent';
+
+export class DynamicContentResponse {
+  constructor(readonly dc: DynamicContent) {}
+
+  toJSON() {
+    return {
+      id: this.dc.id,
+      name: this.dc.name,
+      defaultLocale: this.dc.defaultLocale,
+      createdAt: this.dc.createdAt,
+      updatedAt: this.dc.updatedAt,
+    };
+  }
+}

--- a/next/api/src/utils/template.ts
+++ b/next/api/src/utils/template.ts
@@ -1,0 +1,99 @@
+enum TokenType {
+  Text,
+  Name,
+}
+
+enum State {
+  Text,
+  LeftBrace,
+  Name,
+  RightBrace,
+}
+
+interface Token {
+  type: TokenType;
+  content: string;
+}
+
+export class Template {
+  private tokens: Token[];
+
+  readonly names: string[];
+
+  constructor(readonly template: string) {
+    this.tokens = Template.parse(template);
+    this.names = this.tokens
+      .filter((token) => token.type === TokenType.Name)
+      .map((token) => token.content);
+  }
+
+  render(names: Record<string, string>) {
+    if (this.names.length === 0) {
+      return this.template;
+    }
+    return this.tokens
+      .map(({ type, content }) => {
+        if (type === TokenType.Text) {
+          return content;
+        }
+        const name = names[content];
+        return name ?? '';
+      })
+      .join('');
+  }
+
+  static parse(template: string): Token[] {
+    const tokens: Token[] = [];
+
+    let state = State.Text;
+    let content = '';
+
+    for (let i = 0; i < template.length; ++i) {
+      const ch = template[i];
+      content += ch;
+
+      if (state === State.Text) {
+        if (ch === '{') {
+          state = State.LeftBrace;
+        }
+      } else if (state === State.LeftBrace) {
+        if (ch === '{') {
+          state = State.Name;
+          if (content.length > 2) {
+            tokens.push({
+              type: TokenType.Text,
+              content: content.slice(0, -2),
+            });
+          }
+          content = '';
+        } else {
+          state = State.Text;
+        }
+      } else if (state === State.Name) {
+        if (ch === '}') {
+          state = State.RightBrace;
+        }
+      } else if (state === State.RightBrace) {
+        if (ch === '}') {
+          state = State.Text;
+          tokens.push({
+            type: TokenType.Name,
+            content: content.slice(0, -2).trim(),
+          });
+          content = '';
+        } else {
+          state = State.Name;
+        }
+      }
+    }
+
+    if (content) {
+      tokens.push({
+        type: TokenType.Text,
+        content: content,
+      });
+    }
+
+    return tokens;
+  }
+}

--- a/next/web/src/App/Admin/Settings/DynamicContents/DynamicContentForm.tsx
+++ b/next/web/src/App/Admin/Settings/DynamicContents/DynamicContentForm.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Controller, useForm } from 'react-hook-form';
+
+import { LOCALES } from '@/i18n/locales';
+import { Button, Form, Input, Select } from '@/components/antd';
+
+const { TextArea } = Input;
+
+export interface DynamicContentFormData {
+  name: string;
+  defaultLocale: string;
+  content: string;
+}
+
+export interface DynamicContentFormProps {
+  initData?: Partial<DynamicContentFormData>;
+  submitting?: boolean;
+  onSubmit: (data: DynamicContentFormData) => void;
+}
+
+export function DynamicContentForm({ initData, submitting, onSubmit }: DynamicContentFormProps) {
+  const { control, handleSubmit } = useForm<DynamicContentFormData>({ defaultValues: initData });
+
+  const localeOptions = useMemo(() => {
+    return Object.entries(LOCALES).map(([value, label]) => ({ label, value }));
+  }, []);
+
+  return (
+    <Form layout="vertical" onFinish={handleSubmit(onSubmit)}>
+      <Controller
+        control={control}
+        name="name"
+        rules={{
+          required: '请填写名称',
+          pattern: {
+            value: /^[a-zA-Z0-9_]+$/,
+            message: '请仅使用 A-Z、0-9、_',
+          },
+        }}
+        render={({ field, fieldState: { error } }) => (
+          <Form.Item
+            label="名称"
+            htmlFor="dc_form_name"
+            required
+            validateStatus={error ? 'error' : undefined}
+            help={error?.message}
+          >
+            <Input {...field} id="dc_form_name" autoFocus />
+          </Form.Item>
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="defaultLocale"
+        rules={{ required: '请填写默认语言' }}
+        render={({ field, fieldState: { error } }) => (
+          <Form.Item
+            label="默认语言"
+            htmlFor="dc_form_defaultLocale"
+            extra="此动态内容项目的默认语言。"
+            required
+            validateStatus={error ? 'error' : undefined}
+            help={error?.message}
+          >
+            <Select {...field} id="dc_form_defaultLocale" options={localeOptions} />
+          </Form.Item>
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="content"
+        rules={{ required: '请填写内容' }}
+        render={({ field, fieldState: { error } }) => (
+          <Form.Item
+            label="内容"
+            htmlFor="dc_form_content"
+            extra="动态内容的文本。您也可以在您的文本中使用占位符。"
+            required
+            validateStatus={error ? 'error' : undefined}
+            help={error?.message}
+          >
+            <TextArea {...field} id="dc_form_content" rows={10} />
+          </Form.Item>
+        )}
+      />
+
+      <div className="flex">
+        <div className="grow"></div>
+        <Link to="..">
+          <Button type="link" disabled={submitting}>
+            取消
+          </Button>
+        </Link>
+        <Button className="ml-1" type="primary" htmlType="submit" loading={submitting}>
+          创建
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/next/web/src/App/Admin/Settings/DynamicContents/index.tsx
+++ b/next/web/src/App/Admin/Settings/DynamicContents/index.tsx
@@ -1,0 +1,596 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Controller, useForm } from 'react-hook-form';
+import { useQueryClient } from 'react-query';
+import moment from 'moment';
+import { FormInstance } from 'antd/lib/form';
+
+import { LOCALES } from '@/i18n/locales';
+import {
+  CreateDynamicContentVariantData,
+  DynamicContentSchema,
+  DynamicContentVariantSchema,
+  UpdateDynamicContentVariantData,
+  useCreateDynamicContent,
+  useCreateDynamicContentVariant,
+  useDeleteDynamicContent,
+  useDeleteDynamicContentVariant,
+  useDynamicContent,
+  useDynamicContents,
+  useDynamicContentVariants,
+  useUpdateDynamicContent,
+  useUpdateDynamicContentVariant,
+} from '@/api/dynamic-content';
+import {
+  message,
+  Breadcrumb,
+  Button,
+  Divider,
+  Form,
+  Input,
+  Modal,
+  Radio,
+  Select,
+  Spin,
+  Table,
+} from '@/components/antd';
+import { usePage } from '@/utils/usePage';
+import { DynamicContentForm } from './DynamicContentForm';
+
+const { TextArea } = Input;
+const { Column } = Table;
+
+const PAGE_SIZE = 40;
+
+export function DynamicContentList() {
+  const [page, { set: setPage }] = usePage();
+
+  const { data, count, isLoading } = useDynamicContents({
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const queryClient = useQueryClient();
+  const { mutate: remove, isLoading: removing } = useDeleteDynamicContent({
+    onSuccess: () => {
+      message.success('已删除');
+      queryClient.invalidateQueries('dynamicContents');
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  const handleRemove = (id: string) => {
+    Modal.confirm({
+      title: '删除动态内容',
+      content: '该操作不可恢复',
+      okType: 'danger',
+      onOk: () => remove(id),
+    });
+  };
+
+  return (
+    <div className="p-10">
+      <div className="flex flex-row-reverse mb-4">
+        <Link to="new">
+          <Button type="primary">添加</Button>
+        </Link>
+      </div>
+
+      <Table
+        rowKey="id"
+        loading={isLoading}
+        dataSource={data}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          onChange: setPage,
+          showSizeChanger: false,
+          total: count,
+        }}
+      >
+        <Column key="name" title="名称" render={({ id, name }) => <Link to={id}>{name}</Link>} />
+        <Column
+          dataIndex="defaultLocale"
+          title="默认"
+          render={(locale) => LOCALES[locale] ?? 'unknown'}
+        />
+        <Column
+          dataIndex="updatedAt"
+          title="最后更新于"
+          render={(ts) => <div title={ts}>{moment(ts).fromNow()}</div>}
+        />
+        <Column
+          key="actions"
+          render={({ id }) => (
+            <div>
+              <Button
+                type="link"
+                danger
+                disabled={removing}
+                onClick={() => handleRemove(id)}
+                style={{ padding: 0, border: 'none', height: 22 }}
+              >
+                删除
+              </Button>
+            </div>
+          )}
+        />
+      </Table>
+    </div>
+  );
+}
+
+export function NewDynamicContent() {
+  const navigate = useNavigate();
+
+  const { mutate, isLoading } = useCreateDynamicContent({
+    onSuccess: () => {
+      message.success('创建成功');
+      navigate('..');
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  return (
+    <div className="p-10">
+      <DynamicContentForm submitting={isLoading} onSubmit={mutate} />
+    </div>
+  );
+}
+
+interface EditDynamicContentModalProps {
+  visible: boolean;
+  onHide: () => void;
+  dc: DynamicContentSchema;
+  locales?: string[];
+}
+
+function EditDynamicContentModal({ visible, onHide, dc, locales }: EditDynamicContentModalProps) {
+  const localeOptions = useMemo(
+    () =>
+      locales?.map((locale) => ({
+        label: LOCALES[locale] ?? 'unknown',
+        value: locale,
+      })),
+    [locales]
+  );
+
+  const { control, handleSubmit, reset } = useForm();
+
+  useEffect(() => {
+    if (!visible) {
+      reset({
+        name: dc.name,
+        defaultLocale: dc.defaultLocale,
+      });
+    }
+  }, [visible]);
+
+  const $form = useRef<FormInstance>(null!);
+
+  const queryClient = useQueryClient();
+
+  const { mutate, isLoading } = useUpdateDynamicContent({
+    onSuccess: () => {
+      message.success('保存成功');
+      queryClient.invalidateQueries(['dynamicContent', dc.id]);
+      onHide();
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  return (
+    <Modal
+      destroyOnClose
+      title="编辑动态内容"
+      visible={visible}
+      onCancel={() => !isLoading && onHide()}
+      cancelButtonProps={{ disabled: isLoading }}
+      onOk={() => $form.current.submit()}
+      okButtonProps={{ loading: isLoading }}
+    >
+      <Form ref={$form} layout="vertical" onFinish={handleSubmit((data) => mutate([dc.id, data]))}>
+        <Controller
+          control={control}
+          name="name"
+          rules={{
+            required: '请填写名称',
+            pattern: {
+              value: /^[a-zA-Z0-9_]+$/,
+              message: '请仅使用 A-Z、0-9、_',
+            },
+          }}
+          render={({ field, fieldState: { error } }) => (
+            <Form.Item
+              label="名称"
+              htmlFor="dc_form_name"
+              required
+              validateStatus={error ? 'error' : undefined}
+              help={error?.message}
+            >
+              <Input {...field} id="dc_form_name" autoFocus />
+            </Form.Item>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="defaultLocale"
+          rules={{ required: '请填写默认语言' }}
+          render={({ field, fieldState: { error } }) => (
+            <Form.Item
+              label="默认语言"
+              htmlFor="dc_form_defaultLocale"
+              required
+              validateStatus={error ? 'error' : undefined}
+              help={error?.message}
+            >
+              <Select {...field} id="dc_form_defaultLocale" options={localeOptions} />
+            </Form.Item>
+          )}
+        />
+      </Form>
+    </Modal>
+  );
+}
+
+interface AddVariantModalProps {
+  visible: boolean;
+  onHide: () => void;
+  excludeLocales?: string[];
+  dynamicContentId: string;
+}
+
+function AddVariantModal({
+  visible,
+  onHide,
+  excludeLocales,
+  dynamicContentId,
+}: AddVariantModalProps) {
+  const { control, handleSubmit, reset } = useForm<CreateDynamicContentVariantData>();
+
+  useEffect(() => {
+    if (!visible) {
+      reset();
+    }
+  }, [visible]);
+
+  const localeOptions = useMemo(() => {
+    return Object.entries(LOCALES).map(([value, label]) => ({
+      label,
+      value,
+      disabled: excludeLocales?.includes(value),
+    }));
+  }, [excludeLocales]);
+
+  const $form = useRef<FormInstance>(null!);
+
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useCreateDynamicContentVariant({
+    onSuccess: () => {
+      message.success('添加成功');
+      onHide();
+      queryClient.invalidateQueries(['dynamicContentVariants', dynamicContentId]);
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  return (
+    <Modal
+      destroyOnClose
+      title="添加变量"
+      visible={visible}
+      onCancel={() => !isLoading && onHide()}
+      cancelButtonProps={{ disabled: isLoading }}
+      onOk={() => $form.current.submit()}
+      okButtonProps={{ loading: isLoading }}
+      width="80%"
+    >
+      <Form
+        ref={$form}
+        layout="vertical"
+        onFinish={handleSubmit((data) => mutate({ ...data, dynamicContentId }))}
+      >
+        <Controller
+          control={control}
+          name="locale"
+          rules={{ required: '请填写默认语言' }}
+          render={({ field, fieldState: { error } }) => (
+            <Form.Item
+              label="语言"
+              htmlFor="dc_form_locale"
+              extra="动态内容变量的语言。"
+              required
+              validateStatus={error ? 'error' : undefined}
+              help={error?.message}
+            >
+              <Select {...field} id="dc_form_locale" options={localeOptions} autoFocus />
+            </Form.Item>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="active"
+          defaultValue={true}
+          render={({ field }) => (
+            <Form.Item label="状态">
+              <Radio.Group {...field}>
+                <Radio value={true}>活跃的</Radio>
+                <Radio value={false}>非活跃的</Radio>
+              </Radio.Group>
+            </Form.Item>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="content"
+          rules={{ required: '请填写内容' }}
+          render={({ field, fieldState: { error } }) => (
+            <Form.Item
+              label="内容"
+              htmlFor="dc_form_content"
+              extra="动态内容的文本。您也可以在您的文本中使用占位符。"
+              required
+              validateStatus={error ? 'error' : undefined}
+              help={error?.message}
+            >
+              <TextArea {...field} id="dc_form_content" rows={10} />
+            </Form.Item>
+          )}
+        />
+      </Form>
+    </Modal>
+  );
+}
+
+interface EditVariantModalProps {
+  onHide: () => void;
+  dc: DynamicContentSchema;
+  variant?: DynamicContentVariantSchema;
+}
+
+function EditVariantModal({ onHide, dc, variant }: EditVariantModalProps) {
+  const { control, handleSubmit, reset } = useForm<UpdateDynamicContentVariantData>();
+
+  useEffect(() => {
+    if (variant) {
+      reset({
+        active: variant.active,
+        content: variant.content,
+      });
+    } else {
+      reset();
+    }
+  }, [variant]);
+
+  const $form = useRef<FormInstance>(null!);
+
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useUpdateDynamicContentVariant({
+    onSuccess: () => {
+      message.success('已保存');
+      onHide();
+      queryClient.invalidateQueries(['dynamicContentVariants', dc.id]);
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  return (
+    <Modal
+      destroyOnClose
+      title="编辑变量"
+      visible={variant !== undefined}
+      onCancel={() => !isLoading && onHide()}
+      cancelButtonProps={{ disabled: isLoading }}
+      onOk={() => $form.current.submit()}
+      okButtonProps={{ loading: isLoading }}
+      width="80%"
+    >
+      <Form
+        ref={$form}
+        layout="vertical"
+        onFinish={handleSubmit((data) =>
+          mutate({ ...data, dynamicContentId: dc.id, variantId: variant!.id })
+        )}
+      >
+        <Controller
+          control={control}
+          name="active"
+          defaultValue={true}
+          render={({ field }) => (
+            <Form.Item label="状态">
+              <Radio.Group {...field} disabled={dc.defaultLocale === variant?.locale}>
+                <Radio value={true}>活跃的</Radio>
+                <Radio value={false}>非活跃的</Radio>
+              </Radio.Group>
+            </Form.Item>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="content"
+          rules={{ required: '请填写内容' }}
+          render={({ field, fieldState: { error } }) => (
+            <Form.Item
+              label="内容"
+              htmlFor="dc_form_content"
+              extra="动态内容的文本。您也可以在您的文本中使用占位符。"
+              required
+              validateStatus={error ? 'error' : undefined}
+              help={error?.message}
+            >
+              <TextArea {...field} id="dc_form_content" rows={10} />
+            </Form.Item>
+          )}
+        />
+      </Form>
+    </Modal>
+  );
+}
+
+export function DynamicContentDetail() {
+  const { id } = useParams<'id'>();
+
+  const { data: dc, isLoading } = useDynamicContent(id!);
+
+  const { data: variants } = useDynamicContentVariants(id!);
+
+  const [editModalVisible, setEditModalVisible] = useState(false);
+  const [addVariantModalVisible, setAddVariantModalVisible] = useState(false);
+  const [editingVariant, setEditingVariant] = useState<DynamicContentVariantSchema>();
+
+  const locales = useMemo(() => variants?.map((v) => v.locale), [variants]);
+  const activeLocales = useMemo(() => variants?.filter((v) => v.active).map((v) => v.locale), [
+    variants,
+  ]);
+
+  const queryClient = useQueryClient();
+  const { mutate: remove, isLoading: removing } = useDeleteDynamicContentVariant({
+    onSuccess: () => {
+      message.success('已删除');
+      queryClient.invalidateQueries(['dynamicContentVariants', id]);
+    },
+    onError: (error) => {
+      message.error(error.message);
+    },
+  });
+
+  const handleRemove = (variantId: string) => {
+    Modal.confirm({
+      title: '删除变量',
+      content: '该操作不可恢复',
+      okType: 'danger',
+      onOk: () => remove([id!, variantId]),
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-[400px]">
+        <Spin />
+      </div>
+    );
+  }
+
+  if (!dc) {
+    return null;
+  }
+
+  return (
+    <div className="p-10">
+      <div className="flex">
+        <div className="grow">
+          <Breadcrumb>
+            <Breadcrumb.Item>
+              <Link to="..">动态内容</Link>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>{dc.name}</Breadcrumb.Item>
+          </Breadcrumb>
+
+          <div className="mt-2">占位符：{`{{ dc.${dc.name} }}`}</div>
+        </div>
+
+        <div>
+          <Button
+            type="link"
+            onClick={() => setEditModalVisible(true)}
+            style={{ padding: 0, border: 'none', height: 22 }}
+          >
+            编辑
+          </Button>
+        </div>
+      </div>
+
+      <EditDynamicContentModal
+        visible={editModalVisible}
+        onHide={() => setEditModalVisible(false)}
+        dc={dc}
+        locales={activeLocales}
+      />
+
+      <AddVariantModal
+        visible={addVariantModalVisible}
+        onHide={() => setAddVariantModalVisible(false)}
+        excludeLocales={locales}
+        dynamicContentId={dc.id}
+      />
+
+      <EditVariantModal
+        dc={dc}
+        variant={editingVariant}
+        onHide={() => setEditingVariant(undefined)}
+      />
+
+      <Divider />
+
+      <div className="flex flex-row-reverse mb-4">
+        <Button
+          type="link"
+          onClick={() => setAddVariantModalVisible(true)}
+          style={{ padding: 0, border: 'none', height: 22 }}
+        >
+          添加变量
+        </Button>
+      </div>
+
+      <Table rowKey="id" dataSource={variants} pagination={false}>
+        <Column
+          dataIndex="locale"
+          title="语言"
+          render={(locale) => (
+            <>
+              <span>{LOCALES[locale] ?? 'unknown'}</span>
+              {locale === dc.defaultLocale && <span className="font-semibold">（默认）</span>}
+            </>
+          )}
+        />
+
+        <Column dataIndex="content" title="内容" />
+
+        <Column
+          dataIndex="active"
+          title="状态"
+          render={(active) => (active ? '活跃的' : '非活跃的')}
+        />
+
+        <Column
+          key="actions"
+          render={(variant) => (
+            <div>
+              <Button
+                type="link"
+                onClick={() => setEditingVariant(variant)}
+                style={{ padding: 0, border: 'none', height: 22 }}
+              >
+                编辑
+              </Button>
+              <Button
+                className="ml-2"
+                type="link"
+                danger
+                disabled={variant.locale === dc.defaultLocale || removing}
+                onClick={() => handleRemove(variant.id)}
+                style={{ padding: 0, border: 'none', height: 22 }}
+              >
+                删除
+              </Button>
+            </div>
+          )}
+        />
+      </Table>
+    </div>
+  );
+}

--- a/next/web/src/App/Admin/Settings/Menu.tsx
+++ b/next/web/src/App/Admin/Settings/Menu.tsx
@@ -47,6 +47,10 @@ const routeGroups = [
         name: '工单表单',
         path: 'ticket-forms',
       },
+      {
+        name: '动态内容',
+        path: 'dynamic-contents',
+      },
     ],
   },
   {

--- a/next/web/src/App/Admin/Settings/TicketFields/TicketFieldForm.tsx
+++ b/next/web/src/App/Admin/Settings/TicketFields/TicketFieldForm.tsx
@@ -13,6 +13,7 @@ import { BsXCircle } from 'react-icons/bs';
 import cx from 'classnames';
 import { omit } from 'lodash-es';
 
+import { LOCALES } from '@/i18n/locales';
 import { TicketFieldSchema } from '@/api/ticket-field';
 import {
   Button,
@@ -68,23 +69,6 @@ function FieldType({ value, onChange, readonly }: FieldTypeProps) {
     </div>
   );
 }
-
-const LOCALES: Record<string, string> = {
-  'zh-cn': '简体中文',
-  'zh-tw': '繁体中文（台湾）',
-  'zh-hk': '繁体中文（香港）',
-  en: '英文',
-  ja: '日文',
-  ko: '韩文',
-  id: '印尼文',
-  th: '泰文',
-  de: '德文',
-  fr: '法文',
-  ru: '俄文',
-  es: '西班牙文',
-  pt: '葡萄牙文',
-  tr: '土耳其文',
-};
 
 interface LocaleModalProps {
   show: boolean;

--- a/next/web/src/App/Admin/Settings/index.tsx
+++ b/next/web/src/App/Admin/Settings/index.tsx
@@ -11,6 +11,7 @@ import { QuickReplyList, NewQuickReply, QuickReplyDetail } from './QuickReplies'
 import { ViewList, NewView, ViewDetail } from './Views';
 import { TicketFieldList, NewTicketField, TicketFieldDetail } from './TicketFields';
 import { TicketFormList, NewTicketForm, TicketFormDetail } from './TicketForms';
+import { DynamicContentList, NewDynamicContent, DynamicContentDetail } from './DynamicContents';
 import { ArticleDetail, Articles, EditArticle, NewArticle } from './Articles';
 
 import Triggers from './Automations/Triggers';
@@ -59,6 +60,11 @@ const SettingRoutes = () => (
       <Route index element={<TicketFormList />} />
       <Route path="new" element={<NewTicketForm />} />
       <Route path=":id" element={<TicketFormDetail />} />
+    </Route>
+    <Route path="/dynamic-contents">
+      <Route index element={<DynamicContentList />} />
+      <Route path="new" element={<NewDynamicContent />} />
+      <Route path=":id" element={<DynamicContentDetail />} />
     </Route>
     <Route path="/triggers">
       <Route index element={<Triggers />} />

--- a/next/web/src/api/dynamic-content.ts
+++ b/next/web/src/api/dynamic-content.ts
@@ -1,0 +1,183 @@
+import { http } from '@/leancloud';
+import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from 'react-query';
+
+export interface DynamicContentSchema {
+  id: string;
+  name: string;
+  defaultLocale: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DynamicContentVariantSchema {
+  id: string;
+  locale: string;
+  content: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FetchDynamicContentsOptions {
+  page?: number;
+  pageSize?: number;
+}
+
+async function fetchDynamicContents(
+  options?: FetchDynamicContentsOptions
+): Promise<[DynamicContentSchema[], number]> {
+  const { headers, data } = await http.get('/api/2/dynamic-contents', {
+    params: options,
+  });
+  return [data, parseInt(headers['x-total-count'])];
+}
+
+async function fetchDynamicContent(id: string): Promise<DynamicContentSchema> {
+  const { data } = await http.get(`/api/2/dynamic-contents/${id}`);
+  return data;
+}
+
+export interface CreateDynamicContentData {
+  name: string;
+  defaultLocale: string;
+  content: string;
+}
+
+async function createDynamicContent(data: CreateDynamicContentData) {
+  await http.post('/api/2/dynamic-contents', data);
+}
+
+export type UpdateDynamicContentData = Partial<
+  Pick<CreateDynamicContentData, 'name' | 'defaultLocale'>
+>;
+
+async function updateDynamicContent(id: string, data: UpdateDynamicContentData) {
+  await http.patch(`/api/2/dynamic-contents/${id}`, data);
+}
+
+async function deleteDynamicContent(id: string) {
+  await http.delete(`/api/2/dynamic-contents/${id}`);
+}
+
+async function fetchDynamicContentVariants(id: string): Promise<DynamicContentVariantSchema[]> {
+  const { data } = await http.get(`/api/2/dynamic-contents/${id}/variants`);
+  return data;
+}
+
+export interface CreateDynamicContentVariantData {
+  dynamicContentId: string;
+  locale: string;
+  active?: boolean;
+  content: string;
+}
+
+async function createDynamicContentVariant({
+  dynamicContentId,
+  ...data
+}: CreateDynamicContentVariantData) {
+  await http.post(`/api/2/dynamic-contents/${dynamicContentId}/variants`, data);
+}
+
+export interface UpdateDynamicContentVariantData
+  extends Omit<CreateDynamicContentVariantData, 'locale'> {
+  variantId: string;
+}
+
+async function updateDynamicContentVariant({
+  dynamicContentId,
+  variantId,
+  ...data
+}: UpdateDynamicContentVariantData) {
+  await http.patch(`/api/2/dynamic-contents/${dynamicContentId}/variants/${variantId}`, data);
+}
+
+async function deleteDynamicContentVariant(dynamicContentId: string, variantId: string) {
+  await http.delete(`/api/2/dynamic-contents/${dynamicContentId}/variants/${variantId}`);
+}
+
+export interface UseDynamicContentsOptions extends FetchDynamicContentsOptions {
+  queryOptions?: UseQueryOptions<[DynamicContentSchema[], number], Error>;
+}
+
+export const useDynamicContents = ({
+  queryOptions,
+  ...options
+}: UseDynamicContentsOptions = {}) => {
+  const { data, ...result } = useQuery({
+    queryKey: ['dynamicContents', options],
+    queryFn: () => fetchDynamicContents(options),
+    ...queryOptions,
+  });
+
+  return {
+    ...result,
+    data: data?.[0],
+    count: data?.[1],
+  };
+};
+
+export const useDynamicContent = (
+  id: string,
+  options?: UseQueryOptions<DynamicContentSchema, Error>
+) =>
+  useQuery({
+    queryKey: ['dynamicContent', id],
+    queryFn: () => fetchDynamicContent(id),
+    ...options,
+  });
+
+export const useCreateDynamicContent = (
+  options?: UseMutationOptions<void, Error, CreateDynamicContentData>
+) =>
+  useMutation({
+    mutationFn: createDynamicContent,
+    ...options,
+  });
+
+export const useUpdateDynamicContent = (
+  options?: UseMutationOptions<void, Error, [string, UpdateDynamicContentData]>
+) =>
+  useMutation({
+    mutationFn: ([id, data]) => updateDynamicContent(id, data),
+    ...options,
+  });
+
+export const useDeleteDynamicContent = (options?: UseMutationOptions<void, Error, string>) =>
+  useMutation({
+    mutationFn: deleteDynamicContent,
+    ...options,
+  });
+
+export const useDynamicContentVariants = (
+  id: string,
+  options?: UseQueryOptions<DynamicContentVariantSchema[], Error>
+) =>
+  useQuery({
+    queryKey: ['dynamicContentVariants', id],
+    queryFn: () => fetchDynamicContentVariants(id),
+    ...options,
+  });
+
+export const useCreateDynamicContentVariant = (
+  options?: UseMutationOptions<void, Error, CreateDynamicContentVariantData>
+) =>
+  useMutation({
+    mutationFn: createDynamicContentVariant,
+    ...options,
+  });
+
+export const useUpdateDynamicContentVariant = (
+  options?: UseMutationOptions<void, Error, UpdateDynamicContentVariantData>
+) =>
+  useMutation({
+    mutationFn: updateDynamicContentVariant,
+    ...options,
+  });
+
+export const useDeleteDynamicContentVariant = (
+  options?: UseMutationOptions<void, Error, [string, string]>
+) =>
+  useMutation({
+    mutationFn: ([dcId, vid]) => deleteDynamicContentVariant(dcId, vid),
+    ...options,
+  });

--- a/next/web/src/i18n/locales.ts
+++ b/next/web/src/i18n/locales.ts
@@ -1,0 +1,16 @@
+export const LOCALES: Record<string, string> = {
+  'zh-cn': '简体中文',
+  'zh-tw': '繁体中文（台湾）',
+  'zh-hk': '繁体中文（香港）',
+  en: '英文',
+  ja: '日文',
+  ko: '韩文',
+  id: '印尼文',
+  th: '泰文',
+  de: '德文',
+  fr: '法文',
+  ru: '俄文',
+  es: '西班牙文',
+  pt: '葡萄牙文',
+  tr: '土耳其文',
+};

--- a/resources/schema/DynamicContent.json
+++ b/resources/schema/DynamicContent.json
@@ -1,0 +1,63 @@
+{
+  "schema": {
+    "objectId": {
+      "type": "String"
+    },
+    "ACL": {
+      "type": "ACL"
+    },
+    "createdAt": {
+      "type": "Date"
+    },
+    "updatedAt": {
+      "type": "Date"
+    },
+    "name": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "defaultLocale": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    }
+  },
+  "permissions": {
+    "create": {
+      "*": true
+    },
+    "find": {
+      "*": true
+    },
+    "get": {
+      "*": true
+    },
+    "update": {
+      "*": true
+    },
+    "delete": {
+      "*": true
+    },
+    "add_fields": {
+      "roles": [],
+      "users": []
+    }
+  },
+  "indexes": [
+    {
+      "v": 2,
+      "unique": true,
+      "key": {
+        "name": 1
+      },
+      "name": "-user-name_1",
+      "ns": "02AXSPNhJaEqgBfHftLpIsj2-gzGzoHsz.DynamicContent",
+      "background": true
+    }
+  ]
+}

--- a/resources/schema/DynamicContentVariant.json
+++ b/resources/schema/DynamicContentVariant.json
@@ -1,0 +1,79 @@
+{
+  "schema": {
+    "updatedAt": {
+      "type": "Date"
+    },
+    "ACL": {
+      "type": "ACL"
+    },
+    "locale": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "content": {
+      "type": "String",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "objectId": {
+      "type": "String"
+    },
+    "createdAt": {
+      "type": "Date"
+    },
+    "dynamicContent": {
+      "type": "Pointer",
+      "v": 2,
+      "className": "DynamicContent",
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
+    "active": {
+      "type": "Boolean",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    }
+  },
+  "permissions": {
+    "create": {
+      "*": true
+    },
+    "find": {
+      "*": true
+    },
+    "get": {
+      "*": true
+    },
+    "update": {
+      "*": true
+    },
+    "delete": {
+      "*": true
+    },
+    "add_fields": {
+      "roles": [],
+      "users": []
+    }
+  },
+  "indexes": [
+    {
+      "v": 2,
+      "unique": true,
+      "key": {
+        "dynamicContent.$id": 1,
+        "locale": 1
+      },
+      "name": "-user-dynamicContent.$id_1_locale_1",
+      "ns": "02AXSPNhJaEqgBfHftLpIsj2-gzGzoHsz.DynamicContentVariant",
+      "background": true
+    }
+  ]
+}


### PR DESCRIPTION
重新实现 Dynamic content。

还包含一个自己 suo 的 template renderer。考虑过 mustache.js，但这个库在当前场景不够好用，而且会 escape 嵌入的值，就没有使用。