### PR TITLE
refactor: store TDSUser identify in username

### DIFF
--- a/api/next-shim.js
+++ b/api/next-shim.js
@@ -32,27 +32,6 @@ AV.Cloud.define('dailyPushStatsToSlack', () => dailyPushStatsToSlack())
 AV.Cloud.define('weeklyPushStatsToSlack', () => weeklyPushStatsToSlack())
 AV.Cloud.define('monthlyPushStatsToSlack', () => monthlyPushStatsToSlack())
 
-// TDS User Login
-if (process.env.ENABLE_TDS_USER_LOGIN) {
-  AV.Cloud.onAuthData((request) => {
-    const tdsUserData = request.authData['tds-user']
-
-    if (tdsUserData) {
-      const { access_token } = tdsUserData
-      try {
-        return {
-          ...request.authData,
-          'tds-user': User.generateTDSUserAuthData(access_token),
-        }
-      } catch (err) {
-        throw new AV.Cloud.Error(JSON.stringify(err))
-      }
-    }
-
-    return request.authData
-  })
-}
-
 AV.Cloud.onLogin((request) => {
   if (request.object.get('inactive')) {
     throw new AV.Cloud.Error(

--- a/next/api/src/model/User.ts
+++ b/next/api/src/model/User.ts
@@ -52,13 +52,7 @@ const anonymousUserCache = new RedisCache<AV.User | null | undefined>(
 const tdsUserCache = new RedisCache<AV.User | null | undefined>(
   'user:tds',
   async (token: string) => {
-    try {
-      return await User.loginOrSignUpTDSUser(token, true);
-    } catch (error: any) {
-      if (error.code === 211) return undefined;
-
-      throw error;
-    }
+    return (await User.loginTDSUser(token))?.sourceAVObject as AV.User;
   },
   (user) => (user ? encodeAVUser(user) : 'null'),
   (data) => (data === 'null' ? null : decodeAVUser(data))
@@ -341,13 +335,12 @@ export class User extends Model {
       throw err;
     }
   }
+  static getVerifiedTDSUserPayload(token: string) {
+    return getVerifiedPayloadWithSubRequired(token, { issuer: 'tap-support' }, TDSUserSigningKey);
+  }
 
   static generateTDSUserAuthData(token: string) {
-    const { sub } = getVerifiedPayloadWithSubRequired(
-      token,
-      { issuer: 'tap-support' },
-      TDSUserSigningKey
-    );
+    const { sub } = this.getVerifiedTDSUserPayload(token);
 
     return {
       uid: sub,
@@ -355,44 +348,32 @@ export class User extends Model {
     };
   }
 
-  static async loginOrSignUpTDSUser(token: string, failOnNotExist = false): Promise<AV.User> {
-    try {
-      // FIXME: uid is placeholder
-      return await AV.User.loginWithAuthData(
-        { uid: 'placeholder', access_token: token },
-        'tds-user',
-        {
-          failOnNotExist,
-          useMasterKey: true,
-        }
-      );
-    } catch (err: any) {
-      const error = this.hookErrorProcessor(err);
+  static async loginTDSUser(token: string): Promise<User | undefined> {
+    const { sub } = User.getVerifiedTDSUserPayload(token);
+    return this.findByUsername(sub);
+  }
 
-      if (error && error.name === 'JsonWebTokenError') {
-        throw new InvalidCredentialError(error.message, err);
-      }
-
-      throw err;
-    }
+  static async loginOrSignUpTDSUser(token: string): Promise<{ sessionToken: string }> {
+    const { sub } = User.getVerifiedTDSUserPayload(token);
+    return this.upsertByUsername(sub);
   }
 
   static async loginWithTDSUserToken(token: string): Promise<{ sessionToken: string }> {
-    const user = await User.loginOrSignUpTDSUser(token);
+    const sessionToken = await User.loginOrSignUpTDSUser(token);
 
     await tdsUserCache.del(token);
 
-    return { sessionToken: user.getSessionToken() };
+    return sessionToken;
   }
 
   static async associateAnonymousWithTDSUser(token: string, aid: string) {
+    const { sub } = this.getVerifiedTDSUserPayload(token);
     const anonymousUser = await this.findByAnonymousId(aid);
 
     if (anonymousUser) {
-      const authData = transformToHttpError(() => this.generateTDSUserAuthData(token));
       return anonymousUser.update(
         {
-          authData: { 'tds-user': authData },
+          username: sub,
         },
         { sessionToken: await anonymousUser.loadSessionToken() }
       );

--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -125,6 +125,8 @@ export abstract class Model {
 
   updatedAt!: Date;
 
+  sourceAVObject?: AV.Object;
+
   private reloadTasks: Record<string, Promise<any>> = {};
 
   get className() {
@@ -265,6 +267,7 @@ export abstract class Model {
     }
     const instance = this.newInstance();
     instance.applyAVObject(object);
+    instance.sourceAVObject = object;
     return instance;
   }
 


### PR DESCRIPTION
TDSUser identify 现在是放在 authData 里的，想要直接放到 username  里。原因有：

- 客服创建用户的时候目前只支持指定 username 创建的，放在 authData 里现在没发预创建。
- 方便展示（当然这不是主要理由，因为 name 也可以用来展示）
- User 的公开 create 权限已经关闭，不会有被绕过的风险。