### PR TITLE
fix(next/api): fix wrong output when hit words have overlap

### DIFF
--- a/next/api/src/utils/textFilter.ts
+++ b/next/api/src/utils/textFilter.ts
@@ -91,12 +91,15 @@ export class TextFilterService {
           }
         );
         const [filteredText, lastEnd] = res.data.hint.hit_words.reduce<[string, number]>(
-          ([res, lastEnd], { positions: { start_index, end_index } }) => [
-            `${res}${input.slice(lastEnd, start_index)}${(escape ? '\\*' : '*').repeat(
-              end_index - start_index
-            )}`,
-            end_index,
-          ],
+          ([res, lastEnd], { positions: { start_index, end_index } }) =>
+            end_index > lastEnd
+              ? [
+                  `${res}${input.slice(lastEnd, start_index)}${(escape ? '\\*' : '*').repeat(
+                    end_index - Math.max(start_index, lastEnd)
+                  )}`,
+                  end_index,
+                ]
+              : [res, lastEnd],
           ['', 0]
         );
         return filteredText + input.slice(lastEnd);


### PR DESCRIPTION
修复了当文本过滤返回的hit_words有重合时返回的字符串与预期不符的问题