### PR TITLE
fix: import the missing ErrorMessage

### DIFF
--- a/modules/Login.js
+++ b/modules/Login.js
@@ -146,6 +146,3 @@ export default function Login() {
     </div>
   )
 }
-Login.propTypes = {
-  onLogin: PropTypes.func.isRequired,
-}

--- a/modules/utils/AuthRoute.js
+++ b/modules/utils/AuthRoute.js
@@ -6,6 +6,7 @@ import { Route, useHistory, useLocation } from 'react-router-dom'
 import { auth } from '../../lib/leancloud'
 import Login from '../Login'
 import { AppContext } from '../context'
+import ErrorMessage from '../Error'
 
 function BasicAuthWrapper({ children }) {
   const history = useHistory()
@@ -52,7 +53,7 @@ function CSAuthWrapper({ children }) {
     return children
   }
   if (error) {
-    return <Error error={error} />
+    return <ErrorMessage error={error} />
   }
   return null
 }


### PR DESCRIPTION
会导致在没有权限的时候直接抛异常白屏。

Lesson learned: 不要用 `Error` 做类名。