### PR TITLE
feat(next/web): ticket detail page stage 3

### DIFF
--- a/next/web/src/App/Admin/Tickets/Ticket/TagForm.tsx
+++ b/next/web/src/App/Admin/Tickets/Ticket/TagForm.tsx
@@ -40,19 +40,15 @@ export function TagForm({ tagMetadatas, tags, privateTags, onUpdate, updating }:
     onUpdate(newValues, tag.private);
   };
 
-  return (
-    <>
-      {tagMetadatas.map((tag) => (
-        <TagField
-          key={tag.id}
-          tag={tag}
-          value={tag.private ? privateValueMap[tag.key] : valueMap[tag.key]}
-          loading={updating}
-          onChange={(value) => handleChange(tag, value)}
-        />
-      ))}
-    </>
-  );
+  return (tagMetadatas.map((tag) => (
+    <TagField
+      key={tag.id}
+      tag={tag}
+      value={tag.private ? privateValueMap[tag.key] : valueMap[tag.key]}
+      loading={updating}
+      onChange={(value) => handleChange(tag, value)}
+    />
+  )) as any) as JSX.Element;
 }
 
 interface TagFieldProps {

--- a/next/web/src/App/Admin/Tickets/Ticket/api1.tsx
+++ b/next/web/src/App/Admin/Tickets/Ticket/api1.tsx
@@ -42,3 +42,31 @@ export function useUpdateTicket_v1(
     ...options,
   });
 }
+
+export interface TicketField_v1 {
+  id: string;
+  type: string;
+  variants: {
+    title: string;
+    options?: [string, string][];
+  }[];
+}
+
+export function useTicketFields_v1(
+  fieldIds: string[],
+  options?: UseQueryOptions<TicketField_v1[], Error>
+) {
+  return useQuery({
+    queryKey: ['ticketFields_v1', fieldIds],
+    queryFn: async () => {
+      const res = await http.get<TicketField_v1[]>(`/api/1/ticket-fields`, {
+        params: {
+          ids: fieldIds.join(','),
+          includeVariant: true,
+        },
+      });
+      return res.data;
+    },
+    ...options,
+  });
+}

--- a/next/web/src/App/Admin/Tickets/Ticket/components/CustomFields.tsx
+++ b/next/web/src/App/Admin/Tickets/Ticket/components/CustomFields.tsx
@@ -126,9 +126,16 @@ function FileField({ files }: CustomFieldProps<string[]>) {
   );
 }
 
-function withProps<P extends Record<string, any>>(
+type PartialSome<T, K extends keyof T> = Omit<T, K> &
+  {
+    [key in K]?: T[K];
+  };
+
+function withProps<P extends Record<string, any>, K extends keyof P>(
   Component: JSXElementConstructor<P>,
-  presetProps: Partial<P>
-) {
-  return (props: P) => <Component {...presetProps} {...props} />;
+  presetProps: {
+    [key in K]: P[K];
+  }
+): JSXElementConstructor<PartialSome<P, K>> {
+  return (props: any) => <Component {...presetProps} {...props} />;
 }

--- a/next/web/src/App/Admin/Tickets/Ticket/components/CustomFields.tsx
+++ b/next/web/src/App/Admin/Tickets/Ticket/components/CustomFields.tsx
@@ -1,0 +1,134 @@
+import { JSXElementConstructor, useState } from 'react';
+import { isEmpty } from 'lodash-es';
+
+import { Button, Input, Select } from '@/components/antd';
+import { FormField } from './FormField';
+
+interface CustomField {
+  id: string;
+  type: string;
+  label: string;
+  options?: { label: string; value: string }[];
+}
+
+interface FileFieldValue {
+  id: string;
+  name: string;
+  mime: string;
+  url: string;
+}
+
+interface CustomFieldValue<T> {
+  value: T;
+  files?: FileFieldValue[];
+}
+
+interface CustomFieldProps<T> {
+  options?: CustomField['options'];
+  value?: T;
+  files?: FileFieldValue[];
+  disabled?: boolean;
+  onChange: (value: any) => void;
+}
+
+const ComponentByFieldType: Record<string, JSXElementConstructor<CustomFieldProps<any>>> = {
+  text: InputField,
+  date: InputField,
+  number: InputField,
+  'multi-line': TextareaField,
+  dropdown: DropdownField,
+  radios: DropdownField,
+  'multi-select': withProps(DropdownField, { multiple: true }),
+  file: FileField,
+};
+
+interface CustomFieldsProps {
+  fields: CustomField[];
+  values: Record<string, CustomFieldValue<any>>;
+  disabled?: boolean;
+  updating?: boolean;
+  onChange: (values: Record<string, any>) => void;
+}
+
+export function CustomFields({ fields, values, disabled, updating, onChange }: CustomFieldsProps) {
+  const [tempValues, setTempValues] = useState<Record<string, any>>({});
+
+  return (
+    <div>
+      {fields.map((field) => {
+        const Component = ComponentByFieldType[field.type];
+        if (!Component) {
+          return null;
+        }
+        return (
+          <FormField label={field.label}>
+            <Component
+              key={field.id}
+              options={field.options}
+              value={tempValues[field.id] ?? values[field.id]?.value}
+              files={values[field.id]?.files}
+              disabled={disabled}
+              onChange={(value) => setTempValues({ ...tempValues, [field.id]: value })}
+            />
+          </FormField>
+        );
+      })}
+      {!isEmpty(tempValues) && (
+        <Button loading={updating} onClick={() => onChange(tempValues)}>
+          保存
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function InputField({ value, disabled, onChange }: CustomFieldProps<string>) {
+  return <Input value={value} onChange={(e) => onChange(e.target.value)} disabled={disabled} />;
+}
+
+function TextareaField({ value, disabled, onChange }: CustomFieldProps<string>) {
+  return (
+    <Input.TextArea value={value} onChange={(e) => onChange(e.target.value)} disabled={disabled} />
+  );
+}
+
+function DropdownField({
+  options,
+  value,
+  multiple,
+  disabled,
+  onChange,
+}: CustomFieldProps<string> & { multiple?: boolean }) {
+  return (
+    <Select
+      className="w-full"
+      mode={multiple ? 'multiple' : undefined}
+      options={options}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+    />
+  );
+}
+
+function FileField({ files }: CustomFieldProps<string[]>) {
+  if (!files || files.length === 0) {
+    return <div className="w-full text-center text-sm">暂无数据</div>;
+  }
+  return (
+    <div className="flex flex-col items-start gap-0.5">
+      {files.map((file) => (
+        <a className="truncate" href={file.url} target="_blank" title={file.name}>
+          {file.name}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function withProps<P extends Record<string, any>>(
+  Component: JSXElementConstructor<P>,
+  presetProps: Partial<P>
+) {
+  return (props: P) => <Component {...presetProps} {...props} />;
+}

--- a/next/web/src/api/category.ts
+++ b/next/web/src/api/category.ts
@@ -166,3 +166,16 @@ export const useBatchUpdateCategory = (
     mutationFn: batchUpdateCategory,
     ...options,
   });
+
+async function fetchCategory(id: string) {
+  const res = await http.get<CategorySchema>(`/api/2/categories/${id}`);
+  return res.data;
+}
+
+export function useCategory(id: string, options?: UseQueryOptions<CategorySchema>) {
+  return useQuery({
+    queryKey: ['category', id],
+    queryFn: () => fetchCategory(id),
+    ...options,
+  });
+}

--- a/next/web/src/api/ticket.ts
+++ b/next/web/src/api/ticket.ts
@@ -373,3 +373,48 @@ export function useTicketOverview(
     ...options,
   });
 }
+
+export interface TicketFieldValue {
+  field: string;
+  value: any;
+  files?: {
+    id: string;
+    name: string;
+    mime: string;
+    url: string;
+  }[];
+}
+
+async function fetchTicketFieldValues(ticketId: string) {
+  const res = await http.get<TicketFieldValue[]>(`/api/2/tickets/${ticketId}/custom-fields`);
+  return res.data;
+}
+
+export function useTicketFieldValues(
+  ticketId: string,
+  options?: UseQueryOptions<TicketFieldValue[]>
+) {
+  return useQuery({
+    queryKey: ['ticketFieldValues', ticketId],
+    queryFn: () => fetchTicketFieldValues(ticketId),
+    ...options,
+  });
+}
+
+type UpdateTicketFieldValuesData = {
+  field: string;
+  value: any;
+}[];
+
+async function updateTicketFieldValues(ticketId: string, data: UpdateTicketFieldValuesData) {
+  await http.put(`/api/2/tickets/${ticketId}/custom-fields`, data);
+}
+
+export function useUpdateTicketFieldValues(
+  options?: UseMutationOptions<void, Error, Parameters<typeof updateTicketFieldValues>>
+) {
+  return useMutation({
+    mutationFn: (vars) => updateTicketFieldValues(...vars),
+    ...options,
+  });
+}


### PR DESCRIPTION
实现了自定义字段的展示与编辑。

暂不支持修改文件字段，因为修改文件字段值的情况非常少，目前的实现混用了两版 API，非常恶心。等详情页迁完，开始迁 API 的时候再好好实现一下罢。