### PR TITLE
feat(next/api): use inactive represent user activation

### DIFF
--- a/api/next-shim.js
+++ b/api/next-shim.js
@@ -54,7 +54,7 @@ if (process.env.ENABLE_TDS_USER_LOGIN) {
 }
 
 AV.Cloud.onLogin((request) => {
-  if (request.object.get('active') !== true) {
+  if (request.object.get('inactive')) {
     throw new AV.Cloud.Error(
       JSON.stringify(new InactiveUserLoginError('Your account is inactive.'))
     )

--- a/next/api/src/controller/customer-service.ts
+++ b/next/api/src/controller/customer-service.ts
@@ -105,9 +105,10 @@ export class CustomerServiceController {
     @Param('id', FindCustomerServicePipe) user: User
   ) {
     if (data.active !== undefined) {
-      await user.update(data, { useMasterKey: true });
-
-      if (data.active === false) {
+      if (data.active) {
+        await user.update({ inactive: null }, { useMasterKey: true });
+      } else {
+        await user.update({ inactive: true }, { useMasterKey: true });
         await user.refreshSessionToken();
       }
     }

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -141,7 +141,7 @@ export class User extends Model {
   email?: string;
 
   @field()
-  active!: boolean;
+  inactive?: true;
 
   @field()
   password?: string;
@@ -405,7 +405,11 @@ export class User extends Model {
     const qb = User.queryBuilder().relatedTo(csRole, 'users').orderBy('email,username');
 
     if (active !== undefined) {
-      qb.where('active', '==', active);
+      if (active) {
+        qb.where('inactive', 'not-exists');
+      } else {
+        qb.where('inactive', '==', true);
+      }
     }
 
     return qb.find({ useMasterKey: true });
@@ -418,11 +422,8 @@ export class User extends Model {
     ]);
     const qb = User.queryBuilder()
       .relatedTo(csRole, 'users')
-      .where('objectId', 'not-in', vacationerIds);
-
-    if (active !== undefined) {
-      qb.where('active', '==', active);
-    }
+      .where('objectId', 'not-in', vacationerIds)
+      .where('inactive', 'not-exists');
 
     return qb.find({ useMasterKey: true });
   }

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -415,7 +415,7 @@ export class User extends Model {
     return qb.find({ useMasterKey: true });
   }
 
-  static async getCustomerServicesOnDuty(active?: boolean): Promise<User[]> {
+  static async getCustomerServicesOnDuty(): Promise<User[]> {
     const [csRole, vacationerIds] = await Promise.all([
       Role.getCustomerServiceRole(),
       Vacation.getVacationerIds(),

--- a/next/api/src/response/user.ts
+++ b/next/api/src/response/user.ts
@@ -30,7 +30,7 @@ export class UserResponse {
       id: this.user.id,
       username: this.user.username,
       nickname: this.user.name ?? this.user.username,
-      active: this.user.active,
+      active: !this.user.inactive,
       avatarUrl: GravatarUrlManager.getUrl(this.user.email ?? this.user.username),
     };
   }

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -669,8 +669,8 @@ router.patch('/:id', async (ctx) => {
       if (!assignee) {
         return ctx.throw(400, `User ${data.assigneeId} is not exists`);
       }
-      if (!assignee.active) {
-        return ctx.throw(400, `User ${data.assigneeId} is not active`);
+      if (assignee.inactive) {
+        return ctx.throw(400, `User ${data.assigneeId} is inactive`);
       }
       updater.setAssignee(assignee);
     } else {

--- a/next/api/src/ticket/TicketCreator.ts
+++ b/next/api/src/ticket/TicketCreator.ts
@@ -125,7 +125,7 @@ export class TicketCreator {
       throw new Error('The category is required for select assignee');
     }
 
-    const customerServices = await User.getCustomerServicesOnDuty(true);
+    const customerServices = await User.getCustomerServicesOnDuty();
     if (customerServices.length === 0) {
       return;
     }

--- a/resources/schema/_User.json
+++ b/resources/schema/_User.json
@@ -12,11 +12,10 @@
     "email": {
       "type": "String"
     },
-    "active": {
+    "inactive": {
       "type": "Boolean",
       "v": 2,
       "required": false,
-      "default": true,
       "hidden": false,
       "read_only": false
     },


### PR DESCRIPTION
See: https://xindong.slack.com/archives/C01RY5JHB47/p1673927589344479

简单来说就是踩了数据存储默认值的坑。没有选择处理旧数据是因为这个数据量可能很大，还会使部署操作会变得复杂。

现改为用 `inactive` 属性表示用户/客服是否被禁用，同时仅将值设置为 `undefined | true`，避免依赖默认值。