### PR TITLE
feat(next/api): slack plus can be disabled via config

### DIFF
--- a/next/api/src/integration/slack-plus/index.ts
+++ b/next/api/src/integration/slack-plus/index.ts
@@ -178,6 +178,7 @@ interface SlackPlusConfig {
   token: string;
   channel: string;
   signingSecret: string;
+  disabled?: boolean;
 }
 
 async function getConfig(): Promise<SlackPlusConfig | undefined> {
@@ -243,7 +244,7 @@ export class CreateSlackPlus {
 
 export default async function (install: Function) {
   const config = await getConfig();
-  if (!config) {
+  if (!config || config.disabled) {
     return;
   }
 


### PR DESCRIPTION
给 slack-plus 添加了禁用的配置，可以手动实例化发消息但是不会被通知系统触发