### PR TITLE
feat(next/api): autoclear dynamic content cache

### DIFF
--- a/next/api/src/dynamic-content/dynamic-content.service.ts
+++ b/next/api/src/dynamic-content/dynamic-content.service.ts
@@ -72,7 +72,7 @@ class DynamicContentService {
   }
 
   private async getFullContentsFromDB(names: string[]) {
-    const contents = await this.getDynamicContentsByName(names);
+    const contents = await this.getDynamicContentsByNames(names);
     const variants = await this.getDynamicContentVariantsByContents(contents);
 
     const contentByName = _.keyBy(contents, (c) => c.name);
@@ -103,7 +103,7 @@ class DynamicContentService {
     return fullContents;
   }
 
-  private async getDynamicContentsByName(names: string[]) {
+  private async getDynamicContentsByNames(names: string[]) {
     const chunkSize = 100;
     const concurrency = 2;
 

--- a/next/api/src/dynamic-content/dynamic-content.service.ts
+++ b/next/api/src/dynamic-content/dynamic-content.service.ts
@@ -11,8 +11,8 @@ class DynamicContentService {
 
   constructor() {
     this.fullContentCache = new Cache([
-      new LRUCacheStore({ max: 1000, ttl: 1000 * 60 }),
-      new RedisStore({ prefix: 'cache:dc', ttl: 60 * 5 }),
+      new LRUCacheStore({ max: 1000, ttl: 1000 * 60 * 10 }),
+      new RedisStore({ prefix: 'cache:dc', ttl: 60 * 60 }),
     ]);
   }
 
@@ -23,6 +23,10 @@ class DynamicContentService {
     });
     await renderer.render();
     return template.source;
+  }
+
+  async clearContentCache(name: string | string[]) {
+    await this.fullContentCache.del(name);
   }
 
   async getContentMap(names: string[], locales?: string[]) {

--- a/next/web/src/App/Admin/Settings/DynamicContents/index.tsx
+++ b/next/web/src/App/Admin/Settings/DynamicContents/index.tsx
@@ -161,14 +161,13 @@ function EditDynamicContentModal({ visible, onHide, dc, locales }: EditDynamicCo
 
   const { control, handleSubmit, reset } = useForm();
 
-  useEffect(() => {
-    if (!visible) {
-      reset({
-        name: dc.name,
-        defaultLocale: dc.defaultLocale,
-      });
-    }
-  }, [visible]);
+  const resetData = () => {
+    reset({
+      name: dc.name,
+      defaultLocale: dc.defaultLocale,
+    });
+  };
+  useEffect(resetData, [dc]);
 
   const $form = useRef<FormInstance>(null!);
 
@@ -187,13 +186,13 @@ function EditDynamicContentModal({ visible, onHide, dc, locales }: EditDynamicCo
 
   return (
     <Modal
-      destroyOnClose
       title="编辑动态内容"
       visible={visible}
       onCancel={() => !isLoading && onHide()}
       cancelButtonProps={{ disabled: isLoading }}
       onOk={() => $form.current.submit()}
       okButtonProps={{ loading: isLoading }}
+      afterClose={resetData}
     >
       <Form ref={$form} layout="vertical" onFinish={handleSubmit((data) => mutate([dc.id, data]))}>
         <Controller


### PR DESCRIPTION
在创建、更新、删除动态内容和其翻译文本时清除缓存。因为有了清除机制，适当延长缓存时间。

还修了一个前端表单数据不同步的 bug。