### PR TITLE
feat(next): remove article detail api

### DIFF
--- a/next/api/src/controller/category.ts
+++ b/next/api/src/controller/category.ts
@@ -21,7 +21,7 @@ import { auth, customerServiceOnly } from '@/middleware';
 import { Category } from '@/model/Category';
 import { TicketForm } from '@/model/TicketForm';
 import { User } from '@/model/User';
-import { ArticleTranslationAbstractResponse } from '@/response/article';
+import { ArticleTranslationResponse } from '@/response/article';
 import { CategoryResponse } from '@/response/category';
 import { TicketFieldVariantResponse } from '@/response/ticket-field';
 import { ArticleTopicFullResponse } from '@/response/article-topic';
@@ -159,7 +159,7 @@ export class CategoryController {
   }
 
   @Get(':id/faqs')
-  @ResponseBody(ArticleTranslationAbstractResponse)
+  @ResponseBody(ArticleTranslationResponse)
   getFAQs(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
     if (!category.FAQIds) {
       return [];
@@ -168,7 +168,7 @@ export class CategoryController {
   }
 
   @Get(':id/notices')
-  @ResponseBody(ArticleTranslationAbstractResponse)
+  @ResponseBody(ArticleTranslationResponse)
   getNotices(@Param('id', FindCategoryPipe) category: Category, @Locales() locales: ILocale) {
     if (!category.noticeIds) {
       return [];

--- a/next/web/src/api/article.ts
+++ b/next/web/src/api/article.ts
@@ -73,45 +73,6 @@ export function useArticles({ queryOptions, ...options }: UseArticlesOptions = {
   return { ...results, ...data };
 }
 
-export interface FetchArticlesWithDetailResult {
-  data: ArticleTranslation[];
-  totalCount?: number;
-}
-
-export const fetchArticlesWithDetail = async (
-  options: FetchArticlesOptions
-): Promise<FetchArticlesWithDetailResult> => {
-  const { data, headers } = await http.get<ArticleTranslation[]>('/api/2/articles/detail', {
-    params: {
-      pageSize: 1000,
-      ...options,
-      id: options.id?.join(','),
-    },
-  });
-  const totalCount = headers['x-total-count'];
-  return {
-    data,
-    totalCount: totalCount ? parseInt(totalCount) : undefined,
-  };
-};
-
-export interface UseArticlesWithDetailOptions extends FetchArticlesOptions {
-  queryOptions?: UseQueryOptions<FetchArticlesWithDetailResult, Error>;
-}
-
-export function useArticlesWithDetail({
-  queryOptions,
-  ...options
-}: UseArticlesWithDetailOptions = {}) {
-  const { data, ...results } = useQuery({
-    queryKey: ['articlesWithDetail', options],
-    queryFn: () => fetchArticlesWithDetail(options),
-    ...queryOptions,
-  });
-
-  return { ...results, ...data };
-}
-
 export async function fetchArticle(id: string) {
   const { data } = await http.get<Article>(`/api/2/articles/${id}/info`);
   return data;


### PR DESCRIPTION
自用前端改成使用 `/categories/:id/faqs` 获取常见问题。然后就没地方用 `/articles/detail` 了，移除。

另外 `/categories/:id/faqs` 和 `/categories/:id/notices` 现在也会返回内容。