### PR TITLE
fix: in-app better i18n fallback

### DIFF
--- a/in-app/v1/src/i18n/index.ts
+++ b/in-app/v1/src/i18n/index.ts
@@ -66,8 +66,26 @@ const resources = {
   },
 };
 
+const languageDetector = new LanguageDetector();
+
+const querystringOrNavigator = {
+  name: 'querystring-or-navigator',
+
+  lookup(options: ConstructorParameters<typeof LanguageDetector>['1']) {
+    const querystring = languageDetector.detectors['querystring'].lookup(options) as
+      | string[]
+      | undefined;
+
+    return querystring?.length
+      ? querystring
+      : languageDetector.detectors['navigator'].lookup(options);
+  },
+};
+
+languageDetector.addDetector(querystringOrNavigator);
+
 i18n
-  .use(LanguageDetector)
+  .use(languageDetector)
   .use(initReactI18next)
   .init({
     resources,
@@ -77,7 +95,7 @@ i18n
       escapeValue: false,
     },
     detection: {
-      order: ['querystring', 'navigator'],
+      order: ['querystring-or-navigator'],
       lookupQuerystring: 'lang',
       caches: [],
     },


### PR DESCRIPTION
[i18next-browser-languageDetector](https://github.com/i18next/i18next-browser-languageDetector) 会把 order 里所有的结果拼起来...然后如果 `querystring` 传进去是 `ja-JP` 但是用户浏览器 `navigator` 有 `en` 就会把这两个拼起来变成 `['ja-JP', 'en']` 传入 i18next 的 `LanguageUtils.getBestMatchFromCodes`，然后这函数第一轮是直接 `supportedLngs` 里去找有没有一样的（用的 `indexOf`），于是匹配上 `en`（`ja-JP` 匹配 `ja` 在第二轮进行），炸了

i18next 坑真多...