### PR TITLE
feat: topics

### DIFF
--- a/in-app/v1/src/App/Categories/index.module.css
+++ b/in-app/v1/src/App/Categories/index.module.css
@@ -6,11 +6,3 @@
 
   @apply flex shrink-0 w-6 h-6 mr-2;
 }
-
-
-.item:last-child {
-
-  > div {
-    @apply border-0;
-  }
-}

--- a/in-app/v1/src/App/Categories/index.module.css
+++ b/in-app/v1/src/App/Categories/index.module.css
@@ -6,3 +6,11 @@
 
   @apply flex shrink-0 w-6 h-6 mr-2;
 }
+
+
+.item:last-child {
+
+  > div {
+    @apply border-0;
+  }
+}

--- a/in-app/v1/src/App/Categories/index.tsx
+++ b/in-app/v1/src/App/Categories/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useQuery, UseQueryResult } from 'react-query';
+import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
 import { useTranslation } from 'react-i18next';
 import { ChevronRightIcon } from '@heroicons/react/solid';
 import classNames from 'classnames';
@@ -27,10 +27,10 @@ interface ListItemProps {
 
 export function ListItem({ to, content, marker, className }: ListItemProps) {
   return (
-    <Link to={to} className="block px-4 active:bg-gray-50">
+    <Link to={to} className={`block px-4 active:bg-gray-50 ${styles.item}`}>
       <div
         className={classNames(
-          'h-11 flex items-center text-[#666] border-b border-gray-100',
+          `h-11 flex items-center text-[#666] border-b border-gray-100`,
           className
         )}
       >
@@ -52,12 +52,13 @@ async function fetchCategories(rootCategoryId?: string): Promise<Category[]> {
   return data;
 }
 
-export function useCategories() {
+export function useCategories(options?: UseQueryOptions<Category[]>) {
   const rootId = useRootCategory();
   return useQuery({
     queryKey: 'categories',
     queryFn: () => fetchCategories(rootId),
     staleTime: 1000 * 60 * 5,
+    ...options,
   });
 }
 

--- a/in-app/v1/src/App/Home/TicketsLink.tsx
+++ b/in-app/v1/src/App/Home/TicketsLink.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { http } from '@/leancloud';
+import { useRootCategory } from '@/App';
+
+interface TicketsLinkProps {
+  badge?: boolean;
+}
+
+async function fetchUnread(categoryId?: string) {
+  const { data } = await http.get<boolean>(`/api/2/unread`, {
+    params: {
+      product: categoryId,
+    },
+  });
+  return data;
+}
+
+function useHasUnreadTickets(categoryId?: string) {
+  return useQuery({
+    queryKey: ['unread', categoryId],
+    queryFn: () => fetchUnread(categoryId),
+  });
+}
+
+export default function TicketsLink() {
+  const rootCategory = useRootCategory();
+  const { t } = useTranslation();
+  const { data: hasUnreadTickets } = useHasUnreadTickets(rootCategory);
+  return (
+    <Link className="relative p-3 -mr-3 text-[13px] leading-none text-tapBlue" to="/tickets">
+      {t('ticket.record')}
+      {hasUnreadTickets && (
+        <div className="h-1.5 w-1.5 bg-red rounded-full absolute top-0 right-0" />
+      )}
+    </Link>
+  );
+}

--- a/in-app/v1/src/App/Home/Topics.tsx
+++ b/in-app/v1/src/App/Home/Topics.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+import { Tab } from '@headlessui/react';
+import { useCategoryTopics } from '@/api/category';
+import { useRootCategory } from '@/App';
+import { QueryWrapper } from '@/components/QueryWrapper';
+import { ArticleListItem } from '@/App/Articles/utils';
+
+const Topics: FC = () => {
+  const rootCategoryId = useRootCategory();
+  const result = useCategoryTopics(rootCategoryId);
+  const { data } = result;
+
+  return (
+    <div className="mt-2">
+      <QueryWrapper result={result}>
+        <h2 className="grow px-4 font-bold">常见问题</h2>
+        <Tab.Group>
+          <Tab.List className="flex mt-1 px-4 overflow-x-auto">
+            {data?.map((item) => (
+              <Tab
+                key={item.id}
+                className={({ selected }) =>
+                  `rounded mr-2 whitespace-nowrap focus:outline-none px-2 py-1 ${
+                    selected ? 'bg-tapBlue text-white' : 'bg-[#eee] text-[#666]'
+                  }`
+                }
+              >
+                {item.name}
+              </Tab>
+            ))}
+          </Tab.List>
+          <Tab.Panels>
+            {data?.map(({ id, articles }) => (
+              <Tab.Panel key={id}>
+                {articles.map((item) => (
+                  <ArticleListItem key={item.id} article={item} className="px-0" />
+                ))}
+              </Tab.Panel>
+            ))}
+          </Tab.Panels>
+        </Tab.Group>
+      </QueryWrapper>
+    </div>
+  );
+};
+
+export default Topics;

--- a/in-app/v1/src/App/Home/Topics.tsx
+++ b/in-app/v1/src/App/Home/Topics.tsx
@@ -1,27 +1,44 @@
 import { FC } from 'react';
+import { Link } from 'react-router-dom';
 import { Tab } from '@headlessui/react';
 import { useCategoryTopics } from '@/api/category';
 import { useRootCategory } from '@/App';
 import { QueryWrapper } from '@/components/QueryWrapper';
 import { ArticleListItem } from '@/App/Articles/utils';
+import { useTranslation } from 'react-i18next';
+import { useAppState } from '@/App/context';
 
-const Topics: FC = () => {
-  const rootCategoryId = useRootCategory();
-  const result = useCategoryTopics(rootCategoryId);
+const Feedback: FC = () => {
+  return (
+    <div className="my-[20px] text-center">
+      <p className="mb-2 text-sm text-[#666] leading-[16px]">若以上内容没有帮助到你</p>
+
+      <Link
+        className="inline-block py-[7px] px-[36px] text-[14px] text-tapBlue leading-[22px] font-bold border rounded-full"
+        to="/topCategories"
+      >
+        提交反馈
+      </Link>
+    </div>
+  );
+};
+
+const Topics: FC<{}> = () => {
+  const result = useCategoryTopics();
   const { data } = result;
+  const [{ topicIndex }, { update }] = useAppState();
 
   return (
-    <div className="mt-2">
-      <QueryWrapper result={result}>
-        <h2 className="grow px-4 font-bold">常见问题</h2>
-        <Tab.Group>
-          <Tab.List className="flex mt-1 px-4 overflow-x-auto">
+    <QueryWrapper result={result}>
+      <div className="border-b border-gray-100">
+        <Tab.Group selectedIndex={topicIndex} onChange={(topicIndex) => update({ topicIndex })}>
+          <Tab.List className="flex px-4 py-3 overflow-x-auto">
             {data?.map((item) => (
               <Tab
                 key={item.id}
                 className={({ selected }) =>
-                  `rounded mr-2 whitespace-nowrap focus:outline-none px-2 py-1 ${
-                    selected ? 'bg-tapBlue text-white' : 'bg-[#eee] text-[#666]'
+                  `rounded mr-2 whitespace-nowrap focus:outline-none px-2 py-1 text-sm ${
+                    selected ? 'bg-tapBlue text-white font-bold' : 'bg-[#F5F7F8] text-[#868C92]'
                   }`
                 }
               >
@@ -33,14 +50,15 @@ const Topics: FC = () => {
             {data?.map(({ id, articles }) => (
               <Tab.Panel key={id}>
                 {articles.map((item) => (
-                  <ArticleListItem key={item.id} article={item} className="px-0" />
+                  <ArticleListItem key={item.id} article={item} className="!h-[42px]" />
                 ))}
               </Tab.Panel>
             ))}
           </Tab.Panels>
         </Tab.Group>
-      </QueryWrapper>
-    </div>
+      </div>
+      <Feedback />
+    </QueryWrapper>
   );
 };
 

--- a/in-app/v1/src/App/Home/Topics.tsx
+++ b/in-app/v1/src/App/Home/Topics.tsx
@@ -1,12 +1,12 @@
-import { FC } from 'react';
+import { FC, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { Tab } from '@headlessui/react';
 import { useCategoryTopics } from '@/api/category';
-import { useRootCategory } from '@/App';
 import { QueryWrapper } from '@/components/QueryWrapper';
 import { ArticleListItem } from '@/App/Articles/utils';
-import { useTranslation } from 'react-i18next';
 import { useAppState } from '@/App/context';
+import classNames from 'classnames';
+import styles from './index.module.css';
 
 const Feedback: FC = () => {
   return (
@@ -30,19 +30,22 @@ const Topics: FC<{}> = () => {
 
   return (
     <QueryWrapper result={result}>
-      <div className="border-b border-gray-100">
+      <div>
         <Tab.Group selectedIndex={topicIndex} onChange={(topicIndex) => update({ topicIndex })}>
           <Tab.List className="flex px-4 py-3 overflow-x-auto">
             {data?.map((item) => (
-              <Tab
-                key={item.id}
-                className={({ selected }) =>
-                  `rounded mr-2 whitespace-nowrap focus:outline-none px-2 py-1 text-sm ${
-                    selected ? 'bg-tapBlue text-white font-bold' : 'bg-[#F5F7F8] text-[#868C92]'
-                  }`
-                }
-              >
-                {item.name}
+              <Tab as={Fragment} key={item.id}>
+                {({ selected }) => (
+                  <button
+                    data-text={item.name}
+                    className={classNames(
+                      selected ? 'bg-tapBlue text-white font-bold' : 'bg-[#F5F7F8] text-[#868C92]',
+                      styles.topicItem
+                    )}
+                  >
+                    {item.name}
+                  </button>
+                )}
               </Tab>
             ))}
           </Tab.List>

--- a/in-app/v1/src/App/Home/index.module.css
+++ b/in-app/v1/src/App/Home/index.module.css
@@ -1,0 +1,23 @@
+.topicItem{
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  text-decoration: none;
+  @apply rounded mr-2 whitespace-nowrap focus:outline-none px-2 py-1 text-sm;
+}
+
+.topicItem::after{
+  content: attr(data-text);
+  content: attr(data-text) / "";
+  height: 0;
+  visibility: hidden;
+  overflow: hidden;
+  user-select: none;
+  pointer-events: none;
+  @apply font-bold;
+
+  @media speech {
+    display: none;
+  }
+}

--- a/in-app/v1/src/App/Home/index.tsx
+++ b/in-app/v1/src/App/Home/index.tsx
@@ -12,6 +12,7 @@ import { useRootCategory } from '@/App';
 import { CategoryList, useCategories } from '@/App/Categories';
 import { useNotices, ArticleLink } from '@/App/Articles/utils';
 import { keyBy } from 'lodash-es';
+import Topics from './Topics';
 
 interface TicketsLinkProps {
   badge?: boolean;
@@ -84,6 +85,8 @@ export default function Home() {
           <TicketsLink badge={hasUnreadTickets} />
         </div>
         <CategoryList marker categories={topCategories} />
+
+        <Topics />
       </PageContent>
     </QueryWrapper>
   );

--- a/in-app/v1/src/App/Home/index.tsx
+++ b/in-app/v1/src/App/Home/index.tsx
@@ -1,68 +1,46 @@
-import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from 'react-query';
 import { ChevronRightIcon } from '@heroicons/react/solid';
-
-import { http } from '@/leancloud';
 import { PageContent, PageHeader } from '@/components/Page';
-import { QueryWrapper } from '@/components/QueryWrapper';
 import SpeakerIcon from '@/icons/Speaker';
 import { useRootCategory } from '@/App';
-import { CategoryList, useCategories } from '@/App/Categories';
+import { useCategories } from '@/App/Categories';
+import { useCategoryTopics } from '@/api/category';
 import { useNotices, ArticleLink } from '@/App/Articles/utils';
-import { keyBy } from 'lodash-es';
+import { Loading } from '@/components/Loading';
+import { QueryWrapper } from '@/components/QueryWrapper';
 import Topics from './Topics';
+import TicketsLink from './TicketsLink';
+import { TopCategoryList } from '../TopCategories';
 
-interface TicketsLinkProps {
-  badge?: boolean;
-}
-
-function TicketsLink({ badge }: TicketsLinkProps) {
-  const { t } = useTranslation();
+const Categories: FC = () => {
+  const result = useCategories();
   return (
-    <Link className="relative p-3 -mr-3 text-[13px] leading-none text-tapBlue" to="/tickets">
-      {t('ticket.record')}
-      {badge && <div className="h-1.5 w-1.5 bg-red rounded-full absolute top-0 right-0" />}
-    </Link>
+    <QueryWrapper result={result}>
+      <TopCategoryList marker />
+    </QueryWrapper>
   );
-}
-async function fetchUnread(categoryId?: string) {
-  const { data } = await http.get<boolean>(`/api/2/unread`, {
-    params: {
-      product: categoryId,
-    },
-  });
-  return data;
-}
-
-function useHasUnreadTickets(categoryId?: string) {
-  return useQuery({
-    queryKey: ['unread', categoryId],
-    queryFn: () => fetchUnread(categoryId),
-  });
-}
+};
 
 export default function Home() {
   const { t } = useTranslation();
-  const result = useCategories();
-  const categories = result.data;
-  const rootCategory = useRootCategory();
-  const topCategories = useMemo(() => {
-    if (!categories) {
-      return [];
-    }
-    const map = keyBy(categories, 'id');
-    return categories
-      .filter((c) => c.parentId && !map[c.parentId])
-      .sort((a, b) => a.position - b.position);
-  }, [categories]);
-  const { data: hasUnreadTickets } = useHasUnreadTickets(rootCategory);
 
+  const rootCategory = useRootCategory();
   const { data: notices } = useNotices(rootCategory);
+  const { data: topics, isLoading: isTopicsLoading } = useCategoryTopics();
+  const enableCategories = !isTopicsLoading && topics?.length === 0;
+  const { isLoading: isCategoriesLoading } = useCategories({
+    enabled: enableCategories,
+  });
+  const isLoading = isTopicsLoading && isCategoriesLoading;
+  const title = !isLoading ? t(enableCategories ? 'category.select_hint' : 'topic.title') : '';
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
-    <QueryWrapper result={result}>
+    <>
       <PageHeader />
       <PageContent>
         {notices && notices.length > 0 && (
@@ -80,14 +58,14 @@ export default function Home() {
             ))}
           </div>
         )}
-        <div className="flex items-center h-[46px] px-4 mt-1">
-          <h2 className="grow font-bold">{t('category.select_hint')}</h2>
-          <TicketsLink badge={hasUnreadTickets} />
-        </div>
-        <CategoryList marker categories={topCategories} />
 
-        <Topics />
+        <div className="flex items-center h-[46px] px-4 mt-1">
+          <h2 className="grow font-bold">{title}</h2>
+          <TicketsLink />
+        </div>
+        {!enableCategories && <Topics />}
+        {enableCategories && <Categories />}
       </PageContent>
-    </QueryWrapper>
+    </>
   );
 }

--- a/in-app/v1/src/App/TopCategories/index.tsx
+++ b/in-app/v1/src/App/TopCategories/index.tsx
@@ -1,0 +1,46 @@
+import { FC, useMemo } from 'react';
+import { CategoryList, useCategories } from '@/App/Categories';
+import { keyBy } from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+import { QueryWrapper } from '@/components/QueryWrapper';
+import { Helmet } from 'react-helmet-async';
+import { PageContent, PageHeader } from '@/components/Page';
+
+export const TopCategoryList: FC<{ marker: boolean }> = ({ marker }) => {
+  const result = useCategories();
+  const categories = result.data;
+
+  const topCategories = useMemo(() => {
+    if (!categories) {
+      return [];
+    }
+    const map = keyBy(categories, 'id');
+    return categories
+      .filter((c) => c.parentId && !map[c.parentId])
+      .sort((a, b) => a.position - b.position);
+  }, [categories]);
+  return (
+    <QueryWrapper result={result}>
+      <CategoryList marker={marker} categories={topCategories} />
+    </QueryWrapper>
+  );
+};
+
+export default function TopCategories() {
+  const { t } = useTranslation();
+
+  const result = useCategories();
+  const title = result.isLoading ? t('general.loading') + '...' : '问题分类';
+
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <PageHeader>{title}</PageHeader>
+      <PageContent>
+        <TopCategoryList marker={false} />
+      </PageContent>
+    </>
+  );
+}

--- a/in-app/v1/src/App/context/index.tsx
+++ b/in-app/v1/src/App/context/index.tsx
@@ -1,0 +1,25 @@
+import { createContext, useState, FC, useCallback, useContext } from 'react';
+import { noop } from 'lodash';
+
+export interface AppState {
+  topicIndex?: number;
+}
+
+const AppStateContext = createContext<[AppState, { update: (v: Partial<AppState>) => void }]>([
+  {},
+  { update: noop },
+]);
+
+export const useAppState = () => useContext(AppStateContext);
+
+export const AppStateProvider: FC = ({ children }) => {
+  const [status, setStatus] = useState<AppState>({ topicIndex: 0 });
+
+  const update = useCallback((data: Partial<AppState>) => {
+    setStatus((prev) => ({ ...prev, ...data }));
+  }, []);
+
+  return (
+    <AppStateContext.Provider value={[status, { update }]}>{children}</AppStateContext.Provider>
+  );
+};

--- a/in-app/v1/src/App/index.tsx
+++ b/in-app/v1/src/App/index.tsx
@@ -15,7 +15,9 @@ import Categories from './Categories';
 import Tickets from './Tickets';
 import NotFound from './NotFound';
 import Articles from './Articles';
+import TopCategories from './TopCategories';
 import { useTranslation } from 'react-i18next';
+import { AppStateProvider } from './context';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -110,7 +112,9 @@ export default function App() {
             <RootCategoryContext.Provider value={rootCategory}>
               <AuthContext.Provider value={auth}>
                 <TicketInfoContext.Provider value={ticketInfo}>
-                  <AppRoutes />
+                  <AppStateProvider>
+                    <AppRoutes />
+                  </AppStateProvider>
                 </TicketInfoContext.Provider>
               </AuthContext.Provider>
             </RootCategoryContext.Provider>
@@ -149,6 +153,7 @@ const AppRoutes = () => {
           </RequireAuth>
         }
       />
+      <Route path="/topCategories" element={<TopCategories />} />
       <Route path="/articles/*" element={<Articles />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/in-app/v1/src/api/category.ts
+++ b/in-app/v1/src/api/category.ts
@@ -2,6 +2,8 @@ import { UseQueryOptions, useQuery } from 'react-query';
 
 import { http } from '@/leancloud';
 
+import { Article } from '@/types';
+
 export type FieldType = 'text' | 'multi-line' | 'dropdown' | 'multi-select' | 'radios' | 'file';
 
 export interface FieldOption {
@@ -18,8 +20,23 @@ export interface CategoryFieldSchema {
   options?: FieldOption[];
 }
 
+export interface CategoryTopics {
+  id: string;
+  name: string;
+  articleIds: string[];
+  articles: Article[];
+}
+
 export async function fetchCategoryFields(categoryId: string): Promise<CategoryFieldSchema[]> {
   const { data } = await http.get(`/api/2/categories/${categoryId}/fields`);
+  return data;
+}
+
+export async function fetchCategoryTopic(categoryId?: string): Promise<CategoryTopics[]> {
+  if (!categoryId) {
+    return [];
+  }
+  const { data } = await http.get(`/api/2/categories/${categoryId}/topics`);
   return data;
 }
 
@@ -30,6 +47,18 @@ export function useCategoryFields(
   return useQuery({
     queryKey: ['categoryFields', categoryId],
     queryFn: () => fetchCategoryFields(categoryId),
+    staleTime: Infinity,
+    ...options,
+  });
+}
+
+export function useCategoryTopics(
+  categoryId?: string,
+  options?: UseQueryOptions<CategoryTopics[]>
+) {
+  return useQuery({
+    queryKey: ['categoryTopic', categoryId],
+    queryFn: () => fetchCategoryTopic(categoryId),
     staleTime: Infinity,
     ...options,
   });

--- a/in-app/v1/src/api/category.ts
+++ b/in-app/v1/src/api/category.ts
@@ -1,5 +1,7 @@
 import { UseQueryOptions, useQuery } from 'react-query';
 
+import { useRootCategory } from '@/App';
+
 import { http } from '@/leancloud';
 
 import { Article } from '@/types';
@@ -52,13 +54,11 @@ export function useCategoryFields(
   });
 }
 
-export function useCategoryTopics(
-  categoryId?: string,
-  options?: UseQueryOptions<CategoryTopics[]>
-) {
+export function useCategoryTopics(options?: UseQueryOptions<CategoryTopics[]>) {
+  const rootId = useRootCategory();
   return useQuery({
-    queryKey: ['categoryTopic', categoryId],
-    queryFn: () => fetchCategoryTopic(categoryId),
+    queryKey: ['categoryTopic', rootId],
+    queryFn: () => fetchCategoryTopic(rootId),
     staleTime: Infinity,
     ...options,
   });

--- a/in-app/v1/src/i18n/locales/zh.json
+++ b/in-app/v1/src/i18n/locales/zh.json
@@ -24,6 +24,9 @@
   "category": {
     "select_hint": "请选择你遇到的问题"
   },
+  "topic": {
+    "title": "常见问题"
+  },
   "ticket": {
     "record": "问题记录",
     "no_record": "暂无问题记录",


### PR DESCRIPTION
首页展示「常见问题」模块。

目前的展示逻辑调整为：
1. 已配置 topics  首页直接展示为「常见问题」模块，通过 「提交反馈按钮」跳转到一级问题分类页面 [示例](https://stg-ticket.sdjdd.com/in-app/v1/categories/6108e403928aa97734554ef0/#anonymous-id=test-user)
2. 未配置 topics，首页直接展示一级分类 [示例](https://stg-ticket.sdjdd.com/in-app/v1/categories/61e8e8e2eb406f4e4a6ebee0/#anonymous-id=test-user)


