### PR TITLE
feat(next): impl stats for evaluation

### DIFF
--- a/Deploy.md
+++ b/Deploy.md
@@ -278,3 +278,12 @@ Jira 插件内置到主分支了，需要导入 JiraIssue.json，并将 HS_Confi
 - `TDS_CLIENT_ID`: TDS 的 Client ID
 - `TDS_SERVER_SECRET`: TDS 的 Server Secret
 - `TEXT_FILTER_MAX_RETRY`: 文本过滤失败时重试次数，默认为 3
+
+## 2022-10-08
+
+数据仓库创建以下同步
+
+- Ticket
+  - evaluation
+  - category
+  - assignee

--- a/next/api/src/orm/clickhouse.ts
+++ b/next/api/src/orm/clickhouse.ts
@@ -205,13 +205,17 @@ export class ClickHouse {
 
   async find() {
     const sql = this.toSqlString();
+    return await ClickHouse.findWithSqlStr<QueryData>(sql);
+  }
+
+  static async findWithSqlStr<T extends { results: unknown }>(sql: string) {
     try {
-      const { data } = await http.get<QueryData>('/query', {
+      const { data } = await http.get<T>('/query', {
         params: {
           sql,
         },
       });
-      return data.results;
+      return data.results as T['results'];
     } catch (error) {
       console.log(`[clickhouse query error, sql: ${sql}`);
       throw error;

--- a/next/api/src/response/ticket-stats.ts
+++ b/next/api/src/response/ticket-stats.ts
@@ -1,8 +1,21 @@
-
 import { TicketStats } from '@/model/TicketStats';
 import { TicketStatusStats } from '@/model/TicketStatusStats';
+
+export interface EvaluationCounts {
+  likeCount: number;
+  dislikeCount: number;
+  likeRate: number;
+  dislikeRate: number;
+}
+
+export interface EvaluationStats extends Omit<EvaluationCounts, 'likeRate' | 'dislikeRate'> {
+  categoryId?: string;
+  customerServiceId?: string;
+  option: string;
+}
+
 export class TicketStatsResponse {
-  constructor(readonly ticketStats: TicketStats) { }
+  constructor(readonly ticketStats: TicketStats) {}
   toJSON() {
     return {
       id: this.ticketStats.id,
@@ -20,13 +33,13 @@ export class TicketStatsResponse {
       firstReplyCount: this.ticketStats.firstReplyCount || 0,
       internalReplyCount: this.ticketStats.internalReplyCount || 0,
       naturalReplyTime: this.ticketStats.naturalReplyTime || 0,
-      naturalReplyCount: this.ticketStats.naturalReplyCount || 0
+      naturalReplyCount: this.ticketStats.naturalReplyCount || 0,
     };
   }
 }
 
 export class TicketStatusStatsResponse {
-  constructor(readonly ticketStats: TicketStatusStats) { }
+  constructor(readonly ticketStats: TicketStatusStats) {}
   toJSON() {
     return {
       id: this.ticketStats.id,

--- a/next/api/src/response/ticket-stats.ts
+++ b/next/api/src/response/ticket-stats.ts
@@ -11,7 +11,7 @@ export interface EvaluationCounts {
 export interface EvaluationStats extends Omit<EvaluationCounts, 'likeRate' | 'dislikeRate'> {
   categoryId?: string;
   customerServiceId?: string;
-  option: string;
+  selection: string;
 }
 
 export class TicketStatsResponse {

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -532,6 +532,7 @@ const ticketEvaluationSchema = yup
   .object({
     star: yup.number().oneOf([0, 1]).required(),
     content: yup.string().default(''),
+    options: yup.array().of(yup.string()).default([]),
   })
   .noUnknown();
 

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -532,7 +532,7 @@ const ticketEvaluationSchema = yup
   .object({
     star: yup.number().oneOf([0, 1]).required(),
     content: yup.string().default(''),
-    options: yup.array().of(yup.string()).default([]),
+    selections: yup.array().of(yup.string()).default([]),
   })
   .noUnknown();
 

--- a/next/web/src/App/Admin/Stats/StatsDetails.tsx
+++ b/next/web/src/App/Admin/Stats/StatsDetails.tsx
@@ -163,7 +163,7 @@ const TicketStatsDateColumn = () => {
   );
 };
 
-const TicketStatsOptionColumn = () => {
+const TicketStatsSelectionColumn = () => {
   const params = useStatsParams();
   const [field] = useActiveField();
   const { data, isFetching, isLoading } = useTicketFieldStats({
@@ -175,8 +175,8 @@ const TicketStatsOptionColumn = () => {
     if (!data) return [];
     return data
       .filter((v) => v[field])
-      .map(({ option, categoryId, customerServiceId, date, ...rest }) =>
-        valueTransformImpl([option || '其他', rest], field)
+      .map(({ selection, categoryId, customerServiceId, date, ...rest }) =>
+        valueTransformImpl([selection || '其他', rest], field)
       );
   }, [data]);
 
@@ -524,7 +524,11 @@ export function StatsDetails() {
     <div className="w-full">
       <h2>{STATS_FIELD_LOCALE[field]}</h2>
       <div className="w-full relative">
-        {EvaluationFields.includes(field) ? <TicketStatsOptionColumn /> : <TicketStatsDateColumn />}
+        {EvaluationFields.includes(field) ? (
+          <TicketStatsSelectionColumn />
+        ) : (
+          <TicketStatsDateColumn />
+        )}
       </div>
       <Details />
     </div>

--- a/next/web/src/App/Admin/Stats/StatsDetails.tsx
+++ b/next/web/src/App/Admin/Stats/StatsDetails.tsx
@@ -9,10 +9,12 @@ import { useCustomerServices } from '@/api/customer-service';
 import { useFilterData, useStatsParams } from './utils';
 import { Pie, Column } from '@/components/Chart';
 import { Button, Popover, Radio, Table, TableProps } from '@/components/antd';
-import { StatsField, STATS_FIELD_LOCALE, useActiveField } from './StatsPage';
+import { EvaluationFields, StatsField, STATS_FIELD_LOCALE, useActiveField } from './StatsPage';
 import ReplyDetails, { ModalRef } from './ReplyDetails';
 
 type displayMode = 'pieChart' | 'table';
+
+type RequiredKV<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 const timeField = ['naturalReplyTimeAVG', 'replyTimeAVG', 'firstReplyTimeAVG'];
 const avgFieldMap: {
@@ -22,27 +24,41 @@ const avgFieldMap: {
   replyTimeAVG: ['replyTime', 'replyTimeCount'],
   firstReplyTimeAVG: ['firstReplyTime', 'firstReplyCount'],
 };
+const rateField = ['likeCount', 'dislikeCount'];
+const rateFieldMap: {
+  [key in StatsField]?: keyof TicketStats;
+} = {
+  likeCount: 'likeRate',
+  dislikeCount: 'dislikeRate',
+};
 
 export const formatTime = (value: number | string) => {
   value = Number(value);
   return `${value === 0 ? 0 : (value / 3600).toFixed(2)}  小时`;
 };
 
-const valueTransform = (value: [string | Date, Record<string, number>], field: StatsField) => {
+const valueTransformImpl = (value: [string, Record<string, number>], field: StatsField) => {
   const avgField = avgFieldMap[field];
-  const [date, obj] = value;
+  const [key, obj] = value;
   const v = avgField ? (obj[avgField[0]] || 0) / (obj[avgField[1]] || 1) : obj[field];
-  return [moment(date).toISOString(), { [field]: v }] as [string, Record<string, number>];
+  return [key, { [field]: v }] as [string, Record<string, number>];
 };
 
-const TicketStatsColumn = () => {
+const valueTransform = (value: [string | Date, Record<string, number>], field: StatsField) => {
+  const [date, obj] = value;
+  return valueTransformImpl([moment(date).toISOString(), obj], field);
+};
+
+const TicketStatsDateColumn = () => {
   const params = useStatsParams();
   const [field] = useActiveField();
   const { data, isFetching, isLoading } = useTicketFieldStats({
     fields: avgFieldMap[field] || [field],
     ...params,
   });
-  const [filteredData, { rollup, changeFilter }] = useFilterData(data);
+  const [filteredData, { rollup, changeFilter }] = useFilterData(
+    data as RequiredKV<TicketFieldStat, 'date'>[] | undefined
+  );
 
   const chartData = useMemo(() => {
     if (rollup === 'day') {
@@ -147,6 +163,33 @@ const TicketStatsColumn = () => {
   );
 };
 
+const TicketStatsOptionColumn = () => {
+  const params = useStatsParams();
+  const [field] = useActiveField();
+  const { data, isFetching, isLoading } = useTicketFieldStats({
+    fields: avgFieldMap[field] || [field],
+    ...params,
+  });
+
+  const chartData = useMemo(() => {
+    if (!data) return [];
+    return data
+      .filter((v) => v[field])
+      .map(({ option, categoryId, customerServiceId, date, ...rest }) =>
+        valueTransformImpl([option || '其他', rest], field)
+      );
+  }, [data]);
+
+  return (
+    <Column
+      loading={isFetching || isLoading}
+      data={chartData}
+      onSelected={false}
+      names={(value) => STATS_FIELD_LOCALE[value as StatsField]}
+    />
+  );
+};
+
 const getPercentaget = (value: number | string, total = 1) => {
   if (total < 0) {
     total = 1;
@@ -198,6 +241,20 @@ const useTableData = (groupByKey: string, data?: TicketFieldStat[]) => {
               value: _.sumBy(values, 'naturalReplyTime') / naturalReplyCount,
               count: naturalReplyCount,
             };
+          case 'likeCount':
+            const likeCount = _.sumBy(values, 'likeCount');
+            return {
+              [groupByKey]: key,
+              value: likeCount,
+              rate: likeCount / (_.sumBy(values, 'dislikeCount') + likeCount) || 0,
+            };
+          case 'dislikeCount':
+            const dislikeCount = _.sumBy(values, 'dislikeCount');
+            return {
+              [groupByKey]: key,
+              value: dislikeCount,
+              rate: dislikeCount / (_.sumBy(values, 'likeCount') + dislikeCount) || 0,
+            };
           default:
             return {
               [groupByKey]: key,
@@ -206,7 +263,7 @@ const useTableData = (groupByKey: string, data?: TicketFieldStat[]) => {
         }
       })
       .orderBy(['value'], timeField.includes(field) ? 'asc' : 'desc')
-      .map((v) => {
+      .map<{ id: string | number; value: number; count?: number; rate?: number }>((v) => {
         return {
           ...v,
           id: v[groupByKey],
@@ -245,6 +302,7 @@ const TableView = ({
   const tableData = useTableData(groupKey, data);
   const pagination = usePagination();
   const isTimeField = useMemo(() => timeField.includes(field), [field]);
+  const isRateField = useMemo(() => rateField.includes(field), [field]);
   const modalRef = useRef<ModalRef>(null);
 
   const columns = useMemo(() => {
@@ -252,6 +310,7 @@ const TableView = ({
       id: string | number;
       value: number;
       count?: number;
+      rate?: number;
       customerServiceId?: string;
       categoryId?: string;
     }>['columns'] = [
@@ -301,6 +360,16 @@ const TableView = ({
           );
         },
         sorter: (a, b) => a.count! - b.count!,
+      });
+    }
+    if (isRateField) {
+      _columns.push({
+        title: STATS_FIELD_LOCALE[rateFieldMap[field] as 'dislikeRate' | 'likeRate'],
+        dataIndex: 'rate',
+        key: 'rate',
+        defaultSortOrder: 'descend',
+        render: (value) => `${(value * 100).toFixed(1)} %`,
+        sorter: (a, b) => a.rate! - b.rate!,
       });
     }
     return _columns;
@@ -455,7 +524,7 @@ export function StatsDetails() {
     <div className="w-full">
       <h2>{STATS_FIELD_LOCALE[field]}</h2>
       <div className="w-full relative">
-        <TicketStatsColumn />
+        {EvaluationFields.includes(field) ? <TicketStatsOptionColumn /> : <TicketStatsDateColumn />}
       </div>
       <Details />
     </div>

--- a/next/web/src/App/Admin/Stats/StatsPage.tsx
+++ b/next/web/src/App/Admin/Stats/StatsPage.tsx
@@ -46,7 +46,6 @@ export const STATS_FIELD_LOCALE: Record<
 };
 export const EvaluationFields = ['dislikeCount', 'likeCount'];
 export const EvaluationRateFields = ['dislikeRate', 'likeRate'];
-export const NoDetailFields = [...EvaluationRateFields];
 
 enum FILTER_TYPE {
   all = 'all',
@@ -158,7 +157,7 @@ const StatCards = () => {
     };
   }, [data]);
 
-  const getExtraProps = useCallback((field: StatsField) => {
+  const getExtraProps = useCallback((field: StatsField | typeof NO_DETAIL_STATS_FIELD[number]) => {
     if (['replyTimeAVG', 'firstReplyTimeAVG', 'naturalReplyTimeAVG'].includes(field)) {
       return {
         formatter: (value: number | string) => (Number(value) / 3600).toFixed(2),
@@ -176,17 +175,19 @@ const StatCards = () => {
 
   return (
     <div className="flex flex-wrap -m-1">
-      {STATS_FIELD.map((type) => {
+      {[...STATS_FIELD, ...NO_DETAIL_STATS_FIELD].map((type) => {
         return (
           <Card
             loading={isFetching || isLoading}
             key={type}
             className={classnames('!m-1 basis-52 grow-0 shrink-0 cursor-pointer', {
               '!border-primary': type === active,
-              'cursor-not-allowed': NoDetailFields.includes(type),
+              'cursor-not-allowed': (NO_DETAIL_STATS_FIELD as readonly string[]).includes(type),
             })}
             onClick={
-              NoDetailFields.includes(type) ? undefined : () => active !== type && setActive(type)
+              (NO_DETAIL_STATS_FIELD as readonly string[]).includes(type)
+                ? undefined
+                : () => active !== type && setActive(type)
             }
           >
             <Statistic

--- a/next/web/src/App/Admin/Stats/StatsPage.tsx
+++ b/next/web/src/App/Admin/Stats/StatsPage.tsx
@@ -19,6 +19,10 @@ export const STATS_FIELD = [
   'naturalReplyTimeAVG',
   'replyCount',
   'internalReplyCount',
+  'likeCount',
+  'dislikeCount',
+  'likeRate',
+  'dislikeRate',
 ] as const;
 export type StatsField = typeof STATS_FIELD[number];
 export const STATS_FIELD_LOCALE: Record<StatsField, string> = {
@@ -33,7 +37,14 @@ export const STATS_FIELD_LOCALE: Record<StatsField, string> = {
   naturalReplyTimeAVG: '平均回复自然时间',
   replyCount: '对外回复数',
   internalReplyCount: '对内回复数',
+  likeCount: '好评数',
+  dislikeCount: '差评数',
+  likeRate: '好评率',
+  dislikeRate: '差评率',
 };
+export const EvaluationFields = ['dislikeCount', 'likeCount'];
+export const EvaluationRateFields = ['dislikeRate', 'likeRate'];
+export const NoDetailFields = [...EvaluationRateFields];
 
 enum FILTER_TYPE {
   all = 'all',
@@ -152,6 +163,12 @@ const StatCards = () => {
         suffix: '小时',
       };
     }
+    if (EvaluationRateFields.includes(field)) {
+      return {
+        formatter: (value: number | string) => (Number(value) * 100).toFixed(1),
+        suffix: '%',
+      };
+    }
     return {};
   }, []);
 
@@ -164,8 +181,11 @@ const StatCards = () => {
             key={type}
             className={classnames('!m-1 basis-52 grow-0 shrink-0 cursor-pointer', {
               '!border-primary': type === active,
+              'cursor-not-allowed': NoDetailFields.includes(type),
             })}
-            onClick={() => active !== type && setActive(type)}
+            onClick={
+              NoDetailFields.includes(type) ? undefined : () => active !== type && setActive(type)
+            }
           >
             <Statistic
               loading={isFetching || isLoading}

--- a/next/web/src/App/Admin/Stats/StatsPage.tsx
+++ b/next/web/src/App/Admin/Stats/StatsPage.tsx
@@ -21,11 +21,13 @@ export const STATS_FIELD = [
   'internalReplyCount',
   'likeCount',
   'dislikeCount',
-  'likeRate',
-  'dislikeRate',
 ] as const;
+export const NO_DETAIL_STATS_FIELD = ['likeRate', 'dislikeRate'] as const;
 export type StatsField = typeof STATS_FIELD[number];
-export const STATS_FIELD_LOCALE: Record<StatsField, string> = {
+export const STATS_FIELD_LOCALE: Record<
+  StatsField | typeof NO_DETAIL_STATS_FIELD[number],
+  string
+> = {
   created: '新建工单',
   closed: '关单数',
   reopened: '激活工单数',

--- a/next/web/src/api/ticket-stats.ts
+++ b/next/web/src/api/ticket-stats.ts
@@ -25,6 +25,10 @@ export interface TicketStats {
   replyCount: number;
   naturalReplyTime: number;
   naturalReplyCount: number;
+  likeCount: number;
+  dislikeCount: number;
+  likeRate: number;
+  dislikeRate: number;
 }
 
 async function fetchTicketStats(options?: FetchTicketStatsOptions) {
@@ -46,8 +50,9 @@ export function useTicketStats({ queryOptions, ...options }: UseTicketStatsOptio
   });
 }
 
-export type TicketFieldStat = Partial<TicketStats> & {
-  date: Date;
+export type TicketFieldStat = Partial<Omit<TicketStats, 'likeRate' | 'dislikeRate'>> & {
+  date?: Date;
+  option?: string;
   categoryId?: string;
   customerServiceId?: string;
   replyTimeAVG?: number;

--- a/next/web/src/api/ticket-stats.ts
+++ b/next/web/src/api/ticket-stats.ts
@@ -52,7 +52,7 @@ export function useTicketStats({ queryOptions, ...options }: UseTicketStatsOptio
 
 export type TicketFieldStat = Partial<Omit<TicketStats, 'likeRate' | 'dislikeRate'>> & {
   date?: Date;
-  option?: string;
+  selection?: string;
   categoryId?: string;
   customerServiceId?: string;
   replyTimeAVG?: number;

--- a/next/web/src/components/Chart/index.tsx
+++ b/next/web/src/components/Chart/index.tsx
@@ -28,7 +28,7 @@ interface ChartProps {
 }
 export interface ColumnProps extends ChartProps {
   tickInterval?: number;
-  onSelected?: (xAxisValues?: string[]) => void;
+  onSelected?: ((xAxisValues?: string[]) => void) | false;
 }
 export interface PieProps extends Omit<ChartProps, 'formatters' | 'data'> {
   innerRadius?: number;
@@ -176,7 +176,7 @@ export const Column: FunctionComponent<ColumnProps> = ({
         },
       }}
       brush={{
-        enabled: true,
+        enabled: onSelected === false ? false : true,
         type: 'x-rect',
       }}
       // interactions={[{ type: 'zoom-in-chart' }]}


### PR DESCRIPTION
增加评价统计

## API 更改

### PATCH `/api/2/ticket/:id`

#### Request Body

`evaluation` 字段内新增 `selections` 字段，用于传评价的选项，类型为字符串数组

### GET `/api/2/ticket-stats`

#### Response

```typescript
interface TicketStats {
  closed: number;
  conversion: number;
  created: number;
  externalConversion: number;
  internalConversion: number;
  internalReplyCount: number;
  reopened: number;
  firstReplyCount: number;
  firstReplyTime: number;
  replyTime: number;
  replyTimeCount: number;
  replyCount: number;
  naturalReplyTime: number;
  naturalReplyCount: number;
  likeCount: number;  // 新增，好评数量
  dislikeCount: number;  // 新增，差评数量
  likeRate: number; // 新增，好评率
  dislikeRate: number; // 新增，差评率
}
```

### GET `/api/2/ticket-stats/fields`

#### Request Query

- fields: 增加 likeCount 和 dislikeCount 分别表示好评和差评

#### Response
```typescript
type TicketFieldStat = Partial<Omit<TicketStats, 'likeRate' | 'dislikeRate'>> & {  // 好评率和差评率不在此 API 出现
  date?: Date;  // 变为可选，不在 fields 传 likeCount 或 dislikeCount 时出现
  selection?: string;  // 新增，评价的选项，在 fields 传 likeCount 或 dislikeCount 时出现
  categoryId?: string;
  customerServiceId?: string;
  replyTimeAVG?: number;
  firstReplyTimeAVG?: number;
  naturalReplyTimeAVG?: number;
};
```

当 fields 传 likeCount 或 dislikeCount 时，TicketFieldStats 同时包含 likeCount 和 dislikeCount 用于计算好评率和差评率

#### Errors

当 likeCount 或 dislikeCount 和其他 fields 同时出现时会返回 400