### PR TITLE
feat(next/api): TapSupport login JWT exp

### DIFF
--- a/next/api/src/tap-support/tap-support.service.ts
+++ b/next/api/src/tap-support/tap-support.service.ts
@@ -17,6 +17,7 @@ class TapSupportService {
       subject: options.customId,
       issuer: 'LeanTicket',
       audience: 'TapSupport',
+      expiresIn: '5min',
     });
   }
 }


### PR DESCRIPTION
即签即用，5分钟足够了。