### PR TITLE
fix(api): ensure session token for ctx.currentUser attached by the auth middleware

### DIFF
--- a/next/api/src/middleware/auth.ts
+++ b/next/api/src/middleware/auth.ts
@@ -79,6 +79,7 @@ export const auth: Middleware = withSpan(async (ctx, next) => {
       throw new UserNotRegisteredError('未找到该 Token 对应的用户，该用户可能从未使用过客服功能。');
     }
 
+    await user.ensureSessionToken();
     ctx.state.currentUser = user;
     return next();
   }

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -542,6 +542,13 @@ export class User extends Model {
     return this.sessionToken;
   }
 
+  async ensureSessionToken(): Promise<User> {
+    if (this.sessionToken) return this;
+    const sessionToken = await this.loadSessionToken();
+    this.sessionToken = sessionToken;
+    return this;
+  }
+
   async refreshSessionToken(): Promise<void> {
     const avUser = AV.User.createWithoutData('_User', this.id) as AV.User;
     await avUser.refreshSessionToken({ useMasterKey: true });


### PR DESCRIPTION
还挺隐蔽的一个 bug，X-Credential 分支下 findByUsername 得到的 User 没有 sessinToken，然后继续走到 /unread 的逻辑里也不会报错，只是会以未登录的状态请求然后返回一个错的结果。