### PR TITLE
feat(export): flatten fields

### DIFF
--- a/next/api/src/ticket/export/index.ts
+++ b/next/api/src/ticket/export/index.ts
@@ -49,7 +49,7 @@ queue.on('completed', async (jobData, result) => {
 });
 
 queue.on('failed', (job, err) => {
-  console.error('[export ticket]:', job.data, err.message);
+  console.error('[export ticket]:', job.data, err);
   if (job.data.retryCount < 2) {
     queue.add({
       ...job.data,
@@ -57,7 +57,7 @@ queue.on('failed', (job, err) => {
     });
   } else {
     //TODO  send email ?
-    console.error(`[export ticket]: after retry`, job.data, err.message);
+    console.error(`[export ticket]: after retry`, job.data, err);
   }
 });
 


### PR DESCRIPTION
因为 CSV 一行最后如果全部是空值，是可以全部省略的。所以思路是：

固定字段在前，维护一个 fieldKeys，后面发现新的 field 加到这个列表中然后通过指定 key 的方式生成新的一行。最后读完一遍再在文件最上面插入表头。这样只需要一次遍历即可。