### PR TITLE
fix(api): prevernt the state change when a new ticket is replied by a user

### DIFF
--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -284,9 +284,13 @@ export class Ticket extends Model {
         updater.ONLY_FOR_TGB_increaseUnreadCount();
       }
       if (this.status < Status.FULFILLED) {
-        updater.setStatus(
-          isCustomerService ? Status.WAITING_CUSTOMER : Status.WAITING_CUSTOMER_SERVICE
-        );
+        if (isCustomerService) {
+          updater.setStatus(Status.WAITING_CUSTOMER);
+        } else {
+          if (this.status !== Status.NEW) {
+            updater.setStatus(Status.WAITING_CUSTOMER_SERVICE);
+          }
+        }
       }
 
       await updater.update(data.author);


### PR DESCRIPTION
目前用户提工单后立即回复会让状态变为「等待客服回复」。