### PR TITLE
feat(next/web): preview local article

### DIFF
--- a/next/web/src/App/Admin/Settings/Articles/ArticleDetail.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/ArticleDetail.tsx
@@ -41,10 +41,9 @@ const ArticleTranslationList: FC<ArticleTranslationListProps> = ({
 
   const [show, setShow] = useState(false);
 
-  const existLanguages = useMemo(
-    () => translations?.map(({ language }) => language) ?? [],
-    [translations]
-  );
+  const existLanguages = useMemo(() => {
+    return translations?.map(({ language }) => language);
+  }, [translations]);
 
   const handleDelete = (language: string) => {
     Modal.confirm({
@@ -65,7 +64,7 @@ const ArticleTranslationList: FC<ArticleTranslationListProps> = ({
         action={(item) => (
           <>
             <FeedbackSummary revision={item.revision!} />
-            <PreviewLink slug={item.slug} language={item.language} />
+            <PreviewLink articleId={item.id} language={item.language} />
             <Link to={`${item.language}/revisions`}>查看历史</Link>
             <Button
               type="link"

--- a/next/web/src/App/Admin/Settings/Articles/components/PreviewLink.tsx
+++ b/next/web/src/App/Admin/Settings/Articles/components/PreviewLink.tsx
@@ -1,30 +1,51 @@
-import { useCategories } from '@/api/category';
-import { Tooltip } from 'antd';
 import { useMemo } from 'react';
+import { useMutation } from 'react-query';
+import { Button, Tooltip } from 'antd';
+
+import { fetchArticleTranslation } from '@/api/article';
+import { useCategories } from '@/api/category';
 
 export interface PreviewLinkProps {
-  slug: string;
-  language?: string;
+  articleId: string;
+  language: string;
 }
 
-export const PreviewLink = ({ slug, language }: PreviewLinkProps) => {
+export const PreviewLink = ({ articleId, language }: PreviewLinkProps) => {
   const { data: categories, isLoading } = useCategories({ active: true });
 
   const productId = useMemo(() => categories?.[0]?.id, [categories]);
 
-  return productId ? (
-    <a
-      href={`/in-app/v1/products/${productId}/articles/${slug}?nav=0${
-        language ? `&lang=${language}` : ''
-      }`}
-      target="_blank"
-      rel="noreferrer noopener"
+  const { mutate: preview, isLoading: loadingTranslation } = useMutation({
+    mutationFn: () => fetchArticleTranslation(articleId, language),
+    onSuccess: (article) => {
+      const articleData = JSON.stringify({
+        title: article.title,
+        contentSafeHTML: article.contentSafeHTML,
+        updatedAt: article.updatedAt,
+      });
+      localStorage.setItem('TapDesk/articlePreview', articleData);
+      window.open(
+        `/in-app/v1/products/${productId}/articles/preview?nav=0`,
+        'self',
+        'width=500,height=600'
+      );
+    },
+  });
+
+  return (
+    <Tooltip
+      title="你需要一个启用中的产品来使用预览"
+      open={isLoading ? false : productId ? false : undefined}
     >
-      文章预览
-    </a>
-  ) : (
-    <Tooltip title="你需要一个启用中的产品来使用预览" visible={isLoading ? undefined : false}>
-      <div className="text-gray-400">文章预览</div>
+      <Button
+        type="link"
+        disabled={!productId}
+        onClick={() => preview()}
+        loading={loadingTranslation}
+        style={{ padding: 0, border: 0, height: 'fit-content' }}
+      >
+        文章预览
+      </Button>
     </Tooltip>
   );
 };

--- a/next/web/src/App/Admin/components/LocaleModal.tsx
+++ b/next/web/src/App/Admin/components/LocaleModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Select } from 'antd';
+import { Modal } from 'antd';
 import { FC, useEffect, useState } from 'react';
 import { LocaleSelect } from './LocaleSelect';
 
@@ -18,7 +18,7 @@ export const LocaleModal: FC<LocaleModalProps> = ({ show, hiddenLocales, onOk, o
   return (
     <Modal
       title="请选择要添加的语言"
-      visible={show}
+      open={show}
       okButtonProps={{ disabled: !value }}
       onOk={() => onOk?.(value!)}
       onCancel={onCancel}


### PR DESCRIPTION
in-app 使用的 API 无法获取未发布的文章。为了可以预览未发布的文章，在 in-app 中提供一个特殊的文章预览页，从 localStorage 中读取文章数据。客服后台点击预览按钮后先将文章内容写入 localStorage 中，然后跳转到 in-app。