### PR TITLE
feat(next/web): show time in createdAt range picker

### DIFF
--- a/next/web/src/App/Admin/Settings/TicketForms/index.tsx
+++ b/next/web/src/App/Admin/Settings/TicketForms/index.tsx
@@ -37,7 +37,6 @@ function TicketFormActions({ form }: { form: TicketFormSchema }) {
       title: '该操作不可恢复',
       okText: '删除',
       okButtonProps: { danger: true },
-      cancelText: '取消',
       maskClosable: true,
       onOk: () => mutate(form.id),
     });

--- a/next/web/src/App/Admin/Tickets/Filter/FilterForm/CreatedAtSelect.tsx
+++ b/next/web/src/App/Admin/Tickets/Filter/FilterForm/CreatedAtSelect.tsx
@@ -51,7 +51,7 @@ export function CreatedAtSelect({ value, onChange }: CreatedAtSelectProps) {
         return;
       }
       const [starts, ends] = range;
-      onChange(`${starts.startOf('day').toISOString()}..${ends.endOf('day').toISOString()}`);
+      onChange(`${starts.toISOString()}..${ends.toISOString()}`);
     },
     [onChange]
   );
@@ -72,6 +72,9 @@ export function CreatedAtSelect({ value, onChange }: CreatedAtSelectProps) {
             className="w-full"
             value={rangeValue as any}
             onChange={handleChangeRange as any}
+            showTime={{
+              defaultValue: [moment('00:00:00', 'HH:mm:ss'), moment('23:59:59', 'HH:mm:ss')],
+            }}
           />
         </div>
       )}

--- a/next/web/src/App/Admin/Tickets/TicketView/TicketList/index.tsx
+++ b/next/web/src/App/Admin/Tickets/TicketView/TicketList/index.tsx
@@ -10,6 +10,7 @@ import { useGroups } from '@/api/group';
 import { TicketSchema } from '@/api/ticket';
 import { useUsers } from '@/api/user';
 import { Checkbox } from '@/components/antd';
+import { LoadingCover } from '@/components/common';
 import Status from '../TicketStatus';
 import style from './index.module.css';
 
@@ -68,15 +69,16 @@ export function useGetCategoryPath() {
 }
 
 export interface TicketListProps {
-  tickets: TicketSchema[];
+  loading?: boolean;
+  tickets?: TicketSchema[];
   checkedIds: string[];
   onChangeChecked: (id: string, checked: boolean) => void;
 }
 
-export function TicketList({ tickets, checkedIds, onChangeChecked }: TicketListProps) {
+export function TicketList({ loading, tickets, checkedIds, onChangeChecked }: TicketListProps) {
   const checkedIdSet = useMemo(() => new Set(checkedIds), [checkedIds]);
 
-  const userIds = useMemo(() => uniq(tickets.map((t) => t.authorId)), [tickets]);
+  const userIds = useMemo(() => (tickets ? uniq(tickets.map((t) => t.authorId)) : []), [tickets]);
   const { data: users, isLoading: loadingUsers } = useUsers({
     id: userIds,
     queryOptions: {
@@ -95,8 +97,13 @@ export function TicketList({ tickets, checkedIds, onChangeChecked }: TicketListP
   const assigneeById = useMemo(() => keyBy(assignees, 'id'), [assignees]);
 
   return (
-    <>
-      {tickets.map((ticket) => {
+    <div
+      className={cx('flex grow flex-col gap-2 relative', {
+        'overflow-hidden': loading,
+      })}
+    >
+      {loading && <LoadingCover />}
+      {tickets?.map((ticket) => {
         const isClosed = ticket.status >= 250;
         const createdAtFromNow = moment(ticket.createdAt).fromNow();
         const updatedAtFromNow = moment(ticket.updatedAt).fromNow();
@@ -173,6 +180,6 @@ export function TicketList({ tickets, checkedIds, onChangeChecked }: TicketListP
           </div>
         );
       })}
-    </>
+    </div>
   );
 }

--- a/next/web/src/App/Admin/Tickets/TicketView/TicketTable/index.tsx
+++ b/next/web/src/App/Admin/Tickets/TicketView/TicketTable/index.tsx
@@ -13,11 +13,7 @@ const { Column } = Table;
 
 function TicketLink({ ticket }: { ticket: TicketSchema }) {
   return (
-    <a
-    className="mt-1.5 font-bold max-w-full"
-    title={ticket.title}
-    href={`/tickets/${ticket.nid}`}
-    >
+    <a className="mt-1.5 font-bold max-w-full" title={ticket.title} href={`/tickets/${ticket.nid}`}>
       <span>{ticket.title}</span>
       <span className="ml-1 text-[#6f7c87]">#{ticket.nid}</span>
     </a>
@@ -25,15 +21,16 @@ function TicketLink({ ticket }: { ticket: TicketSchema }) {
 }
 
 export interface TicketTableProps {
-  tickets: TicketSchema[];
+  loading?: boolean;
+  tickets?: TicketSchema[];
   checkedIds: string[];
   onChangeChecked: (id: string, checked: boolean) => void;
 }
 
-export function TicketTable({ tickets, checkedIds, onChangeChecked }: TicketTableProps) {
+export function TicketTable({ loading, tickets, checkedIds, onChangeChecked }: TicketTableProps) {
   const checkedIdSet = useMemo(() => new Set(checkedIds), [checkedIds]);
-  
-  const userIds = useMemo(() => uniq(tickets.map((t) => t.authorId)), [tickets]);
+
+  const userIds = useMemo(() => (tickets ? uniq(tickets.map((t) => t.authorId)) : []), [tickets]);
   const { data: users, isLoading: loadingUsers } = useUsers({
     id: userIds,
     queryOptions: {
@@ -52,7 +49,13 @@ export function TicketTable({ tickets, checkedIds, onChangeChecked }: TicketTabl
   const assigneeById = useMemo(() => keyBy(assignees, 'id'), [assignees]);
 
   return (
-    <Table className="min-w-[1000px]" rowKey="id" dataSource={tickets} pagination={false}>
+    <Table
+      className="min-w-[1000px]"
+      rowKey="id"
+      loading={loading}
+      dataSource={tickets}
+      pagination={false}
+    >
       <Column
         className="w-0"
         dataIndex="id"
@@ -83,7 +86,7 @@ export function TicketTable({ tickets, checkedIds, onChangeChecked }: TicketTabl
           <CategoryPath className="whitespace-nowrap text-sm" path={getCategoryPath(id)} />
         )}
       />
-      
+
       <Column
         dataIndex="groupId"
         title="组"

--- a/next/web/src/App/Admin/Tickets/TicketView/index.tsx
+++ b/next/web/src/App/Admin/Tickets/TicketView/index.tsx
@@ -4,20 +4,17 @@ import { TicketTable } from './TicketTable';
 
 export interface TicketViewProps {
   layout: 'card' | 'table';
-  tickets: TicketSchema[];
+  loading?: boolean;
+  tickets?: TicketSchema[];
   checkedIds: string[];
   onChangeChecked: (id: string, checked: boolean) => void;
 }
 
-export function TicketView({ layout, tickets, checkedIds, onChangeChecked }: TicketViewProps) {
+export function TicketView({ layout, ...props }: TicketViewProps) {
   return (
     <>
-      {layout === 'card' && (
-        <TicketList tickets={tickets} checkedIds={checkedIds} onChangeChecked={onChangeChecked} />
-      )}
-      {layout === 'table' && (
-        <TicketTable tickets={tickets} checkedIds={checkedIds} onChangeChecked={onChangeChecked} />
-      )}
+      {layout === 'card' && <TicketList {...props} />}
+      {layout === 'table' && <TicketTable {...props} />}
     </>
   );
 }

--- a/next/web/src/App/Admin/Tickets/index.tsx
+++ b/next/web/src/App/Admin/Tickets/index.tsx
@@ -55,7 +55,7 @@ function TicketListView() {
   const [layout, setLayout] = useLayout();
   const [localFilters, setLocalFilters] = useLocalFilters();
 
-  const { data: tickets, totalCount, isLoading, isFetching } = useSmartSearchTickets({
+  const { data: tickets, totalCount, isFetching } = useSmartSearchTickets({
     page,
     pageSize,
     orderKey,
@@ -108,7 +108,7 @@ function TicketListView() {
         pageSize={pageSize}
         count={tickets?.length}
         totalCount={totalCount}
-        isLoading={isLoading || isFetching}
+        isLoading={isFetching}
         checkedTicketIds={checkedIds}
         onCheckedChange={handleCheckAll}
         layout={layout}
@@ -116,20 +116,15 @@ function TicketListView() {
       />
 
       <div className="flex grow overflow-hidden">
-        <div className="flex grow flex-col p-[10px]  overflow-auto">
+        <div className="flex grow flex-col p-[10px] overflow-auto">
           {showStatsPanel && <StatsPanel />}
-          <div className="flex grow flex-col gap-2">
-            {isLoading && 'Loading...'}
-            {tickets && tickets.length === 0 && 'No data'}
-            {tickets && tickets.length > 0 && (
-              <TicketView
-                layout={layout}
-                tickets={tickets}
-                checkedIds={checkedIds}
-                onChangeChecked={handleCheckTicket}
-              />
-            )}
-          </div>
+          <TicketView
+            layout={layout}
+            loading={isFetching}
+            tickets={tickets}
+            checkedIds={checkedIds}
+            onChangeChecked={handleCheckTicket}
+          />
         </div>
         {showFilterForm && (
           <FilterForm className="shrink-0" filters={localFilters} onChange={setLocalFilters} />

--- a/next/web/src/App/index.tsx
+++ b/next/web/src/App/index.tsx
@@ -2,6 +2,8 @@ import { Suspense, lazy } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { ConfigProvider } from 'antd';
+import zhCN from 'antd/lib/locale/zh_CN';
 
 import { useCurrentUser } from '@/leancloud';
 import { queryClient } from '@/api/query-client';
@@ -45,7 +47,9 @@ export default function App() {
       <RecoilRoot>
         <BrowserRouter basename="/next">
           <SearchParamsProvider>
-            <AppRoutes />
+            <ConfigProvider locale={zhCN}>
+              <AppRoutes />
+            </ConfigProvider>
           </SearchParamsProvider>
         </BrowserRouter>
       </RecoilRoot>

--- a/next/web/src/components/common/LoadingCover.tsx
+++ b/next/web/src/components/common/LoadingCover.tsx
@@ -1,0 +1,9 @@
+import { Spin } from '@/components/antd';
+
+export function LoadingCover() {
+  return (
+    <div className="absolute inset-0 bg-white opacity-60 z-[1] flex justify-center items-center">
+      <Spin />
+    </div>
+  );
+}

--- a/next/web/src/components/common/index.ts
+++ b/next/web/src/components/common/index.ts
@@ -2,6 +2,7 @@ export * from './Category';
 export * from './CategorySelect';
 export * from './CustomerServiceSelect';
 export * from './GroupSelect';
+export * from './LoadingCover';
 export * from './Retry';
 export * from './StatusSelect';
 export * from './UserSelect';


### PR DESCRIPTION
https://xindong.slack.com/archives/C01RY5JHB47/p1662103171373349

createdAt 筛选条件支持设置具体时间。

将 antd 的语言设置为 zh-cn。

顺手优化了下工单列表和表格的 Loading 样式。