### PR TITLE
feat: filter tickets by categoryId

### DIFF
--- a/modules/OrganizationSelect.js
+++ b/modules/OrganizationSelect.js
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types'
 import { auth } from '../lib/leancloud'
 import { getUserDisplayName } from '../lib/common'
 
-export default function OrganizationSelect({ organizations, selectedOrgId, onOrgChange }) {
+export default function OrganizationSelect({ organizations, selectedOrgId, onOrgChange, size }) {
   const { t } = useTranslation()
   return (
     <Form.Group controlId="orgSelect">
       <Form.Label>{t('belong')}:&nbsp;</Form.Label>
-      <Form.Control as="select" value={selectedOrgId} onChange={onOrgChange}>
+      <Form.Control as="select" value={selectedOrgId} onChange={onOrgChange} size={size}>
         {organizations.map((o) => (
           <option key={o.id} value={o.id}>
             {t('organization')}: {o.get('name')}
@@ -28,4 +28,5 @@ OrganizationSelect.propTypes = {
   organizations: PropTypes.array,
   selectedOrgId: PropTypes.string,
   onOrgChange: PropTypes.func,
+  size: PropTypes.string,
 }

--- a/modules/Tickets/CategoryTreeMenu.css
+++ b/modules/Tickets/CategoryTreeMenu.css
@@ -1,0 +1,4 @@
+.menuBody {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/modules/Tickets/CategoryTreeMenu.js
+++ b/modules/Tickets/CategoryTreeMenu.js
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react'
+import { Dropdown, Form } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import PropTypes from 'prop-types'
+
+import css from './CategoryTreeMenu.css'
+
+function getIndentString(depth) {
+  return depth === 0 ? '' : '　'.repeat(depth) + '└ '
+}
+
+export default function CategoryTreeMenu({ className, categoriesTree, value, onChange }) {
+  const { t } = useTranslation()
+
+  const items = useMemo(() => {
+    const items = []
+    const dfs = (categories, depth = 0) => {
+      for (const category of categories) {
+        if (!category.data.deletedAt) {
+          items.push({
+            id: category.id,
+            name: getIndentString(depth) + category.data.name,
+          })
+        }
+        if (category.children && category.children.length) {
+          dfs(category.children, depth + 1)
+        }
+      }
+    }
+    if (categoriesTree) {
+      dfs(categoriesTree)
+    }
+    return items
+  }, [categoriesTree])
+
+  const currentCategoryName = useMemo(() => {
+    if (!value) {
+      return t('all')
+    }
+    if (categoriesTree) {
+      const queue = categoriesTree.slice()
+      while (queue.length) {
+        const category = queue.shift()
+        if (category.id === value) {
+          return category.data.name
+        }
+        if (category.children) {
+          category.children.forEach((c) => queue.push(c))
+        }
+      }
+    }
+    return value
+  }, [categoriesTree, value, t])
+
+  return (
+    <Form.Group className={className}>
+      <Form.Label>{t('category')}:&nbsp;</Form.Label>
+      <Dropdown onSelect={onChange}>
+        <Dropdown.Toggle variant="light" size="sm">
+          {currentCategoryName}
+        </Dropdown.Toggle>
+        <Dropdown.Menu className={css.menuBody}>
+          <Dropdown.Item active={!value}>{t('all')}</Dropdown.Item>
+          {items.map(({ id, name }) => (
+            <Dropdown.Item key={id} eventKey={id} active={value === id}>
+              {name}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </Form.Group>
+  )
+}
+CategoryTreeMenu.propTypes = {
+  className: PropTypes.string,
+  categoriesTree: PropTypes.array,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+}

--- a/modules/Tickets/index.js
+++ b/modules/Tickets/index.js
@@ -1,226 +1,244 @@
-import React, { Component } from 'react'
-import { Button, Dropdown, DropdownButton, Form } from 'react-bootstrap'
-import { withTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button, Form } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { Link, useHistory, useLocation } from 'react-router-dom'
+import { useMutation, useQuery } from 'react-query'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
+import qs from 'query-string'
 import { auth, db } from '../../lib/leancloud'
 import css from '../CustomerServiceTickets.css'
 
 import { getCategoryPathName, getCategoriesTree } from '../common'
+import { useAppContext } from '../context'
 import OrganizationSelect from '../OrganizationSelect'
 import TicketsMoveButton from '../TicketsMoveButton'
 import { getTicketAcl } from '../../lib/common'
 import { TicketItem } from './TicketItem'
 import { DocumentTitle } from '../utils/DocumentTitle'
+import CategoryTreeMenu from './CategoryTreeMenu'
 
-class Tickets extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      organization: null,
-      categoriesTree: [],
-      tickets: [],
-      batchOpsEnable: false,
-      checkedTickets: new Set(),
-      isCheckedAll: false,
-      filters: {
-        page: 0,
-        size: 20,
-      },
-    }
-  }
-
-  componentDidMount() {
-    getCategoriesTree(false)
-      .then((categoriesTree) => {
-        this.setState({ categoriesTree })
-        this.findTickets({ organizationId: this.props.selectedOrgId })
-        return
-      })
-      .catch(this.props.addNotification)
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.selectedOrgId !== prevProps.selectedOrgId) {
-      this.findTickets({ organizationId: this.props.selectedOrgId })
-    }
-  }
-
-  findTickets(filter) {
-    const filters = _.assign({}, this.state.filters, filter)
-    let query = db.class('Ticket')
-    if (filter.organizationId) {
-      query = query.where(
-        'organization',
-        '==',
-        _.find(this.props.organizations, { id: filter.organizationId })
-      )
-    } else {
-      query = query.where({
-        author: auth.currentUser,
-        organization: db.cmd.or(null, db.cmd.notExists()),
-      })
-    }
-    query
-      .include('author')
-      .include('assignee')
-      .limit(filters.size)
-      .skip(filters.page * filters.size)
-      .orderBy('createdAt', 'desc')
-      .find()
-      .then((tickets) => {
-        this.setState({ tickets, filters })
-        return
-      })
-      .catch(this.props.addNotification)
-  }
-
-  handleClickCheckbox(id) {
-    const checkedTickets = this.state.checkedTickets
-    if (this.state.checkedTickets.has(id)) {
-      checkedTickets.delete(id)
-    } else {
-      checkedTickets.add(id)
-    }
-    this.setState({
-      checkedTickets,
-      isCheckedAll: checkedTickets.size == this.state.tickets.length,
+function findTickets({ organizationId, categoryIds, page, pageSize }) {
+  let query = db.class('Ticket')
+  if (organizationId) {
+    query = query.where('organization', '==', db.class('Organization').object(organizationId))
+  } else {
+    query = query.where({
+      author: auth.currentUser,
+      organization: db.cmd.or(null, db.cmd.notExists()),
     })
   }
+  if (categoryIds?.length) {
+    query = query.where('category.objectId', 'in', categoryIds)
+  }
+  return query
+    .include('author', 'assignee')
+    .limit(pageSize)
+    .skip((page - 1) * pageSize)
+    .orderBy('createdAt', 'desc')
+    .find()
+}
 
-  handleClickCheckAll(e) {
-    if (e.target.checked) {
-      this.setState({
-        checkedTickets: new Set(this.state.tickets.map((t) => t.id)),
-        isCheckedAll: true,
-      })
+function moveTickets(tickets, organization) {
+  const p = db.pipeline()
+  tickets.forEach((ticket) => {
+    const ACL = getTicketAcl(ticket.get('author'), organization)
+    if (organization) {
+      p.update(ticket, { ACL, organization })
     } else {
-      this.setState({ checkedTickets: new Set(), isCheckedAll: false })
+      p.update(ticket, { ACL, organization: db.op.unset() })
+    }
+  })
+  return p.commit()
+}
+
+function findCategory(categoriesTree, id) {
+  const queue = categoriesTree.slice()
+  while (queue.length) {
+    const category = queue.shift()
+    if (category.id === id) {
+      return category
+    }
+    if (category.children?.length) {
+      category.children.forEach((c) => queue.push(c))
     }
   }
+}
 
-  handleBatchOps(batchOpsEnable) {
-    this.setState({ batchOpsEnable })
-  }
-
-  handleTicketsMove(organization) {
-    const tickets = _.filter(this.state.tickets, (t) => this.state.checkedTickets.has(t.id))
-    const p = db.pipeline()
-    tickets.forEach((t) => {
-      const ACL = getTicketAcl(t.get('author'), organization)
-      if (organization) {
-        p.update(t, { ACL, organization })
-      } else {
-        p.update(t, { ACL, organization: db.op.unset() })
+function useCategoryIds(categoriesTree, categoryId) {
+  return useMemo(() => {
+    if (categoriesTree && categoryId) {
+      const category = findCategory(categoriesTree, categoryId)
+      if (category) {
+        const ids = []
+        const queue = [category]
+        while (queue.length) {
+          const front = queue.shift()
+          ids.push(front.id)
+          front.children?.forEach((c) => queue.push(c))
+        }
+        return ids
       }
-    })
-    p.commit()
-      .then(() => {
-        this.setState({ checkedTickets: new Set(), isCheckedAll: false })
-        this.findTickets({ organizationId: this.props.selectedOrgId })
-        return
-      })
-      .catch(this.props.addNotification)
-  }
+    }
+    return []
+  }, [categoriesTree, categoryId])
+}
 
-  render() {
-    const { t } = this.props
-    const { tickets } = this.state
+function Tickets({ organizations, selectedOrgId, handleOrgChange }) {
+  const { addNotification } = useAppContext()
+  const { t } = useTranslation()
+  const history = useHistory()
+  const { search } = useLocation()
+  const searchParams = useMemo(() => qs.parse(search), [search])
+  const { categoryId } = searchParams
 
-    return (
-      <div>
-        <DocumentTitle title={`${t('ticketList')} - LeanTicket`} />
-        {this.props.organizations.length > 0 && (
-          <Form inline>
-            {(this.state.batchOpsEnable && (
-              <>
-                <Form.Check
-                  className={css.ticketSelectCheckbox}
-                  onChange={this.handleClickCheckAll.bind(this)}
-                  checked={this.state.isCheckedAll}
-                  label={t('selectAll')}
-                />
-                <TicketsMoveButton
-                  className="ml-1"
-                  selectedOrgId={this.props.selectedOrgId}
-                  organizations={this.props.organizations}
-                  onTicketsMove={this.handleTicketsMove.bind(this)}
-                />
-                <Button className="ml-1" variant="link" onClick={() => this.handleBatchOps(false)}>
-                  {t('return')}
-                </Button>
-              </>
-            )) || (
-              <>
-                <OrganizationSelect
-                  organizations={this.props.organizations}
-                  selectedOrgId={this.props.selectedOrgId}
-                  onOrgChange={this.props.handleOrgChange}
-                />
-                <DropdownButton id="tickets-ops" className="ml-1" variant="light" title="">
-                  <Dropdown.Item onClick={() => this.handleBatchOps(true)}>
-                    {t('batchOperation')}
-                  </Dropdown.Item>
-                </DropdownButton>
-              </>
-            )}
-          </Form>
-        )}
-        {tickets.length ? (
-          tickets.map((ticket) => (
-            <TicketItem
-              key={ticket.data.nid}
-              ticket={ticket.toJSON()}
-              checkable={this.state.batchOpsEnable}
-              checked={this.state.checkedTickets.has(ticket.id)}
-              onCheckboxChange={() => this.handleClickCheckbox(ticket.id)}
-              category={getCategoryPathName(ticket.data.category, this.state.categoriesTree)}
-            />
-          ))
-        ) : (
-          <div key={0}>
-            {t('ticketsNotFound')}
-            <Link to="/tickets/new">{t('createANewOne')}</Link>
-          </div>
-        )}
-        <div className="my-2 d-flex justify-content-between">
-          <Button
-            variant="light"
-            disabled={this.state.filters.page === 0}
-            onClick={() =>
-              this.findTickets({
-                page: this.state.filters.page - 1,
-                organizationId: this.props.selectedOrgId,
-              })
-            }
-          >
+  const setSearchParams = useCallback(
+    (params) => {
+      const newParams = { ...searchParams, ..._.omitBy(params, _.isNull) }
+      history.push({ search: `?${qs.stringify(newParams)}` })
+    },
+    [history, searchParams]
+  )
+
+  const [batchOpsEnable, setBatchOpsEnable] = useState(false)
+  const [checkedTickets, setCheckedTickets] = useState([])
+
+  const [page, setPage] = useState(1)
+  const [pageSize] = useState(20)
+
+  const { data: categoriesTree } = useQuery({
+    queryKey: ['endUser/categoriesTree'],
+    queryFn: () => getCategoriesTree(false),
+    onError: addNotification,
+  })
+
+  const categoryIds = useCategoryIds(categoriesTree, categoryId)
+
+  const filters = { organizationId: selectedOrgId, categoryIds, page, pageSize }
+  const { data: tickets, isLoading: loadingTickets, refetch } = useQuery({
+    queryKey: ['endUser/tickets', filters],
+    queryFn: () => findTickets(filters),
+    enabled: categoriesTree !== undefined,
+    onError: addNotification,
+  })
+  useEffect(() => setCheckedTickets([]), [tickets])
+
+  const { mutate: move, isLoading: moving } = useMutation({
+    mutationFn: (org) => moveTickets(checkedTickets, org),
+    onSuccess: () => refetch(),
+    onError: addNotification,
+  })
+
+  const handleClickCheckAll = useCallback(() => {
+    if (tickets) {
+      setCheckedTickets((prev) => (prev.length < tickets.length ? tickets : []))
+    }
+  }, [tickets])
+
+  return (
+    <div>
+      <DocumentTitle title={`${t('ticketList')} - LeanTicket`} />
+      {organizations.length > 0 && (
+        <Form inline>
+          {(batchOpsEnable && (
+            <>
+              <Form.Check
+                className={css.ticketSelectCheckbox}
+                label={t('selectAll')}
+                checked={tickets?.length > 0 && checkedTickets.length === tickets.length}
+                onChange={handleClickCheckAll}
+              />
+              <TicketsMoveButton
+                className="ml-2"
+                size="sm"
+                organizations={organizations}
+                selectedOrgId={selectedOrgId}
+                disabled={checkedTickets.length === 0 || moving}
+                onTicketsMove={move}
+              />
+              <Button
+                className="ml-2"
+                variant="link"
+                size="sm"
+                onClick={() => {
+                  setBatchOpsEnable(false)
+                  setCheckedTickets([])
+                }}
+              >
+                {t('return')}
+              </Button>
+            </>
+          )) || (
+            <>
+              <OrganizationSelect
+                size="sm"
+                organizations={organizations}
+                selectedOrgId={selectedOrgId}
+                onOrgChange={handleOrgChange}
+              />
+              <CategoryTreeMenu
+                className="ml-2"
+                categoriesTree={categoriesTree}
+                value={categoryId}
+                onChange={(categoryId) => setSearchParams({ categoryId })}
+              />
+              <Button
+                className="ml-2"
+                variant="light"
+                size="sm"
+                disabled={tickets?.length === 0}
+                onClick={() => setBatchOpsEnable(true)}
+              >
+                {t('batchOperation')}
+              </Button>
+            </>
+          )}
+        </Form>
+      )}
+      {loadingTickets && <div className="py-2">{t('loading') + '...'}</div>}
+      {tickets?.map((ticket) => (
+        <TicketItem
+          key={ticket.data.nid}
+          ticket={ticket.toJSON()}
+          checkable={batchOpsEnable}
+          checked={checkedTickets.some((t) => t.id === ticket.id)}
+          onCheckboxChange={(e) =>
+            e.target.checked
+              ? setCheckedTickets([...checkedTickets, ticket])
+              : setCheckedTickets(checkedTickets.filter((t) => t.id !== ticket.id))
+          }
+          category={getCategoryPathName(ticket.data.category, categoriesTree)}
+        />
+      ))}
+      {tickets?.length === 0 && (
+        <div className="py-2">
+          {t('ticketsNotFound')}
+          <Link to="/tickets/new">{t('createANewOne')}</Link>
+        </div>
+      )}
+
+      {tickets?.length > 0 && (
+        <div className="py-2 d-flex justify-content-between">
+          <Button variant="light" disabled={page === 1} onClick={() => setPage(page - 1)}>
             &larr; {t('previousPage')}
           </Button>
           <Button
             variant="light"
-            disabled={this.state.filters.size !== this.state.tickets.length}
-            onClick={() =>
-              this.findTickets({
-                page: this.state.filters.page + 1,
-                organizationId: this.props.selectedOrgId,
-              })
-            }
+            disabled={pageSize !== tickets.length}
+            onClick={() => setPage(page + 1)}
           >
             {t('nextPage')} &rarr;
           </Button>
         </div>
-      </div>
-    )
-  }
+      )}
+    </div>
+  )
 }
 
 Tickets.propTypes = {
   organizations: PropTypes.array,
-  handleOrgChange: PropTypes.func,
   selectedOrgId: PropTypes.string,
-  addNotification: PropTypes.func,
-  t: PropTypes.func.isRequired,
+  handleOrgChange: PropTypes.func,
 }
 
-export default withTranslation()(Tickets)
+export default Tickets


### PR DESCRIPTION
给用户侧的工单列表页加一个「根据分类 id 筛选工单」的功能。选择父分类会同时查找父分类和所有子分类的工单。

Class 组件改起来太费劲，就直接重写了。

预览地址：https://ticket.sdjdd.com/tickets?categoryId=61e8e8e2eb406f4e4a6ebee0