### PR TITLE
refactor: login and sign up

### DIFF
--- a/in-app/v1/src/App/index.tsx
+++ b/in-app/v1/src/App/index.tsx
@@ -70,16 +70,13 @@ export default function App() {
 
   useEffect(() => {
     setAuth({ loading: true });
-    if (params['anonymous-id']) {
-      lcAuth
-        .loginWithAuthData('anonymous', { id: params['anonymous-id'] })
-        .then((user) => setAuth({ user }))
-        .catch((error) => setAuth({ error }));
-    } else if (params['xd-access-token'] || params['tds-credential']) {
+    if (params['anonymous-id'] || params['xd-access-token'] || params['tds-credential']) {
       http
         .post(
           '/api/2/users',
-          params['xd-access-token']
+          params['anonymous-id']
+            ? { type: 'anonymous', anonymousId: params['anonymous-id'] }
+            : params['xd-access-token']
             ? { XDAccessToken: params['xd-access-token'] }
             : {
                 type: 'tds-user',

--- a/modules/Login.js
+++ b/modules/Login.js
@@ -67,15 +67,14 @@ export default function Login() {
     }
   }
 
-  const handleSignup = async () => {
+  const handleResetPassword = async () => {
     try {
-      const { sessionToken } = await http.post(`/api/2/users/signup`, {
-        username,
-        password,
-        name: username,
-      })
-      setCurrentUser(await auth.loginWithSessionToken(sessionToken))
-      redirect()
+      if (!username) {
+        addNotification({ message: t('resetPasswordEmptyEmail'), level: 'error' })
+        return
+      }
+      await auth.requestPasswordReset(username)
+      addNotification({ message: t('resetPasswordSent') })
     } catch (error) {
       addNotification(error)
     }
@@ -113,8 +112,8 @@ export default function Login() {
               </Form.Group>
               <Form.Group>
                 <Button type="submit">{t('login')}</Button>{' '}
-                <Button variant="light" onClick={handleSignup}>
-                  {t('signup')}
+                <Button variant="light" onClick={handleResetPassword}>
+                  {t('resetPassword')}
                 </Button>
               </Form.Group>
             </Form>

--- a/modules/Login.js
+++ b/modules/Login.js
@@ -5,7 +5,7 @@ import { Button, Form } from 'react-bootstrap'
 import { useHistory, useLocation } from 'react-router'
 import PropTypes from 'prop-types'
 import qs from 'query-string'
-import { auth } from '../lib/leancloud'
+import { auth, http } from '../lib/leancloud'
 import { isCN } from './common'
 import css from './Login.css'
 import { AppContext } from './context'
@@ -55,8 +55,12 @@ export default function Login() {
   const handleLogin = async (e) => {
     e.preventDefault()
     try {
-      const user = await auth.login(username, password)
-      setCurrentUser(user)
+      const { sessionToken } = await http.post('/api/2/users', {
+        type: 'password',
+        username,
+        password,
+      })
+      setCurrentUser(await auth.loginWithSessionToken(sessionToken))
       redirect()
     } catch (error) {
       addNotification(error)
@@ -65,12 +69,12 @@ export default function Login() {
 
   const handleSignup = async () => {
     try {
-      const user = await auth.signUp({
+      const { sessionToken } = await http.post(`/api/2/users/signup`, {
         username,
         password,
         name: username,
       })
-      setCurrentUser(user)
+      setCurrentUser(await auth.loginWithSessionToken(sessionToken))
       redirect()
     } catch (error) {
       addNotification(error)

--- a/modules/i18n/locales/en.json
+++ b/modules/i18n/locales/en.json
@@ -323,5 +323,8 @@
   "pagination.nextPage": "Next",
   "pagination.prePage": "Previous",
   "pagination.display": "<1>{{total}}</1> items · <3></3> items per page",
-  "noData": "No data available"
+  "noData": "No data available",
+  "resetPassword": "Reset password",
+  "resetPasswordSent": "A verification email has been sent to your mailbox",
+  "resetPasswordEmptyEmail": "Please enter your email"
 }

--- a/modules/i18n/locales/zh.json
+++ b/modules/i18n/locales/zh.json
@@ -327,5 +327,8 @@
     "pagination.prePage": "上一页",
     "pagination.display": "共 <1>{{total}}</1> 条 · 每页显示 <3></3> 条",
     "noData": "暂无数据",
-    "evaluation.selections": "用户选择的评价："
+    "evaluation.selections": "用户选择的评价：",
+    "resetPassword": "重置密码",
+    "resetPasswordSent": "验证邮件已经发送到你的邮箱",
+    "resetPasswordEmptyEmail": "请填写邮箱"
 }

--- a/next/api/package-lock.json
+++ b/next/api/package-lock.json
@@ -28,7 +28,7 @@
         "kafkajs": "^2.2.2",
         "koa": "^2.13.4",
         "koa-bodyparser": "^4.3.0",
-        "leancloud-storage": "^4.13.4",
+        "leancloud-storage": "^4.14.0",
         "leanengine": "^3.8.0",
         "lodash": "^4.17.21",
         "lru-cache": "^7.14.0",
@@ -4584,9 +4584,9 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/leancloud-storage": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.13.4.tgz",
-      "integrity": "sha512-U2kcuokRljC2uyeCcK11yW02hPNuAu5LVXOYCsfVM8K/inRSbq4nKQbkAuzBfZKQsDOsryq16ztAeOB3fItcYg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.14.0.tgz",
+      "integrity": "sha512-DCJ67Dk6jrmCnoKZ/zTDwZSeBg2Gk2vHG8wnk2oWEJgcR290BB/2nDSe0H0xPT6nY36qfYYbNmM/tHPtLzRO0A==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.18.6",
         "@leancloud/adapter-types": "^5.0.0",
@@ -10334,9 +10334,9 @@
       "requires": {}
     },
     "leancloud-storage": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.13.4.tgz",
-      "integrity": "sha512-U2kcuokRljC2uyeCcK11yW02hPNuAu5LVXOYCsfVM8K/inRSbq4nKQbkAuzBfZKQsDOsryq16ztAeOB3fItcYg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/leancloud-storage/-/leancloud-storage-4.14.0.tgz",
+      "integrity": "sha512-DCJ67Dk6jrmCnoKZ/zTDwZSeBg2Gk2vHG8wnk2oWEJgcR290BB/2nDSe0H0xPT6nY36qfYYbNmM/tHPtLzRO0A==",
       "requires": {
         "@babel/runtime-corejs3": "^7.18.6",
         "@leancloud/adapter-types": "^5.0.0",

--- a/next/api/package.json
+++ b/next/api/package.json
@@ -34,7 +34,7 @@
     "kafkajs": "^2.2.2",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
-    "leancloud-storage": "^4.13.4",
+    "leancloud-storage": "^4.14.0",
     "leanengine": "^3.8.0",
     "lodash": "^4.17.21",
     "lru-cache": "^7.14.0",

--- a/next/api/src/controller/user.ts
+++ b/next/api/src/controller/user.ts
@@ -53,12 +53,6 @@ const authSchema = z.union([
 ]);
 type AuthData = z.infer<typeof authSchema>;
 
-const PasswordSignupSchema = z.object({
-  username: z.string(),
-  password: z.string(),
-  name: z.string().optional(),
-});
-
 const preCraeteSchema = z.object({
   email: z.string().email().optional(),
   username: z.string().optional(),
@@ -158,14 +152,6 @@ export class UserController {
       return User.loginWithPassword(authData.username, authData.password);
     }
     return User.loginWithAnonymousId(authData.anonymousId, authData.name);
-  }
-
-  @Post('signup')
-  async signup(
-    @Body(new ZodValidationPipe(PasswordSignupSchema))
-    signUpData: z.infer<typeof PasswordSignupSchema>
-  ) {
-    return User.signUpWithPassword(signUpData.username, signUpData.password, signUpData.name);
   }
 
   @Post('pre-create')

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -217,11 +217,6 @@ export class User extends Model {
     }
   }
 
-  static async signUpWithPassword(username: string, password: string, name?: string) {
-    const user = await AV.User.signUp(username, password, { name }, { useMasterKey: true });
-    return { sessionToken: user.getSessionToken() };
-  }
-
   static async loginWithJWT(token: string): Promise<{ sessionToken: string }> {
     let payload;
     try {

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -202,7 +202,9 @@ export class User extends Model {
     const sessionToken = await findAndUpdate();
     if (sessionToken) return { sessionToken };
     try {
-      const newUser = await AV.User.signUp(username, Math.random().toString(), attributes);
+      const newUser = await AV.User.signUp(username, Math.random().toString(), attributes, {
+        useMasterKey: true,
+      });
       return { sessionToken: newUser.getSessionToken() };
     } catch (error) {
       if (
@@ -213,6 +215,11 @@ export class User extends Model {
       }
       throw error;
     }
+  }
+
+  static async signUpWithPassword(username: string, password: string, name?: string) {
+    const user = await AV.User.signUp(username, password, { name }, { useMasterKey: true });
+    return { sessionToken: user.getSessionToken() };
   }
 
   static async loginWithJWT(token: string): Promise<{ sessionToken: string }> {
@@ -282,7 +289,13 @@ export class User extends Model {
   }
 
   static async loginWithAnonymousId(id: string, name?: string) {
-    throw new Error('Not implemented');
+    const user = await AV.User.loginWithAuthData({ id }, 'anonymous', { useMasterKey: true });
+    return { sessionToken: user.getSessionToken() };
+  }
+
+  static async loginWithPassword(username: string, password: string) {
+    const user = await AV.User.logIn(username, password);
+    return { sessionToken: user.getSessionToken() };
   }
 
   static generateTDSUserAuthData(token: string) {
@@ -306,6 +319,7 @@ export class User extends Model {
         'tds-user',
         {
           failOnNotExist,
+          useMasterKey: true,
         }
       );
     } catch (err: any) {

--- a/oauth/lc.js
+++ b/oauth/lc.js
@@ -53,7 +53,9 @@ exports.loginCallback = (callbackUrl) => {
         return getAccessToken(region, req.query.code, callbackUrl).then((accessToken) => {
           accessToken.uid = '' + accessToken.uid
           if (!sessionToken) {
-            return AV.User.loginWithAuthData(accessToken, getLeanCloudPlatform(region))
+            return AV.User.loginWithAuthData(accessToken, getLeanCloudPlatform(region), {
+              useMasterKey: true,
+            })
               .then((user) => {
                 if (!user.get('gravatarHash')) {
                   // 第一次登录，从 LeanCloud 初始化用户信息

--- a/oauth/xd-cas.js
+++ b/oauth/xd-cas.js
@@ -55,7 +55,9 @@ module.exports = (router) => {
                 }
                 const user = new AV.User()
                 user.set('email', email).set('name', realname)
-                await user.loginWithAuthData({ uid: userId, access_token: accessToken }, 'xd_cas')
+                await user.loginWithAuthData({ uid: userId, access_token: accessToken }, 'xd_cas', {
+                  useMasterKey: true,
+                })
                 console.log('new user created', user.id)
                 if (process.env.AUTO_ASSIGN_XD_STAFF_ROLE) {
                   const staff = await new AV.Query(AV.Role).equalTo('name', 'staff').first()


### PR DESCRIPTION
重构了登录和注册逻辑，现在会走一遍后端获取 sessionToken 再登录而不是在前端调用 lc sdk 直接用户密码/匿名 id 登录注册

OAuth 未测试