### PR TITLE
feat(Automation): support all operation actions

### DIFF
--- a/modules/CustomerService/Tickets.js
+++ b/modules/CustomerService/Tickets.js
@@ -373,8 +373,8 @@ function TicketMenu({ customerServices, categories }) {
   let statusTitle
   if (status) {
     statusTitle = t(TICKET_STATUS_MSG[status])
-  } else if (stage === 'todp') {
-    statusTitle = t('todp')
+  } else if (stage === 'todo') {
+    statusTitle = t('todo')
   } else if (stage === 'in-progress') {
     statusTitle = t('in-progress')
   } else if (stage === 'done') {
@@ -458,12 +458,7 @@ function TicketMenu({ customerServices, categories }) {
             </Button>
           </OverlayTrigger>
           <OverlayTrigger
-            overlay={
-              <Tooltip>
-                {t(TICKET_STATUS_MSG[TICKET_STATUS.WAITING_CUSTOMER])} /{' '}
-                {t(TICKET_STATUS_MSG[TICKET_STATUS.PRE_FULFILLED])}
-              </Tooltip>
-            }
+            overlay={<Tooltip>{t(TICKET_STATUS_MSG[TICKET_STATUS.WAITING_CUSTOMER])}</Tooltip>}
           >
             <Button
               variant="light"
@@ -476,6 +471,7 @@ function TicketMenu({ customerServices, categories }) {
           <OverlayTrigger
             overlay={
               <Tooltip>
+                {t(TICKET_STATUS_MSG[TICKET_STATUS.PRE_FULFILLED])} /{' '}
                 {t(TICKET_STATUS_MSG[TICKET_STATUS.FULFILLED])} /{' '}
                 {t(TICKET_STATUS_MSG[TICKET_STATUS.CLOSED])}
               </Tooltip>
@@ -694,9 +690,9 @@ async function getQuery(filters) {
   } else if (stage === 'in-progress') {
     query = query
       .where('status', '>', TICKET_STATUS.WAITING_CUSTOMER_SERVICE)
-      .where('status', '<', TICKET_STATUS.FULFILLED)
+      .where('status', '<', TICKET_STATUS.PRE_FULFILLED)
   } else if (stage === 'done') {
-    query = query.where('status', '>=', TICKET_STATUS.FULFILLED)
+    query = query.where('status', '>=', TICKET_STATUS.PRE_FULFILLED)
   } else if (status) {
     query = query.where('status', '==', parseInt(status))
   }

--- a/next/api/src/model/OpsLog.ts
+++ b/next/api/src/model/OpsLog.ts
@@ -4,7 +4,8 @@ import { Group } from './Group';
 import { Ticket } from './Ticket';
 import { User } from './User';
 
-export type OperateAction = 'replyWithNoContent' | 'replySoon' | 'resolve' | 'close' | 'reopen';
+export const actions = ['replyWithNoContent', 'replySoon', 'resolve', 'close', 'reopen'] as const;
+export type OperateAction = typeof actions[number];
 
 export type Action =
   | 'selectAssignee'

--- a/next/api/src/ticket/automation/action/changeStatus.ts
+++ b/next/api/src/ticket/automation/action/changeStatus.ts
@@ -1,0 +1,17 @@
+import { actions } from '@/model/OpsLog';
+import { z } from 'zod';
+
+import { Action } from '.';
+
+const schema = z.object({
+  value: z.enum(actions),
+});
+
+export default function (options: unknown): Action {
+  const { value } = schema.parse(options);
+  return {
+    exec: (ctx) => {
+      return ctx.changeStatus(value);
+    },
+  };
+}

--- a/next/api/src/ticket/automation/context.ts
+++ b/next/api/src/ticket/automation/context.ts
@@ -5,6 +5,7 @@ import { Group } from '@/model/Group';
 import { Tag, Ticket } from '@/model/Ticket';
 import { User, systemUser } from '@/model/User';
 import { TicketUpdater } from '@/ticket';
+import { OperateAction } from '@/model/OpsLog';
 
 export interface DirtyData {
   categoryId?: string;
@@ -104,9 +105,29 @@ export class Context {
     return this.dirtyData.status ?? this.ticket.status;
   }
 
+  changeStatus(action: OperateAction) {
+    switch (action) {
+      case 'replyWithNoContent':
+        this.dirtyData.status = Ticket.Status.WAITING_CUSTOMER;
+        break;
+      case 'replySoon':
+        this.dirtyData.status = Ticket.Status.WAITING_CUSTOMER_SERVICE;
+        break;
+      case 'resolve':
+        this.dirtyData.status = Ticket.Status.PRE_FULFILLED;
+        break;
+      case 'close':
+        this.dirtyData.status = Ticket.Status.CLOSED;
+        break;
+      case 'reopen':
+        this.dirtyData.status = Ticket.Status.WAITING_CUSTOMER;
+        break;
+    }
+    this.updater.operate(action);
+  }
+
   closeTicket() {
-    this.dirtyData.status = Ticket.Status.CLOSED;
-    this.updater.operate('close');
+    return this.changeStatus('close');
   }
 
   getTags() {

--- a/next/api/src/ticket/automation/time-trigger/action/index.ts
+++ b/next/api/src/ticket/automation/time-trigger/action/index.ts
@@ -4,6 +4,7 @@ import { Action, ActionFactory } from '../../action';
 import updateCategoryId from '../../action/updateCategoryId';
 import updateAssigneeId from '../../action/updateAssigneeId';
 import updateGroupId from '../../action/updateGroupId';
+import changeStatus from '../../action/changeStatus';
 import closeTicket from '../../action/closeTicket';
 import addTag from '../../action/addTag';
 
@@ -11,6 +12,7 @@ const factories: Record<string, ActionFactory<unknown>> = {
   updateAssigneeId,
   updateCategoryId,
   updateGroupId,
+  changeStatus,
   closeTicket,
   addTag,
 };

--- a/next/api/src/ticket/automation/time-trigger/index.ts
+++ b/next/api/src/ticket/automation/time-trigger/index.ts
@@ -36,7 +36,7 @@ export class TimeTrigger {
 
 function getOpenTickets(cursor?: string): Promise<Ticket[]> {
   const query = Ticket.queryBuilder()
-    .where('status', '<', Ticket.Status.FULFILLED)
+    .where('status', '<', Ticket.Status.PRE_FULFILLED)
     .orderBy('objectId', 'asc')
     .limit(1000);
   if (cursor) {

--- a/next/api/src/ticket/automation/trigger/action/index.ts
+++ b/next/api/src/ticket/automation/trigger/action/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { Action, ActionFactory } from '../../action';
 import updateCategoryId from '../../action/updateCategoryId';
 import updateGroupId from '../../action/updateGroupId';
+import changeStatus from '../../action/changeStatus';
 import closeTicket from '../../action/closeTicket';
 import addTag from '../../action/addTag';
 
@@ -13,6 +14,7 @@ const factories: Record<string, ActionFactory<unknown, TriggerContext>> = {
   updateAssigneeId,
   updateCategoryId,
   updateGroupId,
+  changeStatus,
   closeTicket,
   addTag,
 };

--- a/next/web/src/App/Admin/Settings/Automations/TimeTriggers/actions/index.ts
+++ b/next/web/src/App/Admin/Settings/Automations/TimeTriggers/actions/index.ts
@@ -2,6 +2,7 @@ import { UpdateCategoryId } from '../../actions/UpdateCategoryId';
 import { UpdateAssigneeId } from '../../actions/UpdateAssigneeId';
 import { UpdateGroupId } from '../../actions/UpdateGroupId';
 import { TagSelect } from '../../components/TagSelect';
+import { ChangeStatus } from '../../actions/ChangeStatus';
 
 export default {
   updateAssigneeId: {
@@ -16,8 +17,12 @@ export default {
     label: '将客服组更新为',
     component: UpdateGroupId,
   },
+  changeStatus: {
+    label: '变更状态',
+    component: ChangeStatus,
+  },
   closeTicket: {
-    label: '关闭工单',
+    label: '关闭工单（已废弃）',
   },
   addTag: {
     label: '设置标签',

--- a/next/web/src/App/Admin/Settings/Automations/Triggers/actions/index.ts
+++ b/next/web/src/App/Admin/Settings/Automations/Triggers/actions/index.ts
@@ -1,5 +1,6 @@
 import { UpdateCategoryId } from '../../actions/UpdateCategoryId';
 import { UpdateGroupId } from '../../actions/UpdateGroupId';
+import { ChangeStatus } from '../../actions/ChangeStatus';
 import { TagSelect } from '../../components/TagSelect';
 
 import { UpdateAssigneeId } from './UpdateAssigneeId';
@@ -17,8 +18,12 @@ export default {
     label: '将客服组更新为',
     component: UpdateGroupId,
   },
+  changeStatus: {
+    label: '变更状态',
+    component: ChangeStatus,
+  },
   closeTicket: {
-    label: '关闭工单',
+    label: '关闭工单（已废弃）',
   },
   addTag: {
     label: '设置标签',

--- a/next/web/src/App/Admin/Settings/Automations/actions/ChangeStatus.tsx
+++ b/next/web/src/App/Admin/Settings/Automations/actions/ChangeStatus.tsx
@@ -1,0 +1,41 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import { get } from 'lodash-es';
+
+import { Form, Select } from '@/components/antd';
+import { actions, OperateAction } from '@/api/op-log';
+
+const labels: Record<OperateAction, string> = {
+  replyWithNoContent: '无需回复（等待用户回复）',
+  replySoon: '稍后回复（待客服跟进）',
+  resolve: '待用户确认解决',
+  close: '关闭工单',
+  reopen: '重新打开工单',
+};
+const options = actions.map((action) => ({
+  value: action,
+  label: labels[action],
+}));
+
+export function ChangeStatus({ path }: { path: string }) {
+  const { control, formState } = useFormContext();
+  const errors = get(formState.errors, path);
+
+  return (
+    <Form.Item validateStatus={errors?.value ? 'error' : undefined}>
+      <Controller
+        control={control}
+        name={`${path}.value`}
+        rules={{ validate: (value) => value !== undefined }}
+        render={({ field }) => (
+          <Select
+            {...field}
+            options={options}
+            placeholder="请选择"
+            optionFilterProp="label"
+            style={{ width: 200 }}
+          />
+        )}
+      />
+    </Form.Item>
+  );
+}

--- a/next/web/src/App/Admin/Settings/Automations/actions/ChangeStatus.tsx
+++ b/next/web/src/App/Admin/Settings/Automations/actions/ChangeStatus.tsx
@@ -1,5 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form';
-import { get } from 'lodash-es';
+import { Controller } from 'react-hook-form';
 
 import { Form, Select } from '@/components/antd';
 import { actions, OperateAction } from '@/api/op-log';
@@ -11,22 +10,19 @@ const labels: Record<OperateAction, string> = {
   close: '关闭工单',
   reopen: '重新打开工单',
 };
+
 const options = actions.map((action) => ({
   value: action,
   label: labels[action],
 }));
 
 export function ChangeStatus({ path }: { path: string }) {
-  const { control, formState } = useFormContext();
-  const errors = get(formState.errors, path);
-
   return (
-    <Form.Item validateStatus={errors?.value ? 'error' : undefined}>
-      <Controller
-        control={control}
-        name={`${path}.value`}
-        rules={{ validate: (value) => value !== undefined }}
-        render={({ field }) => (
+    <Controller
+      name={`${path}.value`}
+      rules={{ required: true }}
+      render={({ field, fieldState: { error } }) => (
+        <Form.Item validateStatus={error ? 'error' : undefined}>
           <Select
             {...field}
             options={options}
@@ -34,8 +30,8 @@ export function ChangeStatus({ path }: { path: string }) {
             optionFilterProp="label"
             style={{ width: 200 }}
           />
-        )}
-      />
-    </Form.Item>
+        </Form.Item>
+      )}
+    />
   );
 }

--- a/next/web/src/api/op-log.ts
+++ b/next/web/src/api/op-log.ts
@@ -1,0 +1,2 @@
+export const actions = ['replyWithNoContent', 'replySoon', 'resolve', 'close', 'reopen'] as const;
+export type OperateAction = typeof actions[number];


### PR DESCRIPTION
### 目的
客服有自动将用户长时间未回复的工单「归档」的诉求，但目前 Automation 提供的能力只有 close 一种操作。这有可能会导致给用户带来不被尊重的感觉。

### 这个 PR 改了什么
- 客服端将「等待用户确认」状态视为「完成」状态，「等待用户确认」的工单也不会被 TimerAutomation 运行。
- Automation 的 actions 增加了所有的 OperationActions 作为可选项。
- 原来的 close action 保留但标记为废弃了，等手动改掉存量数据后再下掉。