### PR TITLE
fix(next/api): fix x-total-count always return pageSize when search with ticket field value

### DIFF
--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -138,9 +138,11 @@ router.get(
         }
 
         // we can't get the count in the second query, but we can in the first query
-        const [ticketFieldValues, count] = await ticketFieldQuery.findAndCount({
-          useMasterKey: true,
-        });
+        const [ticketFieldValues, count] = params.count
+          ? await ticketFieldQuery.findAndCount({
+              useMasterKey: true,
+            })
+          : [await ticketFieldQuery.find({ useMasterKey: true }), undefined];
 
         return [
           Ticket.queryBuilder()

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -254,12 +254,16 @@ router.get(
     }
 
     let tickets: Ticket[];
-    if (params.count) {
+    if (params.count && !count) {
       const result = await finalQuery.findAndCount(currentUser.getAuthOptions());
       tickets = result[0];
-      ctx.set('X-Total-Count', (count ?? result[1]).toString());
+      ctx.set('X-Total-Count', result[1].toString());
     } else {
       tickets = await finalQuery.find(currentUser.getAuthOptions());
+
+      if (params.count && count) {
+        ctx.set('X-Total-Count', count.toString());
+      }
     }
 
     if (params.includeCategoryPath) {

--- a/next/api/src/router/ticket.ts
+++ b/next/api/src/router/ticket.ts
@@ -119,7 +119,7 @@ router.get(
 
     const sortItems = sort.get(ctx);
 
-    const finalQuery = await (async () => {
+    const [finalQuery, count] = await (async () => {
       if (params.fieldName && params.fieldValue) {
         const ticketFieldQuery = TicketFieldValue.queryBuilder()
           .where('values', '==', {
@@ -137,13 +137,21 @@ router.get(
           ticketFieldQuery.where('createdAt', '<=', params.createdAtTo);
         }
 
-        return Ticket.queryBuilder()
-          .where(
-            'objectId',
-            'in',
-            (await ticketFieldQuery.find({ useMasterKey: true })).map(({ ticketId }) => ticketId)
-          )
-          .orderBy('createdAt', 'desc');
+        // we can't get the count in the second query, but we can in the first query
+        const [ticketFieldValues, count] = await ticketFieldQuery.findAndCount({
+          useMasterKey: true,
+        });
+
+        return [
+          Ticket.queryBuilder()
+            .where(
+              'objectId',
+              'in',
+              ticketFieldValues.map(({ ticketId }) => ticketId)
+            )
+            .orderBy('createdAt', 'desc'),
+          count,
+        ];
       } else {
         const categoryIds = new Set(params.categoryId);
         const rootId = params.product || params.rootCategoryId;
@@ -215,7 +223,7 @@ router.get(
         query.skip((params.page - 1) * params.pageSize).limit(params.pageSize);
         sortItems?.forEach(({ key, order }) => query.orderBy(key, order));
 
-        return query;
+        return [query, undefined];
       }
     })();
 
@@ -249,7 +257,7 @@ router.get(
     if (params.count) {
       const result = await finalQuery.findAndCount(currentUser.getAuthOptions());
       tickets = result[0];
-      ctx.set('X-Total-Count', result[1].toString());
+      ctx.set('X-Total-Count', (count ?? result[1]).toString());
     } else {
       tickets = await finalQuery.find(currentUser.getAuthOptions());
     }


### PR DESCRIPTION
修复了当以工单选项字段值筛选时，`X-Total-Count` 只会返回 `pageSize` 的问题