### PR TITLE
feat(next): ticket export 

### DIFF
--- a/next/api/package-lock.json
+++ b/next/api/package-lock.json
@@ -22,6 +22,7 @@
         "ioredis": "^4.28.3",
         "isomorphic-dompurify": "^0.18.0",
         "jira-client": "^8.0.0",
+        "json-2-csv": "^3.17.1",
         "jsonwebtoken": "^8.5.1",
         "koa": "^2.13.4",
         "koa-bodyparser": "^4.3.0",
@@ -2207,6 +2208,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/deeks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-2.5.1.tgz",
+      "integrity": "sha512-fqrBeUz7f1UqaXDRzVB5RG2EfPk15HJRrb2pMZj8mLlSTtz4tRPsK5leFOskoHFPuyZ6+7aRM9j657fvXLkJ7Q==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2296,6 +2305,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doc-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.2.tgz",
+      "integrity": "sha512-VRlA2OKSjTbHWj6wmSanxJ338fE/YN8pqmZ0FIWK5JWkIJMFRc4KmD35JtOrnjvVG0WrzOtDDNHx1lN1tkb+lA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/domexception": {
@@ -3498,6 +3515,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-2-csv": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-3.17.1.tgz",
+      "integrity": "sha512-i6QynVy42GGMgY8fYde0mp6nYteptvk8oJsphOLiT3CITzw7NBBAiRwHV35kDOBii/elDQe1HCWLqaBPJ3istQ==",
+      "dependencies": {
+        "deeks": "2.5.1",
+        "doc-path": "3.0.2"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/json-buffer": {
@@ -7632,6 +7661,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "deeks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-2.5.1.tgz",
+      "integrity": "sha512-fqrBeUz7f1UqaXDRzVB5RG2EfPk15HJRrb2pMZj8mLlSTtz4tRPsK5leFOskoHFPuyZ6+7aRM9j657fvXLkJ7Q=="
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -7701,6 +7735,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "doc-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.2.tgz",
+      "integrity": "sha512-VRlA2OKSjTbHWj6wmSanxJ338fE/YN8pqmZ0FIWK5JWkIJMFRc4KmD35JtOrnjvVG0WrzOtDDNHx1lN1tkb+lA=="
     },
     "domexception": {
       "version": "4.0.0",
@@ -8594,6 +8633,15 @@
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
           "requires": {}
         }
+      }
+    },
+    "json-2-csv": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-3.17.1.tgz",
+      "integrity": "sha512-i6QynVy42GGMgY8fYde0mp6nYteptvk8oJsphOLiT3CITzw7NBBAiRwHV35kDOBii/elDQe1HCWLqaBPJ3istQ==",
+      "requires": {
+        "deeks": "2.5.1",
+        "doc-path": "3.0.2"
       }
     },
     "json-buffer": {

--- a/next/api/package.json
+++ b/next/api/package.json
@@ -28,6 +28,7 @@
     "ioredis": "^4.28.3",
     "isomorphic-dompurify": "^0.18.0",
     "jira-client": "^8.0.0",
+    "json-2-csv": "^3.17.1",
     "jsonwebtoken": "^8.5.1",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",

--- a/next/api/src/integration/mailgun.ts
+++ b/next/api/src/integration/mailgun.ts
@@ -31,10 +31,13 @@ class MailgunClient {
 
   constructor(private key: string, private domain: string) {
     this.client = mailgun.client({ username: 'api', key });
-    notification.on('newTicket', this.sendNewTicket);
-    notification.on('replyTicket', this.sendReplyTicket);
-    notification.on('changeAssignee', this.sendChangeAssignee);
-    notification.on('delayNotify', this.sendDelayNotify);
+    const enabled = Boolean(process.env.NOTIFICATION_MAIL_TICKET_ENABLED);
+    if (enabled) {
+      notification.on('newTicket', this.sendNewTicket);
+      notification.on('replyTicket', this.sendReplyTicket);
+      notification.on('changeAssignee', this.sendChangeAssignee);
+      notification.on('delayNotify', this.sendDelayNotify);
+    }
     notification.on('ticketExported', this.sendTicketExported);
   }
 

--- a/next/api/src/integration/mailgun.ts
+++ b/next/api/src/integration/mailgun.ts
@@ -9,6 +9,7 @@ import notification, {
   DelayNotifyContext,
   NewTicketContext,
   ReplyTicketContext,
+  TicketExportedContext,
 } from '@/notification';
 import { Ticket } from '@/model/Ticket';
 import { User } from '@/model/User';
@@ -34,6 +35,7 @@ class MailgunClient {
     notification.on('replyTicket', this.sendReplyTicket);
     notification.on('changeAssignee', this.sendChangeAssignee);
     notification.on('delayNotify', this.sendDelayNotify);
+    notification.on('ticketExported', this.sendTicketExported);
   }
 
   verifyWebhook = (ctx: Koa.Context, next: Koa.Next) => {
@@ -134,6 +136,20 @@ ${ticket.content}
 
 ${ticket.latestReply?.content || '<暂无>'}`,
       ticketUrl: ticket.getUrl(),
+    });
+  };
+
+  sendTicketExported = ({ downloadUrl, to }: TicketExportedContext) => {
+    if (!to.email) {
+      return;
+    }
+    this.client.messages.create(this.domain, {
+      from: 'support<ticket@leancloud.cn>',
+      to: to.email,
+      'h:Reply-To': `ticket-${to.id}@leancloud.cn`,
+      subject: '导出工单数据准备就绪',
+      text: `Hi,${to.getDisplayName()}
+      你导出工单数据，我们已经准备就绪，请点击下列链接下载 ${downloadUrl}`,
     });
   };
 }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -18,7 +18,7 @@ import { User } from '@/model/User';
 import { TicketResponse, TicketListItemResponse } from '@/response/ticket';
 import { ReplyResponse } from '@/response/reply';
 import { Vacation } from '@/model/Vacation';
-import { TicketCreator, TicketUpdater } from '@/ticket';
+import { TicketCreator, TicketUpdater, createTicketExportJob } from '@/ticket';
 import { CategoryService } from '@/service/category';
 
 const router = new Router().use(auth);
@@ -298,6 +298,30 @@ router.get(
 
     ctx.set('X-Total-Count', searchQuery.hits().toString());
     ctx.body = tickets.map((t) => new TicketListItemResponse(t));
+  }
+);
+
+const exportTicketParamsSchema = ticketFiltersSchema.shape({
+  type: yup.string().oneOf(['json', 'csv']).required(),
+});
+router.get(
+  '/export',
+  customerServiceOnly,
+  sort('orderBy', ['status', 'createdAt', 'updatedAt']),
+  parseRange('createdAt'),
+  async (ctx) => {
+    const currentUser = ctx.state.currentUser as User;
+    if (!currentUser.email) {
+      throw new Error('Email is not set');
+    }
+    const { page, pageSize, ...rest } = exportTicketParamsSchema.validateSync(ctx.query);
+    const sortItems = sort.get(ctx);
+    createTicketExportJob({
+      userId: currentUser.id,
+      params: rest,
+      sortItems,
+    });
+    ctx.body = {};
   }
 );
 

--- a/next/api/src/ticket/export/ExportFileManager.ts
+++ b/next/api/src/ticket/export/ExportFileManager.ts
@@ -107,7 +107,7 @@ export class ExportFileManager {
       const file = new AV.File(path.parse(this.file).base, readStream);
       const res = await file.save({ useMasterKey: true });
       fs.unlink(this.file, (err) => {});
-      return res.url();
+      return res.get('url');
     } catch (error) {
       console.error('[export ticket]: upload', error);
     }

--- a/next/api/src/ticket/export/ExportFileManager.ts
+++ b/next/api/src/ticket/export/ExportFileManager.ts
@@ -77,14 +77,17 @@ export class ExportFileManager {
   }
 
   async append(data: Record<string, any>) {
-    const prependHeader = this.isFirst;
+    let prependHeader = false;
+    let jsonSep = ',';
     if (this.isFirst) {
       this.prepend();
       this.isFirst = false;
+      jsonSep = '';
+      prependHeader = true;
     }
     try {
       if (this.ext === '.json') {
-        this.appendData(`${this.isFirst ? '' : ','}${JSON.stringify(data)}`);
+        this.appendData(`${jsonSep}${JSON.stringify(data)}`);
       }
       if (this.ext === '.csv') {
         const csvData = await json2csvAsync([data], {

--- a/next/api/src/ticket/export/ExportFileManager.ts
+++ b/next/api/src/ticket/export/ExportFileManager.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import path from 'path';
+import AV from 'leancloud-storage';
+import { json2csvAsync } from 'json-2-csv';
+
+type fileExtension = '.json' | '.csv';
+
+export class ExportFileManager {
+  tmpDir = `${__dirname}/tmp`;
+  private file: string | undefined;
+  private ext: fileExtension | undefined;
+  private isFirst: boolean;
+  constructor(fileName: string) {
+    this.createFile(fileName);
+    this.isFirst = true;
+  }
+
+  private createFile(fileName: string) {
+    const file = path.join(this.tmpDir, fileName);
+    const res = path.parse(file);
+    if (res.ext !== '.json' && res.ext !== '.csv') {
+      throw Error(`[export ticket]: Invalid file extension, one of ['csv','json']`);
+    }
+    if (res.dir !== this.tmpDir) {
+      throw Error(`[export ticket]: Invalid filename`);
+    }
+    let stats: fs.Stats | undefined;
+    try {
+      stats = fs.statSync(file);
+    } catch (error) {
+      if (stats && stats.isFile()) {
+        console.log(`${res.name} is exists`);
+      } else {
+        try {
+          if (!fs.statSync(this.tmpDir).isDirectory()) {
+            fs.readdirSync(this.tmpDir);
+          }
+        } catch (err: any) {
+          if (err && err.code === 'ENOENT') {
+            fs.mkdirSync(this.tmpDir);
+          } else {
+            throw err;
+          }
+        }
+      }
+    }
+    this.ext = res.ext;
+    fs.writeFileSync(file, '');
+    this.file = file;
+  }
+
+  private appendData(data: string | Uint8Array) {
+    if (!this.file) {
+      throw Error('export file not exists');
+    }
+    fs.appendFileSync(this.file, data, {
+      flag: 'a',
+    });
+  }
+
+  private prepend() {
+    if (!this.file || !this.ext) {
+      return;
+    }
+    if (this.ext === '.json') {
+      this.appendData('[');
+    }
+  }
+
+  private complete() {
+    if (!this.file || !this.ext) {
+      return;
+    }
+    if (this.ext === '.json') {
+      this.appendData(']');
+    }
+  }
+
+  async append(data: Record<string, any>) {
+    const prependHeader = this.isFirst;
+    if (this.isFirst) {
+      this.prepend();
+      this.isFirst = false;
+    }
+    try {
+      if (this.ext === '.json') {
+        this.appendData(`${this.isFirst ? '' : ','}${JSON.stringify(data)}`);
+      }
+      if (this.ext === '.csv') {
+        const csvData = await json2csvAsync([data], {
+          prependHeader,
+          emptyFieldValue: '',
+        });
+        this.appendData(csvData + '\n');
+      }
+    } catch (error) {
+      console.error('[export ticket]: append data', (error as Error).message);
+    }
+  }
+
+  async upload() {
+    if (!this.file) {
+      return;
+    }
+    try {
+      const readStream = fs.createReadStream(this.file);
+      const file = new AV.File(path.parse(this.file).base, readStream);
+      const res = await file.save({ useMasterKey: true });
+      fs.unlink(this.file, (err) => {});
+      return res.url();
+    } catch (error) {
+      console.error('[export ticket]: upload', error);
+    }
+  }
+
+  async done() {
+    this.complete();
+    const url = await this.upload();
+    return { url };
+  }
+}

--- a/next/api/src/ticket/export/ExportTicket.ts
+++ b/next/api/src/ticket/export/ExportTicket.ts
@@ -320,17 +320,3 @@ export default async function exportTicket({ params, sortItems, date }: JobData)
   }
   await exportFileManager.done();
 }
-
-function printMemoryUsage() {
-  const info = process.memoryUsage();
-  const mb = (v: number) => (v / 1024 / 1024).toFixed(2) + ' MB';
-  console.log(
-    'rss=%s,heapTotal=%s,heapUsed=%s',
-    mb(info.rss),
-    mb(info.heapTotal),
-    mb(info.heapUsed)
-  );
-}
-
-setInterval(printMemoryUsage, 1000);
-// 489.573ms

--- a/next/api/src/ticket/export/ExportTicket.ts
+++ b/next/api/src/ticket/export/ExportTicket.ts
@@ -318,5 +318,5 @@ export default async function exportTicket({ params, sortItems, date }: JobData)
       await exportFileManager.append(data);
     }
   }
-  await exportFileManager.done();
+  return exportFileManager.done();
 }

--- a/next/api/src/ticket/export/ExportTicket.ts
+++ b/next/api/src/ticket/export/ExportTicket.ts
@@ -1,0 +1,273 @@
+import _ from 'lodash';
+import { format } from 'date-fns';
+import { Category } from '@/model/Category';
+import { User } from '@/model/User';
+import { UserSearchResult } from '@/response/user';
+import { TicketResponse } from '@/response/ticket';
+import { Group } from '@/model/Group';
+import { GroupResponse } from '@/response/group';
+import { Reply } from '@/model/Reply';
+import { Ticket } from '@/model/Ticket';
+import { TicketForm } from '@/model/TicketForm';
+import { TicketFieldValue } from '@/model/TicketFieldValue';
+import { TicketField } from '@/model/TicketField';
+import { AuthOptions, Model, QueryBuilder } from '@/orm';
+import { CategoryService } from '@/service/category';
+import { ExportFileManager } from './ExportFileManager';
+import { JobData } from '.';
+import { SortItem } from '@/middleware';
+
+export interface FilterOptions {
+  authorId?: string;
+  assigneeId?: string[];
+  categoryId?: string[];
+  rootCategoryId?: string;
+  product?: string;
+  groupId?: string[];
+  status?: number[];
+  'evaluation.star'?: number;
+  createdAtFrom?: string | Date;
+  createdAtTo?: string | Date;
+  tagKey?: string;
+  tagValue?: string;
+  privateTagKey?: string;
+  privateTagValue?: string;
+  type?: string;
+}
+// copy ticket filter
+function addPointersCondition(
+  query: QueryBuilder<any>,
+  key: string,
+  ids: string[],
+  pointedModel: typeof Model
+) {
+  const createPointer = pointedModel.ptr.bind(pointedModel);
+  query.where((query) => {
+    if (ids.includes('null')) {
+      query.where(key, 'not-exists');
+      ids = ids.filter((id) => id !== 'null');
+      if (ids.length) {
+        query.orWhere(key, 'in', ids.map(createPointer));
+      }
+    } else {
+      query.where(key, 'in', ids.map(createPointer));
+    }
+  });
+}
+
+const createTicketQuery = async (params: FilterOptions, sortItems?: SortItem[]) => {
+  const categoryIds = new Set(params.categoryId);
+  const rootId = params.product || params.rootCategoryId;
+  if (rootId) {
+    categoryIds.add(rootId);
+    const subCategories = await CategoryService.getSubCategories(rootId);
+    subCategories.forEach((c) => categoryIds.add(c.id));
+  }
+  const query = Ticket.queryBuilder();
+  if (params.authorId) {
+    query.where('author', '==', User.ptr(params.authorId));
+  }
+  if (params.assigneeId) {
+    addPointersCondition(query, 'assignee', params.assigneeId, User);
+  }
+  if (params.groupId) {
+    addPointersCondition(query, 'group', params.groupId, Group);
+  }
+  if (categoryIds.size) {
+    query.where('category.objectId', 'in', Array.from(categoryIds));
+  }
+  if (params.status) {
+    query.where('status', 'in', params.status);
+  }
+  if (params['evaluation.star'] !== undefined) {
+    query.where('evaluation.star', '==', params['evaluation.star']);
+  }
+  if (params.createdAtFrom) {
+    query.where('createdAt', '>=', new Date(params.createdAtFrom));
+  }
+  if (params.createdAtTo) {
+    query.where('createdAt', '<=', new Date(params.createdAtTo));
+  }
+  if (params.tagKey) {
+    query.where('tags.key', '==', params.tagKey);
+  }
+  if (params.tagValue) {
+    query.where('tags.value', '==', params.tagValue);
+  }
+  if (params.privateTagKey) {
+    query.where('privateTags.key', '==', params.privateTagKey);
+  }
+  if (params.privateTagValue) {
+    query.where('privateTags.value', '==', params.privateTagValue);
+  }
+  sortItems?.forEach(({ key, order }) => query.orderBy(key, order));
+  return query;
+};
+
+const getCategory = async (id: string, authOptions?: AuthOptions) => {
+  const category = await Category.find(id, authOptions);
+  if (!category) {
+    return { id };
+  }
+  const { name, description, meta, deletedAt, formId } = category;
+  return {
+    id,
+    active: !deletedAt,
+    name,
+    description,
+    meta,
+    formId,
+  };
+};
+
+const getCustomerServices = async () => {
+  const customerServices = await User.getCustomerServices();
+  return _(customerServices)
+    .map((user) => new UserSearchResult(user).toJSON())
+    .keyBy('id')
+    .valueOf();
+};
+
+const getGroups = async (authOptions?: AuthOptions) => {
+  const groups = await Group.query().find(authOptions);
+  return _(groups)
+    .map((group) => new GroupResponse(group).toJSON())
+    .keyBy('id')
+    .valueOf();
+};
+
+const getReplies = async (ticketId: string, authOptions?: AuthOptions) => {
+  const query = Reply.queryBuilder().where('ticket', '==', Ticket.ptr(ticketId));
+  query.limit(100);
+  const replies = await query.find(authOptions);
+  return replies.map((reply) => {
+    const { id, content, authorId, isCustomerService, createdAt } = reply;
+    return { id, content, authorId, isCustomerService, createdAt: createdAt.toISOString() };
+  });
+};
+
+const getCustomFormFieldsFun = (authOptions?: AuthOptions) => {
+  const formCacheMap = new Map<string, string[]>();
+  const formFieldCacheMap = new Map<string, string | undefined>();
+  const getFormFieldIds = async (fromId: string) => {
+    const cacheForm = formCacheMap.get(fromId);
+    if (cacheForm) {
+      return cacheForm;
+    }
+    const form = await TicketForm.find(fromId, authOptions);
+    if (!form) {
+      return;
+    }
+    const { fieldIds } = form;
+    formCacheMap.set(fromId, fieldIds);
+    return fieldIds;
+  };
+
+  const getFormFields = async (fieldIds: string[]) => {
+    const reqIds = fieldIds.filter((id) => !formFieldCacheMap.get(id));
+    if (reqIds.length > 0) {
+      const fields = await TicketField.queryBuilder()
+        .where('objectId', 'in', fieldIds)
+        .find({ useMasterKey: true });
+      fields.forEach((field) => {
+        formFieldCacheMap.set(field.id, field.title);
+      });
+    }
+    return fieldIds.map((id) => ({
+      id,
+      title: formFieldCacheMap.get(id),
+    }));
+  };
+
+  return async (fromId?: string) => {
+    if (!fromId) {
+      return;
+    }
+    const ids = await getFormFieldIds(fromId);
+    if (!ids || ids.length === 0) {
+      return;
+    }
+    return getFormFields(ids.filter((id) => id !== 'title'));
+  };
+};
+
+const getCustomFormValues = async (
+  ticketId: string,
+  authOptions?: AuthOptions
+): Promise<Record<string, any>> => {
+  const results = await TicketFieldValue.queryBuilder()
+    .where('ticket', '==', Ticket.ptr(ticketId))
+    .find(authOptions);
+  return _(results)
+    .map((data) => data.values)
+    .flatten()
+    .keyBy('field')
+    .mapValues('value')
+    .valueOf();
+};
+
+const authOptions = { useMasterKey: true };
+const limit = 100;
+export default async function exportTicket({ params, sortItems, date }: JobData) {
+  const { type: fileType, ...rest } = params;
+  const fileName = `ticket_${format(new Date(date), 'yyMMdd_HHmmss')}.${fileType || 'json'}`;
+  const exportFileManager = new ExportFileManager(fileName);
+  const query = await createTicketQuery(rest, sortItems);
+  const count = await query.count(authOptions);
+  const getCustomFormFields = getCustomFormFieldsFun(authOptions);
+  const customerServices = await getCustomerServices();
+  const groups = await getGroups(authOptions);
+
+  for (let index = 0; index < count; index += limit) {
+    const tickets = await query
+      .preload('author', { authOptions })
+      .limit(limit)
+      .skip(index)
+      .find(authOptions);
+    for (let ticketIndex = 0; ticketIndex < tickets.length; ticketIndex++) {
+      const ticket = tickets[ticketIndex];
+      const ticketResponse = new TicketResponse(ticket).toJSON();
+      const {
+        assigneeId,
+        assignee,
+        authorId,
+        author,
+        categoryId,
+        categoryPath,
+        groupId,
+        group,
+        files,
+        contentSafeHTML,
+        ...rest
+      } = ticketResponse;
+      const category = await getCategory(categoryId, authOptions);
+      const replies = await getReplies(ticket.id, authOptions);
+      const formFields = await getCustomFormFields(category.formId);
+      const formValues = await getCustomFormValues(ticket.id, authOptions);
+      const data = {
+        ...rest,
+        author: author?.toJSON(),
+        assignee: assigneeId
+          ? customerServices[assigneeId] || {
+              id: assigneeId,
+            }
+          : undefined,
+        category: _.omit(category, 'formId'),
+        content: ticket.content,
+        group: groupId
+          ? groups[groupId] || {
+              id: groupId,
+            }
+          : undefined,
+        metaData: ticket.metaData,
+        replies,
+        customFields: formFields?.map((field) => ({
+          ...field,
+          value: formValues[field.id],
+        })),
+      };
+      await exportFileManager.append(data);
+    }
+  }
+  return exportFileManager.done();
+}

--- a/next/api/src/ticket/export/index.ts
+++ b/next/api/src/ticket/export/index.ts
@@ -1,0 +1,64 @@
+import { createQueue } from '@/queue';
+import { SortItem } from '@/middleware';
+import exportTicket, { FilterOptions } from './ExportTicket';
+import notification from '@/notification';
+
+export interface JobData {
+  params: FilterOptions;
+  sortItems?: SortItem[];
+  userId: string;
+  date: Date;
+  retryCount: number;
+}
+
+const queue = createQueue<JobData>('ticket:exported', {
+  limiter: {
+    max: 1,
+    duration: 1000,
+  },
+  defaultJobOptions: {
+    removeOnComplete: true,
+    removeOnFail: true,
+  },
+});
+
+queue.process(async (jobData, done) => {
+  try {
+    const result = await exportTicket(jobData.data);
+    done(null, result);
+  } catch (error) {
+    done(error as Error);
+  }
+});
+
+queue.on('completed', async (jobData, result) => {
+  if (result && result.url) {
+    notification.notifyTicketExported({
+      downloadUrl: result.url,
+      userId: jobData.data.userId,
+    });
+  } else {
+    console.error('[export ticket]: download url is required', result);
+  }
+});
+
+queue.on('failed', (job, err) => {
+  console.error('[export ticket]:', job.data, err.message);
+  if (job.data.retryCount < 2) {
+    queue.add({
+      ...job.data,
+      retryCount: job.data.retryCount + 1,
+    });
+  } else {
+    //TODO  send email ?
+    console.error(`[export ticket]: after retry`, job.data, err.message);
+  }
+});
+
+export const createTicketExportJob = (jobData: Omit<JobData, 'date' | 'retryCount'>) => {
+  queue.add({
+    ...jobData,
+    retryCount: 0,
+    date: new Date(),
+  });
+};

--- a/next/api/src/ticket/index.ts
+++ b/next/api/src/ticket/index.ts
@@ -1,2 +1,3 @@
 export { TicketCreator } from './TicketCreator';
 export { TicketUpdater } from './TicketUpdater';
+export { createTicketExportJob } from './export';

--- a/next/web/src/App/Admin/Tickets/Topbar/Exporter.tsx
+++ b/next/web/src/App/Admin/Tickets/Topbar/Exporter.tsx
@@ -35,7 +35,7 @@ function ExporterContent({ close }: ContentProps) {
   const { orderKey, orderType } = useOrderBy();
   const { mutate, isLoading } = useExportTickets({
     onSuccess: () => {
-      message.success('导出任务进行中，导出成功后将发送邮件进行通知，请注意查收邮件进行下载。');
+      message.success('导出任务进行中，导出成功后将发送邮件进行通知，请注意查收邮件进行下载。', 5);
       close && close();
     },
     onError: (error) => {

--- a/next/web/src/App/Admin/Tickets/Topbar/Exporter.tsx
+++ b/next/web/src/App/Admin/Tickets/Topbar/Exporter.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Button, message, Popover, Tooltip } from '@/components/antd';
+import { useExportTickets } from '@/api/ticket';
+
+import { useLocalFilters } from '../Filter';
+import { useOrderBy } from './SortDropdown';
+
+interface Props {
+  trigger: React.ReactNode;
+}
+export function Exporter({ trigger }: Props) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <Tooltip title="导出工单">
+      <Popover
+        title="工单保存为"
+        destroyTooltipOnHide={true}
+        onVisibleChange={(nextStatus) => setVisible(nextStatus)}
+        content={<ExporterContent close={() => setVisible(false)} />}
+        trigger="click"
+        visible={visible}
+        placement="bottomRight"
+      >
+        {trigger}
+      </Popover>
+    </Tooltip>
+  );
+}
+
+interface ContentProps {
+  close?: () => void;
+}
+function ExporterContent({ close }: ContentProps) {
+  const [localFilters] = useLocalFilters();
+  const { orderKey, orderType } = useOrderBy();
+  const { mutate, isLoading } = useExportTickets({
+    onSuccess: () => {
+      message.success('导出任务进行中，导出成功后将发送邮件进行通知，请注意查收邮件进行下载。');
+      close && close();
+    },
+    onError: (error) => {
+      message.success(`导出失败：${error.message}`);
+      close && close();
+    },
+  });
+
+  return (
+    <div>
+      <Button
+        disabled={isLoading}
+        onClick={() => {
+          mutate({
+            type: 'json',
+            orderKey,
+            orderType,
+            filters: localFilters,
+          });
+        }}
+      >
+        JSON
+      </Button>
+      <Button
+        disabled={isLoading}
+        onClick={() => {
+          mutate({
+            type: 'csv',
+            orderKey,
+            orderType,
+            filters: localFilters,
+          });
+        }}
+        className="ml-2"
+      >
+        CSV
+      </Button>
+    </div>
+  );
+}

--- a/next/web/src/App/Admin/Tickets/Topbar/index.tsx
+++ b/next/web/src/App/Admin/Tickets/Topbar/index.tsx
@@ -6,6 +6,7 @@ import {
   HiChevronRight,
   HiOutlineChartPie,
   HiOutlineRefresh,
+  HiOutlineDownload,
 } from 'react-icons/hi';
 import { useQueryClient } from 'react-query';
 import cx from 'classnames';
@@ -20,6 +21,7 @@ import { BatchUpdateData, BatchUpdateError, batchUpdate } from './batchUpdate';
 import { SortDropdown } from './SortDropdown';
 import { Layout, LayoutDropdown } from './LayoutDropdown';
 import { useLocalFilters } from '../Filter';
+import { Exporter } from './Exporter';
 
 export { useOrderBy } from './SortDropdown';
 
@@ -248,6 +250,17 @@ export function Topbar({
           <HiOutlineChartPie className="w-4 h-4" />
         </NavButton>
       </Tooltip>
+
+      <Exporter
+        trigger={
+          <NavButton
+            className="ml-2 px-[7px] py-[7px]"
+            disabled={totalCount === 0 || !!localFilters.keyword}
+          >
+            <HiOutlineDownload className="w-4 h-4" />
+          </NavButton>
+        }
+      />
 
       <NavButton
         className="ml-2 px-[7px] py-[7px]"

--- a/next/web/src/api/ticket.ts
+++ b/next/web/src/api/ticket.ts
@@ -258,3 +258,23 @@ export function useSearchTicketCustomField(
     ...options,
   });
 }
+type exportType = 'json' | 'csv';
+interface ExportParams extends FetchTicketsOptions {
+  type: exportType;
+}
+async function exportTickets({ type, orderKey, orderType, filters = {} }: ExportParams) {
+  const params = {
+    ...encodeTicketFilters(filters),
+    orderBy: `${orderKey}-${orderType}`,
+    type,
+  };
+  await http.get('/api/2/tickets/export', { params });
+  return;
+}
+
+export function useExportTickets(options?: UseMutationOptions<void, Error, ExportParams>) {
+  return useMutation({
+    mutationFn: (params: ExportParams) => exportTickets(params),
+    ...options,
+  });
+}


### PR DESCRIPTION
根据工单导出工单数据具体导出数据流程：

查询数据 -> 写入临时文件 -> 上传到 AV.File -> 删除临时文件  -> 发送通知邮件


导出速度：
    目前 2W 条工单数据导出时间（云引擎上是 3分多，本地为 8 - 9 分）耗时主要是网络 IO 以及写入
    1. 网络IO 
           目前一次查询 20个工单如果想要更快可以考虑适当提升 limit 数量。（注意使用内存 本质这是空间换时间的做法）
    2. 写入
           写入这方面可以考虑换成 stream，另外避免每次写入创建 handle。（理论上提升不大  主要瓶颈也不再这里）


导出的工单（一个工单）数据结构为：

```ts
{
  id: string;
  nid: number;
  title: string;
  status: number;
  assignee: {
    id?: string;
    username?: string;
    nickname?: string;
    email?: string;
  };
  author: {
    id?: string;
    username?: string;
    nickname?: string;
  };
  category: {
    id: string;
    name: string;
    description?: string;
    meta?: Record<string, any>;
  };
  content: string;
  evaluation: {
    star?: number;
    content?: string;
  };
  firstCustomerServiceReplyAt: string;
  latestCustomerServiceReplyAt: string;
  group: {
    id?: string;
    name?: string;
    description?: string;
  };
  metaData?: string | Record<string, any>;
  privateTags?: Tag[];
  customFrom: {
    title?: string;
    fields?: {
      id: string;
      title?: string;
      value?: string | string[];
    }[];
  };
  replies: {
    id: string;
    ticketId: string;
    content: string;
    authorId: string;
    isCustomerService: boolean;
    createdAt: string;
  }[];
  createdAt: string;
  updatedAt: string;
}
```





