### PR TITLE
feat: quick reply tags

### DIFF
--- a/modules/Ticket/CSReplyEditor/index.module.scss
+++ b/modules/Ticket/CSReplyEditor/index.module.scss
@@ -35,6 +35,7 @@
 
 .quickReplyModal {
   max-height: calc(100vh - 56px);
+  min-height: 600px;
   overflow: hidden;
 
   :global(.modal-body) {
@@ -45,6 +46,9 @@
   }
 
   .searchQuickReply {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
     padding: 8px;
     border-bottom:  1px rgba(0, 0, 0, 0.13) solid;
   }

--- a/next/api/src/controller/quick-reply.ts
+++ b/next/api/src/controller/quick-reply.ts
@@ -29,6 +29,7 @@ const createQuickReplySchema = z.object({
   content: z.string(),
   fileIds: z.array(z.string()).optional(),
   userId: z.string().optional(),
+  tags: z.array(z.string()).optional(),
 });
 
 const updateQuickReplySchema = createQuickReplySchema
@@ -53,8 +54,12 @@ export class QuickReplyController {
     const ACL = new ACLBuilder().allowCustomerService('read', 'write');
     const quickReply = await QuickReply.create(
       {
-        ...data,
         ACL,
+        name: data.name,
+        content: data.content,
+        fileIds: data.fileIds,
+        userId: data.userId,
+        tags: data.tags,
       },
       currentUser.getAuthOptions()
     );

--- a/next/api/src/controller/quick-reply.ts
+++ b/next/api/src/controller/quick-reply.ts
@@ -1,14 +1,11 @@
-import { Context } from 'koa';
 import { z } from 'zod';
 
 import {
   Body,
   Controller,
-  Ctx,
   CurrentUser,
   Delete,
   Get,
-  Pagination,
   Param,
   Patch,
   Post,
@@ -17,7 +14,7 @@ import {
   StatusCode,
   UseMiddlewares,
 } from '@/common/http';
-import { FindModelPipe, ParseBoolPipe, ParseCsvPipe, ZodValidationPipe } from '@/common/pipe';
+import { FindModelPipe, ParseCsvPipe, ZodValidationPipe } from '@/common/pipe';
 import { auth, customerServiceOnly } from '@/middleware';
 import { ACLBuilder } from '@/orm';
 import { User } from '@/model/User';
@@ -70,14 +67,8 @@ export class QuickReplyController {
 
   @Get()
   @ResponseBody(QuickReplyResponse)
-  async find(
-    @Ctx() ctx: Context,
-    @CurrentUser() currentUser: User,
-    @Pagination() [page, pageSize]: [number, number],
-    @Query('userId', ParseCsvPipe) userIds?: string[],
-    @Query('count', ParseBoolPipe) count?: boolean
-  ) {
-    const query = QuickReply.queryBuilder().paginate(page, pageSize);
+  async find(@CurrentUser() currentUser: User, @Query('userId', ParseCsvPipe) userIds?: string[]) {
+    const query = QuickReply.queryBuilder().limit(1000);
 
     if (userIds) {
       if (userIds.includes('null')) {
@@ -90,17 +81,7 @@ export class QuickReplyController {
       }
     }
 
-    let quickReplies: QuickReply[];
-    let totalCount: number | undefined;
-
-    if (count) {
-      [quickReplies, totalCount] = await query.findAndCount(currentUser.getAuthOptions());
-      ctx.set('X-Total-Count', totalCount.toString());
-    } else {
-      quickReplies = await query.find(currentUser.getAuthOptions());
-    }
-
-    return quickReplies;
+    return query.find(currentUser.getAuthOptions());
   }
 
   @Get(':id')

--- a/next/api/src/model/QuickReply.ts
+++ b/next/api/src/model/QuickReply.ts
@@ -14,4 +14,7 @@ export class QuickReply extends Model {
 
   @pointerId(() => User, 'owner')
   userId?: string;
+
+  @field()
+  tags?: string[];
 }

--- a/next/api/src/response/quick-reply.ts
+++ b/next/api/src/response/quick-reply.ts
@@ -10,6 +10,7 @@ export class QuickReplyResponse {
       content: this.quickReply.content,
       userId: this.quickReply.userId,
       fileIds: this.quickReply.fileIds,
+      tags: this.quickReply.tags,
     };
   }
 }

--- a/next/web/src/App/Admin/Settings/QuickReplies/QuickReplyForm.tsx
+++ b/next/web/src/App/Admin/Settings/QuickReplies/QuickReplyForm.tsx
@@ -113,16 +113,27 @@ export interface QuickReplyFormData {
   content: string;
   visibility: 'all' | 'private';
   fileIds?: string[];
+  tags?: string[];
 }
 
 export interface QuickReplyFormProps {
   initData?: QuickReplyFormData;
+  availableTags?: string[];
   loading?: boolean;
   onSubmit: (data: QuickReplyFormData) => void;
 }
 
-export function QuickReplyForm({ initData, loading, onSubmit }: QuickReplyFormProps) {
+export function QuickReplyForm({
+  initData,
+  availableTags,
+  loading,
+  onSubmit,
+}: QuickReplyFormProps) {
   const { control, handleSubmit } = useForm({ defaultValues: initData });
+
+  const tagOptions = useMemo(() => {
+    return availableTags?.map((label) => ({ label, value: label }));
+  }, [availableTags]);
 
   return (
     <Form layout="vertical" onFinish={handleSubmit(onSubmit)}>
@@ -137,7 +148,6 @@ export function QuickReplyForm({ initData, loading, onSubmit }: QuickReplyFormPr
             htmlFor="quick_reply_form_name"
             validateStatus={error ? 'error' : undefined}
             help={error?.message}
-            style={{ marginBottom: 16 }}
           >
             <Input {...field} id="quick_reply_form_name" autoFocus />
           </Form.Item>
@@ -153,7 +163,7 @@ export function QuickReplyForm({ initData, loading, onSubmit }: QuickReplyFormPr
             required
             label="权限"
             htmlFor="quick_reply_form_visibility"
-            help="谁可以使用这个快捷回复"
+            extra="谁可以使用这个快捷回复"
           >
             <Select {...field} id="quick_reply_form_visibility">
               <Option value="all">所有人</Option>
@@ -163,7 +173,20 @@ export function QuickReplyForm({ initData, loading, onSubmit }: QuickReplyFormPr
         )}
       />
 
-      <Divider style={{ margin: '8px 0' }} />
+      <Controller
+        control={control}
+        name="tags"
+        render={({ field }) => (
+          <Form.Item
+            label="标签"
+            extra="可以用任意字符串创建（输入并按下回车键）或从已有标签中选择，含有相同标签的快捷回复将被分为一组。"
+          >
+            <Select {...field} mode="tags" options={tagOptions} />
+          </Form.Item>
+        )}
+      />
+
+      <Divider />
 
       <Controller
         control={control}
@@ -189,11 +212,11 @@ export function QuickReplyForm({ initData, loading, onSubmit }: QuickReplyFormPr
         render={({ field: { ref, ...field } }) => <Files {...field} />}
       />
 
-      <div className="mt-4">
+      <div className="mt-4 space-x-2">
         <Button type="primary" htmlType="submit" loading={loading}>
           保存
         </Button>
-        <Link className="ml-2" to="..">
+        <Link to="..">
           <Button disabled={loading}>返回</Button>
         </Link>
       </div>

--- a/resources/schema/QuickReply.json
+++ b/resources/schema/QuickReply.json
@@ -1,5 +1,12 @@
 {
   "schema": {
+    "tags": {
+      "type": "Array",
+      "v": 2,
+      "required": false,
+      "hidden": false,
+      "read_only": false
+    },
     "updatedAt": {
       "type": "Date"
     },


### PR DESCRIPTION
## 为快捷回复添加标签

通过为快捷回复添加标签的方式实现快捷回复分组。

客服可为快捷回复添加任意数量的标签。插入快捷回复时支持根据标签进行筛选。

## Deploy.md draft

导入 QuickReply.json，添加 tags 列。
