### PR TITLE
fix:  adjust ticket log sync

### DIFF
--- a/Deploy.md
+++ b/Deploy.md
@@ -241,3 +241,7 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 ## 2022-06-22
 
 导入 TicketField.json
+
+## 2022-08-08
+
+控制台创建 TicketLog 日志表。运行云函数 `syncTicketLog` 同步工单数据到 `TicketLog`

--- a/next/api/src/cloud/ticketLog/index.ts
+++ b/next/api/src/cloud/ticketLog/index.ts
@@ -2,19 +2,33 @@ import throat from 'throat';
 import { Ticket } from '@/model/Ticket';
 import { TicketLog } from '@/model/TicketLog';
 import { retry } from '../utils';
+import { ClickHouse } from '@/orm/clickhouse';
 
 const run = throat(2);
 
-export async function syncTicketLog(from?: Date, limit = 100, skip = 0) {
-  if (from === undefined) {
-    const firstTicket = await Ticket.queryBuilder().orderBy('createdAt', 'asc').first({
-      useMasterKey: true,
-    });
-    if (firstTicket === undefined) {
-      console.log('no ticket insert ticket log');
-      return;
-    }
-    from = firstTicket.createdAt;
+const getFromDate = async () => {
+  const lastTicketLog = await new ClickHouse()
+    .from('TicketLog')
+    .select('ticketCreatedAt')
+    .orderBy(['ticketCreatedAt', 'desc'])
+    .limit(1)
+    .find();
+  if (lastTicketLog && lastTicketLog.length > 0) {
+    return new Date(lastTicketLog[0].ticketCreatedAt);
+  }
+  const firstTicket = await Ticket.queryBuilder().orderBy('createdAt', 'asc').first({
+    useMasterKey: true,
+  });
+  if (firstTicket) {
+    return firstTicket.createdAt;
+  }
+  return;
+};
+
+async function syncTicketLogToClickHouse(from?: Date, limit = 100, skip = 0) {
+  if (!from) {
+    console.log('no ticket insert ticket log');
+    return;
   }
   const query = Ticket.queryBuilder().where('createdAt', '>=', from).limit(limit).skip(skip);
   const tickets = await query.find({
@@ -31,8 +45,27 @@ export async function syncTicketLog(from?: Date, limit = 100, skip = 0) {
       )
     )
   );
-  console.log(`ticket: ${limit}, ${skip} insert success`);
+  console.log(`ticket: ${skip} - ${skip + limit} insert success`);
   if (tickets.length === limit) {
-    await syncTicketLog(from, limit, limit + skip);
+    await syncTicketLogToClickHouse(from, limit, limit + skip);
+  }
+}
+
+export async function syncTicketLog() {
+  const from = await getFromDate();
+  const count = await Ticket.queryBuilder().where('createdAt', '>=', from).count({
+    useMasterKey: true,
+  });
+  if (count > 2000) {
+    // 转为异步 理论上每个独立部署只会同步一次，不值的专门建立一个 class 用日志即可
+    syncTicketLogToClickHouse(from);
+    return {
+      msg: '同步进行中,请在云引擎日志中检查同步进程。',
+    };
+  } else {
+    await syncTicketLogToClickHouse(from);
+    return {
+      msg: '同步完成',
+    };
   }
 }

--- a/next/api/src/model/TicketLog.ts
+++ b/next/api/src/model/TicketLog.ts
@@ -67,6 +67,7 @@ export class TicketLog extends Model {
         ACL: {},
         ticketId: ticket.id,
         ticketCreatedAt: ticket.createdAt,
+        privateTags: ticket.privateTags || [],
         ..._.pick(
           ticket,
           'assigneeId',
@@ -79,7 +80,6 @@ export class TicketLog extends Model {
           'latestCustomerServiceReplyAt',
           'latestReply',
           'nid',
-          'privateTags',
           'replyCount',
           'status',
           'tags',

--- a/next/api/src/orm/clickhouse.ts
+++ b/next/api/src/orm/clickhouse.ts
@@ -127,8 +127,12 @@ export class ClickHouse {
     this.orderExpressions = [];
     this.limitNumber = undefined;
   }
-  from(tableName: string) {
-    this.tableName = tableName;
+  from(table: string | ClickHouse) {
+    if (table instanceof ClickHouse) {
+      this.tableName = '(' + table.toSqlString() + ')';
+    } else {
+      this.tableName = table;
+    }
     return this;
   }
 

--- a/next/api/src/orm/clickhouse.ts
+++ b/next/api/src/orm/clickhouse.ts
@@ -117,11 +117,15 @@ export class ClickHouse {
   private selectList: string[];
   private aggregations: string[];
   private conditions: Conjunction;
+  private orderExpressions: Array<string | [string, 'desc' | 'asc']>;
+  private limitNumber: number | undefined;
   constructor() {
     this.tableName = undefined;
     this.selectList = [];
     this.conditions = new Conjunction();
     this.aggregations = [];
+    this.orderExpressions = [];
+    this.limitNumber = undefined;
   }
   from(tableName: string) {
     this.tableName = tableName;
@@ -156,6 +160,16 @@ export class ClickHouse {
     return this;
   }
 
+  orderBy(...expressions: Array<string | [string, 'desc' | 'asc']>) {
+    expressions.forEach((e) => this.orderExpressions.push(e));
+    return this;
+  }
+
+  limit(number: number) {
+    this.limitNumber = number;
+    return this;
+  }
+
   toSqlString() {
     if (!this.tableName) {
       throw new Error('table name is required');
@@ -168,26 +182,22 @@ export class ClickHouse {
     }
     const from = `from ${this.tableName}`;
     const where = this.conditions.length ? 'where ' + this.conditions : '';
-    const groupby = this.aggregations.length
+    const groupBy = this.aggregations.length
       ? 'group by ' + this.aggregations.map((c) => quoteColumn(c)).join()
       : '';
-    const parts = ['select', select_list, from, where, groupby].filter((v) => v != '');
+    const orderBy = this.orderExpressions.length
+      ? 'order by ' +
+        this.orderExpressions
+          .map((e) => (Array.isArray(e) ? quoteColumn(e[0]) + ' ' + e[1] : quoteColumn(e)))
+          .join()
+      : '';
+    const limit = this.limitNumber ? `limit ${this.limitNumber}` : '';
+
+    const parts = ['select', select_list, from, where, groupBy, orderBy, limit].filter(
+      (v) => v != ''
+    );
     return parts.join(' ');
   }
-
-  // async createView(name: string) {
-  //   try {
-  //      await http.post('/query', {
-  //       data: {
-  //         sql: `create view ${name} as ${this.toSqlString()}`,
-  //       },
-  //     });
-  //     return;
-  //   } catch (error) {
-  //     console.log(`[clickhouse create view error]: ${(error as AxiosError).message}`);
-  //     throw error;
-  //   }
-  // }
 
   async find() {
     const sql = this.toSqlString();

--- a/next/api/src/router/ticket-stats.ts
+++ b/next/api/src/router/ticket-stats.ts
@@ -119,8 +119,25 @@ router.get('/realtime', parseRange('createdAt'), async (ctx) => {
   if (params['privateTagValue']) {
     privateTagCondition.push(params['privateTagValue']);
   }
+
+  const ticketLogLatest = new ClickHouse()
+    .from('TicketLog')
+    .select(
+      'argMax(authorId, updatedAt) as authorId',
+      'argMax(assigneeId, updatedAt) as assigneeId',
+      'argMax(groupId, updatedAt) as groupId',
+      'argMax(status, updatedAt) as status',
+      'argMax(categoryId, updatedAt) as categoryId',
+      'argMax(ticketCreatedAt, updatedAt) as ticketCreatedAt',
+      'argMax(evaluation, updatedAt) as evaluation',
+      'argMax(privateTags, updatedAt) as privateTags',
+      'ticketId',
+      'nid'
+    )
+    .groupBy('ticketId', 'nid');
+
   const data = await new ClickHouse()
-    .from('TicketLog_latest')
+    .from(ticketLogLatest)
     .select(...selectList)
     .where('authorId', params['authorId'])
     .where('assigneeId', params['assigneeId'], 'in')


### PR DESCRIPTION
1. 调整同步函数 如果同步数据过多则转为异步执行（考虑到独立部署基本只会运行一次，所以不在存储建立 class 而是直接看云引擎日志）
2. 移除视图 `TicketLog_latest`, 使用视图的本意是认为会有性能提升。但是不能提升不如直接移除。(也减少部署步骤)
3. privateTags 默认为 []。实际统计查询中有这个字段条件，防止 privateTags 全部都是 undefined 造成 数据仓库不创建此字段影响查询 所以默认为  []



考虑到同步会有大量读写 准备晚上工单使用频率下来后 同步下 ticket-dc 和 ticket-xd