### PR TITLE
feat(next/api): [Slack] sub notification by category

### DIFF
--- a/next/api/src/integration/slack-plus/index.ts
+++ b/next/api/src/integration/slack-plus/index.ts
@@ -178,7 +178,7 @@ async function getConfig(): Promise<SlackPlusConfig | undefined> {
   const requiredKeys: (keyof SlackPlusConfig)[] = ['token', 'channel', 'signingSecret'];
   const missingKeys = requiredKeys.filter((key) => config[key] === undefined);
   if (missingKeys.length) {
-    console.warn('[JiraPlus] Missing config:', missingKeys.join(', '));
+    console.warn('[SlackPlus] Missing config:', missingKeys.join(', '));
     return;
   }
   return config as SlackPlusConfig;

--- a/next/api/src/model/Config.ts
+++ b/next/api/src/model/Config.ts
@@ -1,41 +1,42 @@
 import { Model, field } from '@/orm';
 
-
 export class Config extends Model {
   @field()
   key!: string;
 
   @field()
   value!: string | number | Array<any> | Record<any, any> | boolean;
+
+  static findOneByKey(key: string) {
+    return this.queryBuilder().where('key', '==', key).first({ useMasterKey: true });
+  }
+
   static async get(key: string): Promise<any> {
     try {
-      const config = await this.queryBuilder()
-        .where('key', '==', key)
-        .first({ useMasterKey: true });
+      const config = await this.findOneByKey(key);
       if (config) {
-        console.log(`[Config] ${key} = ${config.value}`);
+        console.log(`[Config] ${key} = ${JSON.stringify(config.value)}`);
+        return config.value;
       }
-      return config?.value;
     } catch (error) {
       // TODO: Sentry
       console.error('[Config] Get config failed', error);
     }
   }
 
-  static async set(key: string, value: any): Promise<any> {
-    const config = await this.queryBuilder()
-      .where('key', '==', key)
-      .first({ useMasterKey: true });
+  static async set(key: string, value: any): Promise<Config> {
+    const config = await this.findOneByKey(key);
     if (config) {
-      return config.update({
-        value
-      }, { useMasterKey: true })
+      return config.update({ value }, { useMasterKey: true });
     } else {
-      return Config.create({
-        ACL: {},
-        key,
-        value
-      }, { useMasterKey: true })
+      return Config.create(
+        {
+          ACL: {},
+          key,
+          value,
+        },
+        { useMasterKey: true }
+      );
     }
   }
 }

--- a/next/api/src/service/category.ts
+++ b/next/api/src/service/category.ts
@@ -89,7 +89,7 @@ export class CategoryService {
       const addToList = (category: Category) => {
         parentIds.push(category.id);
         subCategories.push(category);
-      }
+      };
       categoriesByParentId[parentId]?.forEach(addToList);
       categoriesByAlias[parentId]?.forEach(addToList);
     }
@@ -100,6 +100,22 @@ export class CategoryService {
         : subCategories.filter((c) => c.deletedAt !== undefined);
     }
     return subCategories;
+  }
+
+  static async getParentCategories(id: string) {
+    const categories = await CategoryService.getAll();
+    const categoriesById = _.keyBy(categories, (c) => c.id);
+    const parents: Category[] = [];
+    let target = categoriesById[id];
+    while (target) {
+      parents.push(target);
+      if (target.parentId) {
+        target = categoriesById[target.parentId];
+      } else {
+        break;
+      }
+    }
+    return parents.slice(1);
   }
 
   static async create(data: CreateData<Category>, options?: AuthOptions) {


### PR DESCRIPTION
https://xindong.slack.com/archives/C01RY599GNB/p1658489806134599

实现方式就是添加一个新的 Slack integration 的配置 object，格式是：
```ts
interface SlackConfig {
  token: string;
  channel?: string;
  categoryChannels: Record<string, string[]>;
}
```

其中 token 和 channel 还是会 fallback 到环境变量。

categoryChannels 就是以 categoryId 为 key，channels 数组为 value 的新配置项，每次广播消息的同时还会发送消息到指定的 channels。