### PR TITLE
feat(next/api): article centralized cache

### DIFF
--- a/next/api/src/article/article.service.ts
+++ b/next/api/src/article/article.service.ts
@@ -89,21 +89,16 @@ export class ArticleService {
   }
 
   async clearArticleCache(articleId: string) {
-    await this.clearArticleTranslationsCache(articleId);
     await this.cache.del(articleId);
   }
 
-  async clearArticleTranslationsCache(articleId: string) {
+  async clearAllArticleCache(articleId: string) {
+    const cacheKeys = [articleId, `${articleId}:langs`];
     const { published, unpublished } = await this.getArticleLanguages(articleId);
-    const langs = published.concat(unpublished);
-    if (langs.length) {
-      await this.cache.del([
-        `${articleId}:langs`,
-        ...langs.map((lang) => `${articleId}:lang:${lang}`),
-      ]);
-    } else {
-      await this.cache.del(`${articleId}:langs`);
-    }
+    published.concat(unpublished).forEach((lang) => {
+      cacheKeys.push(`${articleId}:lang:${lang}`);
+    });
+    await this.cache.del(cacheKeys);
   }
 
   async clearArticleTranslationCache(articleId: string, language: string) {

--- a/next/api/src/article/article.service.ts
+++ b/next/api/src/article/article.service.ts
@@ -1,0 +1,99 @@
+import { Cache, RedisStore } from '@/cache';
+import { Article } from '@/model/Article';
+import { ArticleTranslation } from '@/model/ArticleTranslation';
+
+export class ArticleService {
+  private cache: Cache;
+
+  constructor() {
+    const redisStore = new RedisStore({
+      prefix: 'article',
+      ttl: 60 * 60, // 1 hour
+    });
+    this.cache = new Cache([redisStore]);
+  }
+
+  async getArticle(articleId: string) {
+    const cacheValue = await this.cache.get(articleId);
+    if (cacheValue) {
+      return Article.fromJSON(cacheValue);
+    }
+    if (cacheValue === null) {
+      return;
+    }
+
+    const article = await Article.queryBuilder()
+      .where('objectId', '==', articleId)
+      .where('deletedAt', 'not-exists')
+      .first({ useMasterKey: true });
+
+    if (article) {
+      await this.cache.set(articleId, article.toJSON());
+    } else {
+      await this.cache.set(articleId, null);
+    }
+
+    return article;
+  }
+
+  async getArticlePublishedLanguages(articleId: string) {
+    const cacheKey = `${articleId}:langs`;
+    const cacheValue = await this.cache.get(cacheKey);
+    if (cacheValue) {
+      return cacheValue;
+    }
+
+    const translations = await ArticleTranslation.queryBuilder()
+      .where('article', '==', Article.ptr(articleId))
+      .where('deletedAt', 'not-exists')
+      .where('private', '==', false)
+      .find({ useMasterKey: true });
+
+    const languages = translations.map((t) => t.language);
+    // 空数组就是一种空值，不需要再回种 null
+    await this.cache.set(cacheKey, languages);
+
+    return languages;
+  }
+
+  async getArticleTranslation(articleId: string, language: string) {
+    const cacheKey = `${articleId}:lang:${language}`;
+    const cacheValue = await this.cache.get(cacheKey);
+    if (cacheValue) {
+      return ArticleTranslation.fromJSON(cacheValue);
+    }
+    if (cacheValue === null) {
+      return;
+    }
+
+    const translation = await ArticleTranslation.queryBuilder()
+      .where('article', '==', Article.ptr(articleId))
+      .where('language', '==', language)
+      .where('deletedAt', 'not-exists')
+      .first({ useMasterKey: true });
+
+    if (translation) {
+      await this.cache.set(cacheKey, translation.toJSON());
+    } else {
+      await this.cache.set(cacheKey, null);
+    }
+
+    return translation;
+  }
+
+  async clearArticleCache(articleId: string) {
+    await this.clearArticleTranslationsCache(articleId);
+    await this.cache.del(articleId);
+  }
+
+  async clearArticleTranslationsCache(articleId: string) {
+    const cacheKey = `${articleId}:langs`;
+    const languages = await this.cache.get<string[]>(cacheKey);
+    if (languages) {
+      const cacheKeys = [cacheKey].concat(languages.map((lang) => `${articleId}:lang:${lang}`));
+      await this.cache.del(cacheKeys);
+    }
+  }
+}
+
+export const articleService = new ArticleService();

--- a/next/api/src/article/types.ts
+++ b/next/api/src/article/types.ts
@@ -1,0 +1,4 @@
+export interface ArticleLanguages {
+  published: string[];
+  unpublished: string[];
+}

--- a/next/api/src/controller/category.ts
+++ b/next/api/src/controller/category.ts
@@ -28,7 +28,7 @@ import { ArticleTopicFullResponse } from '@/response/article-topic';
 import { getTopic } from '@/model/ArticleTopic';
 import { FindCategoryPipe, categoryService } from '@/category';
 import { ILocale, Locales } from '@/common/http/handler/param/locale';
-import { getPublicTranslationWithLocales } from '@/model/ArticleTranslation';
+import { getPublishedArticleTranslations } from '@/model/ArticleTranslation';
 import { dynamicContentService } from '@/dynamic-content';
 
 const createCategorySchema = z.object({
@@ -160,37 +160,20 @@ export class CategoryController {
 
   @Get(':id/faqs')
   @ResponseBody(ArticleTranslationAbstractResponse)
-  async getFAQs(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
+  getFAQs(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
     if (!category.FAQIds) {
       return [];
     }
-
-    const articles = _.compact(
-      await Promise.all(
-        category.FAQIds.map((articleId) =>
-          getPublicTranslationWithLocales(articleId, locales.matcher)
-        )
-      )
-    );
-    return articles;
+    return getPublishedArticleTranslations(category.FAQIds, locales.matcher);
   }
 
   @Get(':id/notices')
   @ResponseBody(ArticleTranslationAbstractResponse)
-  async getNotices(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
+  getNotices(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
     if (!category.noticeIds) {
       return [];
     }
-
-    const articles = _.compact(
-      await Promise.all(
-        category.noticeIds.map((noticeId) =>
-          getPublicTranslationWithLocales(noticeId, locales.matcher)
-        )
-      )
-    );
-
-    return articles;
+    return getPublishedArticleTranslations(category.noticeIds, locales.matcher);
   }
 
   @Get(':id/topics')

--- a/next/api/src/model/Article.ts
+++ b/next/api/src/model/Article.ts
@@ -10,12 +10,15 @@ export class Article extends Model {
   name!: string;
 
   @field()
+  @serialize()
   private?: boolean;
 
   @field()
+  @serialize()
   defaultLanguage!: string;
 
   @field()
+  @serialize()
   deletedAt?: Date;
 
   async delete(this: Article, options?: ModifyOptions) {

--- a/next/api/src/model/Article.ts
+++ b/next/api/src/model/Article.ts
@@ -1,6 +1,4 @@
-import mem from '@/utils/mem-promise';
-import { AuthOptions, field, Model, ModifyOptions, serialize } from '@/orm';
-import { ArticleTranslation } from './ArticleTranslation';
+import { field, Model, ModifyOptions, serialize } from '@/orm';
 
 export class Article extends Model {
   static readonly className = 'FAQ';
@@ -31,35 +29,4 @@ export class Article extends Model {
       { ...options, ignoreAfterHook: true, ignoreBeforeHook: true }
     );
   }
-
-  async getTranslation(this: Article, language?: string, options?: AuthOptions) {
-    const translation = await ArticleTranslation.queryBuilder()
-      .where('article', '==', this.toPointer())
-      .where('language', '==', language || this.defaultLanguage)
-      .preload('revision')
-      .first(options);
-
-    translation && (translation.article = this);
-
-    return translation;
-  }
-
-  async getTranslations(this: Article, isPublic?: boolean) {
-    const translationQb = ArticleTranslation.queryBuilder()
-      .where('article', '==', this.toPointer())
-      .preload('revision');
-
-    if (isPublic) {
-      translationQb.where('private', '==', false);
-    }
-
-    return (await translationQb.find({ useMasterKey: true })).map(
-      (translation) => ((translation.article = this), translation)
-    );
-  }
 }
-
-export const getPublicArticle = mem(
-  (id: string) => Article.find(id).then((article) => (article?.private ? undefined : article)),
-  { max: 500, ttl: 60_000 }
-);

--- a/next/api/src/model/ArticleTopic.ts
+++ b/next/api/src/model/ArticleTopic.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import mem from '@/utils/mem-promise';
 import { field, hasManyThroughIdArray, Model, ModifyOptions, serialize } from '@/orm';
 import { Article } from './Article';
-import { ArticleTranslation, getPublicTranslationWithLocales } from './ArticleTranslation';
+import { ArticleTranslation, getPublishedArticleTranslations } from './ArticleTranslation';
 import { LocaleMatcher } from '@/utils/locale';
 
 export class ArticleTopic extends Model {
@@ -43,11 +43,7 @@ const getRawTopic = mem((id: string) => ArticleTopic.find(id), { max: 500, ttl: 
 export const getTopic = async (id: string, matcher: LocaleMatcher) => {
   const topic = await getRawTopic(id);
   if (topic) {
-    topic.translations = _.compact(
-      await Promise.all(
-        topic.articleIds.map((articleId) => getPublicTranslationWithLocales(articleId, matcher))
-      )
-    );
+    topic.translations = await getPublishedArticleTranslations(topic.articleIds, matcher);
   }
   return topic;
 };

--- a/next/api/src/model/ArticleTranslation.ts
+++ b/next/api/src/model/ArticleTranslation.ts
@@ -90,7 +90,7 @@ export class ArticleTranslation extends Model {
         content: updatedArticle.content,
         title: updatedArticle.title,
       });
-      this.update(
+      await this.update(
         {
           revisionId: revision.id,
         },

--- a/next/api/src/model/ArticleTranslation.ts
+++ b/next/api/src/model/ArticleTranslation.ts
@@ -30,7 +30,7 @@ export class ArticleTranslation extends Model {
 
   @pointerId(() => Article)
   @serialize()
-  articleId?: string;
+  articleId!: string;
 
   @pointTo(() => Article)
   article?: Article;

--- a/next/api/src/model/ArticleTranslation.ts
+++ b/next/api/src/model/ArticleTranslation.ts
@@ -14,18 +14,23 @@ export class ArticleTranslation extends Model {
   title!: string;
 
   @field()
+  @serialize()
   content?: string;
 
   @field()
+  @serialize()
   contentHTML!: string;
 
   @field()
+  @serialize()
   language!: string;
 
   @field()
+  @serialize()
   private!: boolean;
 
   @field()
+  @serialize()
   deletedAt?: Date;
 
   @pointerId(() => Article)

--- a/next/api/src/response/article.ts
+++ b/next/api/src/response/article.ts
@@ -5,16 +5,13 @@ import { config } from '@/config';
 import { ArticleTranslation } from '@/model/ArticleTranslation';
 
 export class ArticleTranslationAbstractResponse {
-  private article: Article;
-
-  constructor(readonly articleTranslation: ArticleTranslation) {
-    this.article = articleTranslation.article!;
-  }
+  constructor(readonly articleTranslation: ArticleTranslation) {}
 
   toJSON() {
-    const slug = `${this.article.id}-${sluggo(this.articleTranslation.title)}`;
+    const articleId = this.articleTranslation.articleId;
+    const slug = `${articleId}-${sluggo(this.articleTranslation.title)}`;
     return {
-      id: this.article.id,
+      id: articleId,
       title: this.articleTranslation.title,
       language: this.articleTranslation.language,
       slug,

--- a/next/api/src/response/article.ts
+++ b/next/api/src/response/article.ts
@@ -19,8 +19,8 @@ export class ArticleTranslationAbstractResponse {
       private: !!this.articleTranslation.private,
       revision: this.articleTranslation.revision
         ? {
-            upvote: this.articleTranslation.revision?.upvote,
-            downvote: this.articleTranslation.revision?.downvote,
+            upvote: this.articleTranslation.revision.upvote,
+            downvote: this.articleTranslation.revision.downvote,
           }
         : undefined,
       createdAt: this.articleTranslation.createdAt.toISOString(),
@@ -30,10 +30,6 @@ export class ArticleTranslationAbstractResponse {
 }
 
 export class ArticleTranslationResponse extends ArticleTranslationAbstractResponse {
-  constructor(readonly articleTranslation: ArticleTranslation) {
-    super(articleTranslation);
-  }
-
   toJSON() {
     return {
       ...super.toJSON(),

--- a/next/api/src/router/article.ts
+++ b/next/api/src/router/article.ts
@@ -86,7 +86,10 @@ router.get('/detail', pagination(20), auth, async (ctx) => {
 
   const currentUser = ctx.state.currentUser as User;
 
-  const articleQb = Article.queryBuilder().orderBy('createdAt', 'desc').paginate(page, pageSize);
+  const articleQb = Article.queryBuilder()
+    .where('deletedAt', 'not-exists')
+    .orderBy('createdAt', 'desc')
+    .paginate(page, pageSize);
   if (isPrivate !== undefined) {
     articleQb.where('private', '==', isPrivate);
   }
@@ -100,11 +103,13 @@ router.get('/detail', pagination(20), auth, async (ctx) => {
     return;
   }
 
-  const translationQb = ArticleTranslation.queryBuilder().where(
-    'article',
-    'in',
-    articles.map((a) => a.toPointer())
-  );
+  const translationQb = ArticleTranslation.queryBuilder()
+    .where('deletedAt', 'not-exists')
+    .where(
+      'article',
+      'in',
+      articles.map((a) => a.toPointer())
+    );
   if (isPrivate !== undefined) {
     translationQb.where('private', '==', isPrivate);
   }

--- a/next/api/src/router/article.ts
+++ b/next/api/src/router/article.ts
@@ -1,13 +1,13 @@
-import Router from '@koa/router';
+import Router, { Middleware } from '@koa/router';
+import _ from 'lodash';
 
-import { Article, getPublicArticle } from '@/model/Article';
+import { Article } from '@/model/Article';
 import {
   ArticleResponse,
   ArticleTranslationAbstractResponse,
   ArticleTranslationResponse,
 } from '@/response/article';
 import * as yup from '@/utils/yup';
-import _ from 'lodash';
 import { auth, customerServiceOnly, pagination } from '@/middleware';
 import { ACLBuilder, CreateData, UpdateData } from '@/orm';
 import htmlify from '@/utils/htmlify';
@@ -15,15 +15,14 @@ import { User } from '@/model/User';
 import { Category } from '@/model/Category';
 import { CategoryResponse } from '@/response/category';
 import { ArticleRevision } from '@/model/ArticleRevision';
-
 import {
   ArticleRevisionListItemResponse,
   ArticleRevisionResponse,
 } from '@/response/article-revision';
 import { FeedbackType } from '@/model/ArticleFeedback';
-import { ArticleTranslation } from '@/model/ArticleTranslation';
+import { ArticleTranslation, getArticleTranslation } from '@/model/ArticleTranslation';
 import { localeSchemaForYup, matchLocale } from '@/utils/locale';
-import { Middleware } from '@koa/router';
+import { articleService } from '@/article/article.service';
 
 const router = new Router();
 
@@ -32,37 +31,16 @@ interface ArticleState {
   translation: ArticleTranslation;
 }
 
-const fetchPreferTranslation: Middleware<ArticleState> = async (ctx, next) => {
-  if (!ctx.state.article) {
-    ctx.throw(404, 'Article not found');
-    return;
-  }
+const fetchPreferredTranslation: Middleware<ArticleState> = async (ctx, next) => {
+  const article = ctx.state.article;
 
-  const translationQb = ArticleTranslation.queryBuilder().where(
-    'article',
-    '==',
-    ctx.state.article.toPointer()
-  );
-
-  const sessionToken = ctx.get('X-LC-Session');
-
-  if (!sessionToken) {
-    translationQb.where('private', '==', false);
-  }
-
-  const translation = matchLocale(
-    await translationQb.find(sessionToken ? { sessionToken } : undefined),
-    (translation) => translation.language,
-    ctx.locales.matcher,
-    ctx.state.article.defaultLanguage
-  );
-
+  // TODO: read cache only once (now twice 👀)
+  const translation = await getArticleTranslation(article.id, ctx.locales.matcher);
   if (!translation) {
     ctx.throw(404, 'Article not found');
     return;
   }
 
-  translation && (translation.article = ctx.state.article);
   ctx.state.translation = translation;
   return next();
 };
@@ -78,9 +56,9 @@ router.get('/', pagination(20), auth, customerServiceOnly, async (ctx) => {
   const { private: isPrivate, id } = findArticlesOptionSchema.validateSync(ctx.request.query);
 
   const query = Article.queryBuilder()
+    .where('deletedAt', 'not-exists')
     .orderBy('createdAt', 'desc')
-    .skip((page - 1) * pageSize)
-    .limit(pageSize);
+    .paginate(page, pageSize);
 
   if (isPrivate !== undefined) {
     query.where('private', '==', isPrivate);
@@ -108,24 +86,29 @@ router.get('/detail', pagination(20), auth, async (ctx) => {
 
   const currentUser = ctx.state.currentUser as User;
 
-  const articleQb = Article.queryBuilder()
-    .orderBy('createdAt', 'desc')
-    .skip((page - 1) * pageSize)
-    .limit(pageSize);
-
-  const translationQb = ArticleTranslation.queryBuilder();
-
+  const articleQb = Article.queryBuilder().orderBy('createdAt', 'desc').paginate(page, pageSize);
   if (isPrivate !== undefined) {
     articleQb.where('private', '==', isPrivate);
-    translationQb.where('private', '==', isPrivate);
   }
-
   if (id) {
     articleQb.where('objectId', 'in', id);
-    translationQb.where('article', 'in', id.map(Article.ptr.bind(Article)));
   }
 
   const articles = await articleQb.find(currentUser.getAuthOptions());
+  if (articles.length === 0) {
+    ctx.body = [];
+    return;
+  }
+
+  const translationQb = ArticleTranslation.queryBuilder().where(
+    'article',
+    'in',
+    articles.map((a) => a.toPointer())
+  );
+  if (isPrivate !== undefined) {
+    translationQb.where('private', '==', isPrivate);
+  }
+
   const translations = await translationQb.find({ useMasterKey: true });
 
   const articleById = _.keyBy(articles, (a) => a.id);
@@ -144,10 +127,7 @@ router.get('/detail', pagination(20), auth, async (ctx) => {
     .values()
     .compact()
     .value()
-    .map((t) => {
-      t.article = articleById[t.articleId!];
-      return new ArticleTranslationResponse(t);
-    });
+    .map((t) => new ArticleTranslationResponse(t));
 
   ctx.body = response;
 });
@@ -197,54 +177,35 @@ router.post('/', auth, customerServiceOnly, async (ctx) => {
 });
 
 router.param('id', async (id, ctx, next) => {
-  let article;
-  // Use cached result only for GET request.
-  // This is a temporary workaround before we replace the memery cache with redis.
-  // if (ctx.request.method !== 'GET') {
-  //   article = await getPublicArticle(id);
-  // }
-  // if (!article) {
-  //   const sessionToken = ctx.get('X-LC-Session');
-  //   if (sessionToken) {
-  //     article = await Article.find(id, { sessionToken });
-  //   }
-  // }
-  const sessionToken = ctx.get('X-LC-Session');
-  if (sessionToken) {
-    article = await Article.find(id, { sessionToken });
-  } else {
-    article = await getPublicArticle(id);
-  }
-
+  const article = await articleService.getArticle(id);
   if (!article) {
     ctx.throw(404, 'Article not found');
   }
-
   ctx.state.article = article;
   return next();
 });
 
 // get translation of article :id based on use prefer
-router.get('/:id', fetchPreferTranslation, async (ctx) => {
-  const translation = ctx.state.translation;
-
-  ctx.body = new ArticleTranslationResponse(translation);
+router.get('/:id', fetchPreferredTranslation, (ctx) => {
+  ctx.body = new ArticleTranslationResponse(ctx.state.translation);
 });
 
 // get article :id
-router.get('/:id/info', auth, customerServiceOnly, async (ctx) => {
-  const article = ctx.state.article as Article;
-
-  ctx.body = new ArticleResponse(article);
+router.get('/:id/info', auth, customerServiceOnly, (ctx) => {
+  ctx.body = new ArticleResponse(ctx.state.article);
 });
 
 // get translations of article :id
 router.get('/:id/translations', auth, customerServiceOnly, async (ctx) => {
   const article = ctx.state.article as Article;
 
-  ctx.body = (await article.getTranslations()).map(
-    (translations) => new ArticleTranslationAbstractResponse(translations)
-  );
+  const translations = await ArticleTranslation.queryBuilder()
+    .where('article', '==', article.toPointer())
+    .where('deletedAt', 'not-exists')
+    .preload('revision')
+    .find({ useMasterKey: true });
+
+  ctx.body = translations.map((translation) => new ArticleTranslationAbstractResponse(translation));
 });
 
 // get a list of category which uses article :id
@@ -266,6 +227,7 @@ const createArticleTranslationSchema = yup.object({
 });
 
 // create translation for article :id
+// TODO: prefer /:id/translations
 router.post('/:id', auth, customerServiceOnly, async (ctx) => {
   const currentUser = ctx.state.currentUser as User;
   const article = ctx.state.article as Article;
@@ -294,7 +256,7 @@ router.post('/:id', auth, customerServiceOnly, async (ctx) => {
   const translation = await ArticleTranslation.create(data, { useMasterKey: true });
   await translation.createRevision(currentUser, translation);
 
-  translation.article = article;
+  await articleService.clearArticleTranslationCache(article.id, language);
 
   ctx.body = new ArticleTranslationResponse(translation);
 });
@@ -304,9 +266,9 @@ const feedbackSchema = yup.object({
 });
 
 // add feedback for translation of user preferred language of article :id
-router.post('/:id/feedback', auth, fetchPreferTranslation, async (ctx) => {
+router.post('/:id/feedback', auth, fetchPreferredTranslation, async (ctx) => {
   const currentUser = ctx.state.currentUser as User;
-  const translation = ctx.state.translation;
+  const translation = ctx.state.translation as ArticleTranslation;
 
   const { type } = feedbackSchema.validateSync(ctx.request.body);
 
@@ -335,6 +297,8 @@ router.patch('/:id', auth, customerServiceOnly, async (ctx) => {
   }
 
   const updatedArticle = await article.update(data, { useMasterKey: true });
+
+  await articleService.clearArticleCache(article.id);
 
   ctx.body = new ArticleResponse(updatedArticle);
 });
@@ -366,29 +330,31 @@ router.delete('/:id', auth, customerServiceOnly, async (ctx) => {
   }
 
   await article.delete(currentUser.getAuthOptions());
+
+  await articleService.clearAllArticleCache(article.id);
+
   ctx.body = {};
 });
 
 router.param('language', async (language, ctx, next) => {
-  if (ctx.params.id) {
-    const translation = await ArticleTranslation.queryBuilder()
-      .where('language', '==', language)
-      .where('article', '==', Article.ptr(ctx.params.id))
-      .first({ useMasterKey: true });
+  const article = ctx.state.article as Article;
 
-    translation && (translation.article = ctx.state.article);
-
-    ctx.state.translation = translation;
+  const translation = await articleService.getArticleTranslation(
+    article.id,
+    language.toLowerCase()
+  );
+  if (!translation) {
+    ctx.throw(404, `language ${language} does not exist`);
   }
+
+  ctx.state.translation = translation;
 
   return next();
 });
 
 // get :language translation of article :id
-router.get('/:id/:language', async (ctx) => {
-  const translation = ctx.state.translation as ArticleTranslation;
-
-  ctx.body = new ArticleTranslationResponse(translation);
+router.get('/:id/:language', (ctx) => {
+  ctx.body = new ArticleTranslationResponse(ctx.state.translation);
 });
 
 const updateArticleTranslationSchema = yup.object({
@@ -436,6 +402,7 @@ router.patch('/:id/:language', auth, customerServiceOnly, async (ctx) => {
 
   if (updated) {
     await translation.createRevision(currentUser, updatedTranslation, translation, comment);
+    await articleService.clearArticleTranslationCache(article.id, translation.language);
   }
 
   ctx.body = new ArticleTranslationResponse(updatedTranslation);
@@ -450,6 +417,9 @@ router.delete('/:id/:language', auth, customerServiceOnly, async (ctx) => {
   }
 
   await translation.delete({ useMasterKey: true });
+
+  await articleService.clearArticleTranslationCache(translation.articleId, translation.language);
+
   ctx.body = {};
 });
 
@@ -469,7 +439,6 @@ router.get('/:id/:language/revisions', auth, customerServiceOnly, pagination(100
     .where('FAQTranslation', '==', translation.toPointer())
     .orderBy('createdAt', 'desc')
     .paginate(page, pageSize)
-    .limit(pageSize)
     .preload('author');
 
   if (meta !== undefined) {
@@ -488,23 +457,18 @@ router.get('/:id/:language/revisions', auth, customerServiceOnly, pagination(100
 });
 
 router.param('rid', async (rid, ctx, next) => {
-  ctx.state.revision = await ArticleRevision.find(rid, {
-    useMasterKey: true,
-  });
+  const revision = await ArticleRevision.find(rid, { useMasterKey: true });
+  if (!revision) {
+    ctx.throw(404, `Revision ${rid} does not exist`);
+  }
+  ctx.state.revision = revision;
   return next();
 });
 
 // get revision :rid
-router.get(
-  '/:id/:language/revisions/:rid',
-  auth,
-  customerServiceOnly,
-  pagination(100),
-  async (ctx) => {
-    const revision = ctx.state.revision as ArticleRevision;
-    ctx.body = new ArticleRevisionResponse(revision);
-  }
-);
+router.get('/:id/:language/revisions/:rid', auth, customerServiceOnly, pagination(100), (ctx) => {
+  ctx.body = new ArticleRevisionResponse(ctx.state.revision);
+});
 
 const getACL = (isPrivate: boolean) => {
   const ACL = new ACLBuilder();


### PR DESCRIPTION
### 主要改动

- 文章和文章翻译使用中央缓存，并在更新、删除时主动失效
- 完善文章和文章翻译的软删除逻辑
- 未发布的文章也可以通过 `/articles/:id` 访问
