### PR TITLE
feat(next/api): router derived controller

### DIFF
--- a/next/api/src/common/http/error.ts
+++ b/next/api/src/common/http/error.ts
@@ -1,5 +1,3 @@
-import { Context, Next } from 'koa';
-
 export class HttpError extends Error {
   constructor(
     readonly status: number,

--- a/next/api/src/common/http/index.ts
+++ b/next/api/src/common/http/index.ts
@@ -81,7 +81,7 @@ function joinPaths(paths: string[]) {
   return '/' + paths.map((path) => _.trim(path, '/')).join('/');
 }
 
-export function applyController(router: Router, controller: any) {
+export function applyController(rootRouter: Router, controller: any) {
   const basePaths = Reflect.getMetadata(KEY_PATH, controller.constructor) as string[];
 
   const middlewares = getMiddlewares(controller);
@@ -92,7 +92,7 @@ export function applyController(router: Router, controller: any) {
 
   const handlers = getHandlers(controller);
 
-  basePaths.map((basePath) =>
+  basePaths.forEach((basePath) => {
     handlers.forEach((handler) => {
       const path = handler.path ? joinPaths([basePath, handler.path]) : joinPaths([basePath]);
 
@@ -103,13 +103,13 @@ export function applyController(router: Router, controller: any) {
       const h = createKoaHandler(controller, handler);
 
       // @ts-ignore
-      router[handler.httpMethod].apply(router, [
+      rootRouter[handler.httpMethod].apply(rootRouter, [
         path,
         ...globalMiddlewares,
         ...controllerMiddlewares,
         ...handlerMiddlewares,
         h,
       ]);
-    })
-  );
+    });
+  });
 }

--- a/next/api/src/router/index.ts
+++ b/next/api/src/router/index.ts
@@ -1,6 +1,6 @@
 import Router from '@koa/router';
 
-import { getControllers, applyController } from '@/common/http';
+import { initControllers } from '@/common/http';
 import '@/controller';
 import { catchLCError, catchYupError, catchZodError } from '@/middleware/error';
 import ticket from './ticket';
@@ -27,8 +27,6 @@ router.use('/replies', reply.routes());
 router.use('/ticket-stats', ticketStats.routes());
 router.use('/config', config.routes());
 
-getControllers().forEach((controller) => {
-  applyController(router, controller);
-});
+initControllers(router);
 
 export default router;


### PR DESCRIPTION
支持为 controller 配置一个已有的 router。

```ts
@Controller({
  path: 'test',
  router: new Router(),
})
export class TestController {}
```

方便逐个 endpoint 将 router 风格的代码重构为 controller。