### PR TITLE
refactor(next/web): current user state

### DIFF
--- a/next/web/src/leancloud/index.ts
+++ b/next/web/src/leancloud/index.ts
@@ -53,42 +53,39 @@ export interface CurrentUser {
   displayName: string;
 }
 
-const currentLCUserState = atom({
-  key: 'currentLCUser',
-  default: auth.currentUser,
-});
+function getCurrentUser(): CurrentUser | undefined {
+  if (auth.currentUser) {
+    const { id, data } = auth.currentUser;
+    return {
+      id,
+      displayName: data.name || data.username,
+    };
+  }
+}
 
-const currentUserState = selector({
+const currentUserState = atom({
   key: 'currentUser',
-  get: ({ get }): CurrentUser | undefined => {
-    const user = get(currentLCUserState);
-    if (user) {
-      return {
-        id: user.id,
-        displayName: user.data.name || user.data.username,
-      };
-    }
-  },
+  default: getCurrentUser(),
 });
 
 export const useCurrentUser = () => useRecoilValue(currentUserState);
 
 export const useRefreshCurrentUser = () => {
-  const setCurrentUser = useSetRecoilState(currentLCUserState);
-  return () => setCurrentUser(auth.currentUser);
+  const setCurrentUser = useSetRecoilState(currentUserState);
+  return () => setCurrentUser(getCurrentUser());
 };
 
 const currentUserRolesState = selector({
   key: 'currentUserRoles',
   get: async ({ get }) => {
-    const currentUser = get(currentLCUserState);
+    const currentUser = get(currentUserState);
     if (!currentUser) {
       return [];
     }
     return auth
       .queryRole()
       .where('name', 'in', ['customerService', 'staff', 'admin'])
-      .where('users', '==', currentUser)
+      .where('users', '==', db.class('_User').object(currentUser.id))
       .find()
       .then((roles) => roles.map((role) => role.name));
   },


### PR DESCRIPTION
Recoil 会递归 Object.freeze 默认值，导致 auth.currentUser.app.payload 被 freeze，进而导致无法使用 live-query 模块（需要修改 app.payload）。

改进：不直接使用 auth.currentUser 作为 currentUserState 的默认值。
