### PR TITLE
feat: node 16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+force=true

--- a/leanengine.yaml
+++ b/leanengine.yaml
@@ -1,7 +1,8 @@
 exposeEnvironmentsOnBuild: true
-install: 
+install:
   - use: default
   - require:
+    - ./.npmrc
     - ./package.json
     - ./package-lock.json
     - ./in-app/v1/package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "webpack-dev-server": "^3.11.2"
       },
       "engines": {
-        "node": "14.x"
+        "node": "^16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "LeanCloud",
   "engines": {
-    "node": "14.x"
+    "node": "^16.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
突然发现一直用的 node 14 + npm 6，然而所有的 lockfile 都升到版本 2 了，应该用 npm 7+ 安装依赖。

所以升到 node 16。