### PR TITLE
feat(api): support multiple category aliases

### DIFF
--- a/next/api/src/orm/model.ts
+++ b/next/api/src/orm/model.ts
@@ -601,6 +601,10 @@ export abstract class AliasModel extends Model {
   @serialize()
   alias?: string;
 
+  @field()
+  @serialize()
+  aliases?: string[];
+
   static async find<M extends typeof AliasModel>(
     this: M,
     id: string,
@@ -610,7 +614,11 @@ export abstract class AliasModel extends Model {
     if (idMatch) {
       return idMatch;
     }
-    return await this.query().where('alias', '==', id).first(options);
+    const aliasMatch = await this.query().where('alias', '==', id).first(options);
+    if (aliasMatch) {
+      return aliasMatch
+    }
+    return await this.query().where('aliases', '==', id).first(options);
   }
 }
 

--- a/resources/schema/Category.json
+++ b/resources/schema/Category.json
@@ -34,6 +34,10 @@
             "type": "String",
             "comment": "用于 URL 的 ID"
         },
+        "aliases": {
+            "type": "Array",
+            "comment": "用于 ID 的其他别名"
+        },
         "createdAt": {
             "type": "Date"
         },
@@ -112,6 +116,17 @@
                 "alias": 1
             },
             "name": "-user-alias_1",
+            "ns": "-.Category",
+            "background": true,
+            "sparse": true
+        },
+        {
+            "v": 2,
+            "unique": true,
+            "key": {
+                "aliases": 1
+            },
+            "name": "-user-aliases_1",
             "ns": "-.Category",
             "background": true,
             "sparse": true


### PR DESCRIPTION
增加 Category.aliases，alias 不动。aliases 的优先级在 alias 之后，aliases 之间保证唯一，但不保证与 alias 唯一。
后台配置就先不做了，很罕见的需求，有需要先手动配。