### PR TITLE
feat(lagecy-web): display username on the ticket page

### DIFF
--- a/modules/Ticket/index.js
+++ b/modules/Ticket/index.js
@@ -277,7 +277,7 @@ function TicketInfo({ ticket }) {
       <span className={csCss.nid}>#{ticket.nid}</span>
       <TicketStatusLabel status={ticket.status} />
       <span className="mx-2">
-        <UserLabel user={ticket.author} displayTags={!isUser} /> {t('createdAt')}{' '}
+        <UserLabel user={ticket.author} displayTags={!isUser} displayId /> {t('createdAt')}{' '}
         <span title={createdAt.format()}>{createdAt.fromNow()}</span>
         {createdAt.fromNow() !== updatedAt.fromNow() && (
           <>

--- a/modules/User.js
+++ b/modules/User.js
@@ -58,7 +58,8 @@ class User extends Component {
           </div>
           <div className={css.info}>
             <h2 className={css.userInfo}>
-              {this.state.user.username}{' '}
+              {this.state.user.name}{' '}
+              <span className="text-muted">({this.state.user.username})</span>{' '}
               {this.props.isCustomerService && (
                 <UserTags user={this.state.user} className={css.tags} />
               )}

--- a/modules/UserLabel.js
+++ b/modules/UserLabel.js
@@ -74,6 +74,7 @@ UserTags.propTypes = {
   className: PropTypes.string,
 }
 
+const isGenaratedName = (name) => /^[0-9a-z]{25}$/.test(name)
 export function UserLabel({ user, simple, displayTags, displayId }) {
   const name = getUserDisplayName(user)
   if (simple) {
@@ -87,7 +88,9 @@ export function UserLabel({ user, simple, displayTags, displayId }) {
       <Link to={'/users/' + user.username} className="username">
         {name}
       </Link>
-      {displayId && <span className="text-muted"> ({user.username})</span>}
+      {displayId && name !== user.username && !isGenaratedName(user.username) && (
+        <span className="text-muted"> ({user.username})</span>
+      )}
       {displayTags && <UserTags user={user} />}
     </span>
   )


### PR DESCRIPTION
对于部分第三方登录方式创建的用户， username 对客服可能是有意义的（与 name 是不同的含义）。在这种情况下把 username 展示出来。