### PR TITLE
feat(in-app): x-root-category

### DIFF
--- a/in-app/v1/src/App/Categories/index.tsx
+++ b/in-app/v1/src/App/Categories/index.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
 import { ChevronRightIcon } from '@heroicons/react/solid';
 import classNames from 'classnames';
 
-import { http } from '@/leancloud';
-import { useRootCategory } from '@/states/root-category';
-import { Category } from '@/types';
+import { Category, useCategories } from '@/api/category';
 import { PageContent, PageHeader } from '@/components/Page';
 import { QueryWrapper } from '@/components/QueryWrapper';
 import { APIError } from '@/components/APIError';
@@ -40,35 +37,6 @@ export function ListItem({ to, content, marker, className }: ListItemProps) {
       </div>
     </Link>
   );
-}
-
-async function fetchCategories(rootCategoryId?: string): Promise<Category[]> {
-  if (rootCategoryId === undefined) {
-    return [];
-  }
-  const { data } = await http.get<Category[]>(
-    `/api/2/products/${rootCategoryId}/categories?active=true`
-  );
-  return data;
-}
-
-export function useCategories(options?: UseQueryOptions<Category[]>) {
-  const rootId = useRootCategory();
-  return useQuery({
-    queryKey: 'categories',
-    queryFn: () => fetchCategories(rootId),
-    staleTime: 1000 * 60 * 5,
-    ...options,
-  });
-}
-
-export function useCategory(id: string) {
-  const { data: categories, ...rest } = useCategories();
-  const category = useMemo(() => categories?.find((c) => c.id === id || c.alias === id), [
-    categories,
-    id,
-  ]);
-  return { data: category, ...rest } as UseQueryResult<Category>;
 }
 
 export type CategoryListProps = JSX.IntrinsicElements['div'] & {

--- a/in-app/v1/src/App/Home/TicketsLink.tsx
+++ b/in-app/v1/src/App/Home/TicketsLink.tsx
@@ -23,7 +23,7 @@ function useHasUnreadTickets(categoryId?: string) {
 export default function TicketsLink() {
   const rootCategory = useRootCategory();
   const { t } = useTranslation();
-  const { data: hasUnreadTickets } = useHasUnreadTickets(rootCategory);
+  const { data: hasUnreadTickets } = useHasUnreadTickets(rootCategory.id);
   return (
     <Link className="relative p-3 -mr-3 text-[13px] leading-none text-tapBlue" to="/tickets">
       {t('ticket.record')}

--- a/in-app/v1/src/App/Home/index.tsx
+++ b/in-app/v1/src/App/Home/index.tsx
@@ -4,8 +4,7 @@ import { ChevronRightIcon } from '@heroicons/react/solid';
 import { PageContent, PageHeader } from '@/components/Page';
 import SpeakerIcon from '@/icons/Speaker';
 import { useRootCategory } from '@/states/root-category';
-import { useCategories } from '@/App/Categories';
-import { useCategoryTopics } from '@/api/category';
+import { useCategories, useCategoryTopics } from '@/api/category';
 import { useNotices, ArticleLink } from '@/App/Articles/utils';
 import { Loading } from '@/components/Loading';
 import { QueryWrapper } from '@/components/QueryWrapper';
@@ -26,7 +25,7 @@ export default function Home() {
   const { t } = useTranslation();
 
   const rootCategory = useRootCategory();
-  const { data: notices } = useNotices(rootCategory);
+  const { data: notices } = useNotices(rootCategory.id);
   const { data: topics, isLoading: isTopicsLoading } = useCategoryTopics();
   const enableCategories = !isTopicsLoading && topics?.length === 0;
   const { isLoading: isCategoriesLoading } = useCategories({

--- a/in-app/v1/src/App/Tickets/New/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/index.tsx
@@ -166,7 +166,6 @@ export function NewTicket() {
   });
 
   if (categories && !category) {
-    // Category is not exists :badbad:
     return <NotFound />;
   }
   return (

--- a/in-app/v1/src/App/Tickets/New/index.tsx
+++ b/in-app/v1/src/App/Tickets/New/index.tsx
@@ -6,6 +6,7 @@ import { Helmet } from 'react-helmet-async';
 import { pick, cloneDeep } from 'lodash-es';
 
 import { http } from '@/leancloud';
+import { Category, useCategories } from '@/api/category';
 import { FieldItem, useTicketFormItems } from '@/api/ticket-form';
 import { useTicketInfo } from '@/states/ticket-info';
 import { useSearchParams } from '@/utils/url';
@@ -14,8 +15,6 @@ import { Button } from '@/components/Button';
 import { QueryWrapper } from '@/components/QueryWrapper';
 import { Loading } from '@/components/Loading';
 import CheckIcon from '@/icons/Check';
-import { Category } from '@/types';
-import { useCategory } from '../../Categories';
 import NotFound from '../../NotFound';
 import { CustomForm, CustomFieldConfig, CustomFormItem } from './CustomForm';
 import { usePersistFormData } from './usePersistFormData';
@@ -147,9 +146,16 @@ async function createTicket(data: NewTicketData): Promise<string> {
 export function NewTicket() {
   const { t } = useTranslation();
   const { category_id } = useSearchParams();
-  const result = useCategory(category_id);
   const { state: ticketId, search } = useLocation();
   const navigate = useNavigate();
+
+  const result = useCategories();
+  const { data: categories } = result;
+  const category = useMemo(() => {
+    if (categories) {
+      return categories.find((c) => c.id === category_id || c.alias === category_id);
+    }
+  }, [categories, category_id]);
 
   const { mutateAsync: submit, isLoading: submitting } = useMutation({
     mutationFn: createTicket,
@@ -159,22 +165,20 @@ export function NewTicket() {
     onError: (error: Error) => alert(error.message),
   });
 
-  if (!ticketId && !result.data && !result.isLoading && !result.error) {
+  if (categories && !category) {
     // Category is not exists :badbad:
     return <NotFound />;
   }
   return (
     <>
-      <Helmet>{result.data?.name && <title>{result.data.name}</title>}</Helmet>
-      <PageHeader>{result.data?.name ?? t('general.loading') + '...'}</PageHeader>
+      <Helmet>{category && <title>{category.name}</title>}</Helmet>
+      <PageHeader>{category?.name ?? t('general.loading') + '...'}</PageHeader>
       <PageContent>
         {ticketId ? (
           <Success ticketId={ticketId as string} />
         ) : (
           <QueryWrapper result={result}>
-            {(category) => (
-              <TicketForm category={category} onSubmit={submit} submitting={submitting} />
-            )}
+            <TicketForm category={category!} onSubmit={submit} submitting={submitting} />
           </QueryWrapper>
         )}
       </PageContent>

--- a/in-app/v1/src/App/Tickets/index.tsx
+++ b/in-app/v1/src/App/Tickets/index.tsx
@@ -49,10 +49,10 @@ async function fetchTickets({
 }
 
 export function useTickets() {
-  const categoryId = useRootCategory();
+  const rootCategory = useRootCategory();
   return useInfiniteQuery<TicketListItem[], Error>({
     queryKey: 'tickets',
-    queryFn: ({ pageParam = 1 }) => fetchTickets({ categoryId, page: pageParam }),
+    queryFn: ({ pageParam = 1 }) => fetchTickets({ categoryId: rootCategory.id, page: pageParam }),
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length === TICKETS_PAGE_SIZE) {
         return allPages.length + 1;

--- a/in-app/v1/src/App/TopCategories/index.tsx
+++ b/in-app/v1/src/App/TopCategories/index.tsx
@@ -1,10 +1,11 @@
 import { FC, useMemo } from 'react';
-import { CategoryList, useCategories } from '@/App/Categories';
-import { keyBy } from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import { QueryWrapper } from '@/components/QueryWrapper';
 import { Helmet } from 'react-helmet-async';
+import { keyBy } from 'lodash-es';
+import { useCategories } from '@/api/category';
+import { QueryWrapper } from '@/components/QueryWrapper';
 import { PageContent, PageHeader } from '@/components/Page';
+import { CategoryList } from '@/App/Categories';
 
 export const TopCategoryList: FC<{ marker: boolean }> = ({ marker }) => {
   const result = useCategories();

--- a/in-app/v1/src/App/index.tsx
+++ b/in-app/v1/src/App/index.tsx
@@ -109,7 +109,7 @@ export default function App() {
   useEffect(() => {
     if (rootCategory) {
       setRootCategory(rootCategory);
-      http.defaults.headers.common['x-root-category'] = rootCategory.id;
+      http.defaults.headers.common['x-product'] = rootCategory.id;
     }
   }, [rootCategory]);
 

--- a/in-app/v1/src/App/index.tsx
+++ b/in-app/v1/src/App/index.tsx
@@ -1,6 +1,5 @@
 import { Suspense, useEffect, useMemo } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { useTranslation } from 'react-i18next';
 import { decodeQueryParams, JsonParam, StringParam } from 'serialize-query-params';
 import { parse } from 'query-string';
@@ -10,6 +9,7 @@ import { auth as lcAuth, http } from '@/leancloud';
 import { useAuth, useSetAuth } from '@/states/auth';
 import { useSetRootCategory } from '@/states/root-category';
 import { useSetTicketInfo } from '@/states/ticket-info';
+import { useCategory } from '@/api/category';
 import { SDKProvider } from '@/components/SDK';
 import { APIError } from '@/components/APIError';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
@@ -22,15 +22,6 @@ import NotFound from './NotFound';
 import Articles from './Articles';
 import TopCategories from './TopCategories';
 import Test from './Test';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
-    },
-  },
-});
 
 function RequireAuth({ children }: { children: JSX.Element }) {
   const { user, loading, error } = useAuth();
@@ -62,7 +53,7 @@ export default function App() {
 
   const pathname = window.location.pathname;
   const paths = pathname.split('/');
-  const rootCategory = paths[4];
+  const rootCategoryId = paths[4];
 
   const setAuth = useSetAuth();
   const setRootCategory = useSetRootCategory();
@@ -71,7 +62,6 @@ export default function App() {
   const params = useHashConfiguration();
 
   useEffect(() => {
-    setRootCategory(rootCategory);
     setTicketInfo({
       meta: params.meta,
       fields: params.fields,
@@ -113,8 +103,18 @@ export default function App() {
     }
   }, []);
 
+  const { data: rootCategory, isLoading: loadingRootCategory } = useCategory(rootCategoryId, {
+    enabled: rootCategoryId !== undefined,
+  });
+  useEffect(() => {
+    if (rootCategory) {
+      setRootCategory(rootCategory);
+      http.defaults.headers.common['x-root-category'] = rootCategory.id;
+    }
+  }, [rootCategory]);
+
   const rootURL = ROOT_URLS.find((URL) => pathname.startsWith(URL));
-  if (!rootURL) {
+  if (!rootURL || (!loadingRootCategory && !rootCategory)) {
     return <p>Not Found</p>;
   }
   return (
@@ -122,16 +122,14 @@ export default function App() {
       <Helmet>
         <title>{t('general.call_center')}</title>
       </Helmet>
-      <BrowserRouter basename={`${rootURL}/${rootCategory}`}>
-        <QueryClientProvider client={queryClient}>
-          <ErrorBoundary>
-            <Suspense fallback={<Loading />}>
-              <SDKProvider>
-                <AppRoutes />
-              </SDKProvider>
-            </Suspense>
-          </ErrorBoundary>
-        </QueryClientProvider>
+      <BrowserRouter basename={`${rootURL}/${rootCategoryId}`}>
+        <ErrorBoundary>
+          <Suspense fallback={<Loading />}>
+            <SDKProvider>
+              <AppRoutes />
+            </SDKProvider>
+          </Suspense>
+        </ErrorBoundary>
       </BrowserRouter>
     </HelmetProvider>
   );

--- a/in-app/v1/src/api/category.ts
+++ b/in-app/v1/src/api/category.ts
@@ -3,6 +3,29 @@ import { useRootCategory } from '@/states/root-category';
 import { http } from '@/leancloud';
 import { Article } from '@/types';
 
+export interface Category {
+  id: string;
+  name: string;
+  alias?: string;
+  parentId?: string;
+  position: number;
+  formId?: string;
+}
+
+async function fetchCategories(rootCategoryId: string): Promise<Category[]> {
+  const { data } = await http.get<Category[]>(`/api/2/products/${rootCategoryId}/categories`, {
+    params: {
+      active: 1,
+    },
+  });
+  return data;
+}
+
+async function fetchCategory(id: string) {
+  const { data } = await http.get<Category>(`/api/2/categories/${id}`);
+  return data;
+}
+
 export interface CategoryTopics {
   id: string;
   name: string;
@@ -10,19 +33,34 @@ export interface CategoryTopics {
   articles: Article[];
 }
 
-async function fetchCategoryTopic(categoryId?: string): Promise<CategoryTopics[]> {
-  if (!categoryId) {
-    return [];
-  }
+async function fetchCategoryTopic(categoryId: string): Promise<CategoryTopics[]> {
   const { data } = await http.get(`/api/2/categories/${categoryId}/topics`);
   return data;
 }
 
-export function useCategoryTopics(options?: UseQueryOptions<CategoryTopics[]>) {
-  const rootId = useRootCategory();
+export function useCategories(options?: UseQueryOptions<Category[]>) {
+  const rootCategory = useRootCategory();
   return useQuery({
-    queryKey: ['categoryTopic', rootId],
-    queryFn: () => fetchCategoryTopic(rootId),
+    queryKey: ['categories', rootCategory.id],
+    queryFn: () => fetchCategories(rootCategory.id),
+    staleTime: 1000 * 60 * 5,
+    ...options,
+  });
+}
+
+export function useCategory(id: string, options?: UseQueryOptions<Category>) {
+  return useQuery({
+    queryKey: ['category', id],
+    queryFn: () => fetchCategory(id),
+    ...options,
+  });
+}
+
+export function useCategoryTopics(options?: UseQueryOptions<CategoryTopics[]>) {
+  const rootCategory = useRootCategory();
+  return useQuery({
+    queryKey: ['categoryTopic', rootCategory.id],
+    queryFn: () => fetchCategoryTopic(rootCategory.id),
     staleTime: Infinity,
     ...options,
   });

--- a/in-app/v1/src/index.tsx
+++ b/in-app/v1/src/index.tsx
@@ -1,16 +1,28 @@
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
 import 'github-markdown-css/github-markdown-light.css';
 import './index.css';
 import './i18n';
 import App from './App';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
 render(
   <StrictMode>
-    <RecoilRoot>
-      <App />
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
+    </QueryClientProvider>
   </StrictMode>,
   document.getElementById('root')
 );

--- a/in-app/v1/src/leancloud/index.ts
+++ b/in-app/v1/src/leancloud/index.ts
@@ -54,6 +54,7 @@ export const db = app.database();
 export const storage = app.storage();
 
 export const http = axios.create();
+
 http.interceptors.request.use((config) => {
   if (auth.currentUser) {
     if (!config.headers) {

--- a/in-app/v1/src/states/root-category.ts
+++ b/in-app/v1/src/states/root-category.ts
@@ -1,6 +1,7 @@
+import { Category } from '@/api/category';
 import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
 
-const rootCategoryState = atom<string>({
+const rootCategoryState = atom<Category>({
   key: 'rootCategory',
 });
 

--- a/in-app/v1/src/types/index.ts
+++ b/in-app/v1/src/types/index.ts
@@ -8,15 +8,6 @@ export interface Article {
   updatedAt: Date;
 }
 
-export interface Category {
-  id: string;
-  name: string;
-  alias?: string;
-  parentId?: string;
-  position: number;
-  formId?: string;
-}
-
 export interface File {
   id: string;
   name: string;

--- a/next/api/src/controller/category.ts
+++ b/next/api/src/controller/category.ts
@@ -119,7 +119,6 @@ export class CategoryController {
   }
 
   @Get(':id')
-  @UseMiddlewares(auth, customerServiceOnly)
   @ResponseBody(CategoryResponse)
   async findOne(@Ctx() ctx: Context, @Param('id', FindCategoryPipe) category: Category) {
     await categoryService.renderCategories([category], ctx.locales);


### PR DESCRIPTION
### In App

完善 root  category 机制，保证仅在使用合法的 root category id 的情况下才加载子组件。

获取 root category 成功后，后续请求会携带 `x-product`（就是 root category id） header。

### Next API

允许终端用户获取某一个 category。
