### PR TITLE
feat: new associate ticket endpoint

### DIFF
--- a/modules/Ticket/RecentTickets.js
+++ b/modules/Ticket/RecentTickets.js
@@ -1,11 +1,4 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useImperativeHandle,
-  useMemo,
-  useState,
-  useRef,
-} from 'react'
+import React, { useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient } from 'react-query'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
@@ -16,130 +9,21 @@ import styles from './index.css'
 import { UserLabel } from '../UserLabel'
 import { useTranslation } from 'react-i18next'
 import { TicketStatusLabel } from '../components/TicketStatusLabel'
-import { Button, Form, Modal } from 'react-bootstrap'
-
-// eslint-disable-next-line react/display-name
-const MainTicketModal = forwardRef(({ ticket }, ref) => {
-  const [show, setShow] = useState(false)
-  const [targetId, setTargetId] = useState()
-  const [selectedId, setSelectedId] = useState()
-
-  const { t } = useTranslation()
-  const queryClient = useQueryClient()
-
-  const { data: target } = useQuery({
-    queryFn: () =>
-      http.get(`/api/2/tickets/${targetId}`, {
-        params: {
-          includeAssociateTicket: true,
-        },
-      }),
-    queryKey: ['ticket', targetId, { includeAssociateTicket: true }],
-    enabled: !!targetId,
-  })
-
-  const { mutate: associate, isLoading } = useMutation({
-    mutationFn: async (mainId) => {
-      await http.patch(`/api/2/tickets/${targetId}`, {
-        associateTicketId: ticket.id,
-        mainTicketId: mainId,
-      })
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries(['ticket', ticket.id])
-      queryClient.invalidateQueries(['ticket', targetId])
-      queryClient.invalidateQueries(['tickets', ticket.authorId])
-    },
-  })
-
-  const handleOpen = useCallback((id) => {
-    setTargetId(id)
-    setShow(true)
-  }, [])
-
-  const handleClose = useCallback(() => {
-    setShow(false)
-  }, [])
-
-  const handleSubmit = useCallback(
-    (e) => {
-      associate(selectedId, {
-        onSuccess: () => {
-          setShow(false)
-        },
-      })
-      e.preventDefault()
-    },
-    [selectedId, associate]
-  )
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      open: handleOpen,
-    }),
-    [handleOpen]
-  )
-
-  const tickets = useMemo(
-    () =>
-      target && [
-        ticket,
-        ...(ticket.associateTickets ?? []),
-        target,
-        ...(target.associateTickets ?? []),
-      ],
-    [ticket, target]
-  )
-
-  return (
-    <Modal show={show}>
-      <Modal.Header closeButton>
-        <Modal.Title>{t('ticket.selectMainTicket')}</Modal.Title>
-      </Modal.Header>
-      <Form onSubmit={handleSubmit}>
-        <Modal.Body
-          onChange={(e) => {
-            setSelectedId(e.target.value)
-          }}
-        >
-          {tickets?.map(({ id, title, nid }) => (
-            <Form.Check
-              key={id}
-              type="radio"
-              label={`#${nid} ${title}`}
-              name="main-ticket"
-              value={id}
-            />
-          ))}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" onClick={handleClose} disabled={isLoading}>
-            {t('close')}
-          </Button>
-          <Button variant="primary" type="submit" disabled={isLoading || !selectedId}>
-            {t('submit')}
-          </Button>
-        </Modal.Footer>
-      </Form>
-    </Modal>
-  )
-})
-
-MainTicketModal.propTypes = {
-  ticket: PropTypes.object.isRequired,
-}
+import { Button } from 'react-bootstrap'
 
 function RecentTickets({ ticket }) {
   const { t } = useTranslation()
   const { addNotification } = useAppContext()
   const queryClient = useQueryClient()
 
-  const modalRef = useRef(null)
+  const { data: associatedTickets } = useQuery({
+    queryKey: ['associatedTickets', ticket.id],
+    queryFn: () => http.get(`/api/2/tickets/${ticket.id}/associated-tickets`),
+  })
 
   const excludeNids = useMemo(
-    () => [ticket.nid, ...(ticket.associateTickets?.map(({ nid }) => nid) ?? [])],
-    [ticket]
+    () => [ticket.nid, ...(associatedTickets?.map(({ nid }) => nid) ?? [])],
+    [ticket, associatedTickets]
   )
 
   const { data } = useQuery({
@@ -159,18 +43,14 @@ function RecentTickets({ ticket }) {
 
   const { mutate: associate } = useMutation({
     mutationFn: async (id) => {
-      await http.patch(`/api/2/tickets/${id}`, { associateTicketId: ticket.id })
+      await http.post(`/api/2/tickets/${ticket.id}/associated-tickets`, { ticketId: id })
     },
     onSuccess: (_, id) => {
-      queryClient.invalidateQueries(['ticket', id])
-      queryClient.invalidateQueries(['ticket', ticket.id])
-      queryClient.invalidateQueries(['tickets', ticket.authorId])
+      queryClient.invalidateQueries(['ticket'])
+      queryClient.invalidateQueries(['tickets'])
+      queryClient.invalidateQueries(['associatedTickets'])
     },
   })
-
-  const handleAssociate = (id) => {
-    modalRef.current?.open(id)
-  }
 
   const tickets = useMemo(() => {
     if (!data) {
@@ -221,13 +101,7 @@ function RecentTickets({ ticket }) {
             </span>
 
             <span>
-              <Button
-                onClick={() => {
-                  ticketItem.associated ? handleAssociate(ticketItem.id) : associate(ticketItem.id)
-                }}
-                variant="light"
-                size="sm"
-              >
+              <Button onClick={() => associate(ticketItem.id)} variant="light" size="sm">
                 {t('ticket.associate')}
               </Button>
             </span>
@@ -242,7 +116,6 @@ function RecentTickets({ ticket }) {
           </li>
         ))}
       </ul>
-      <MainTicketModal ref={modalRef} ticket={ticket} />
     </>
   )
 }

--- a/modules/Ticket/TicketMetadata.js
+++ b/modules/Ticket/TicketMetadata.js
@@ -615,14 +615,19 @@ const AssociateTickets = memo(({ ticket }) => {
   const queryClient = useQueryClient()
   const { t } = useTranslation()
 
+  const { data: associatedTickets } = useQuery({
+    queryKey: ['associatedTickets', ticket.id],
+    queryFn: () => http.get(`/api/2/tickets/${ticket.id}/associated-tickets`),
+  })
+
   const { mutate: disassociate } = useMutation({
     mutationFn: async (id) => {
-      await http.patch(`/api/2/tickets/${id}`, { associateTicketId: null })
+      await http.delete(`/api/2/tickets/${ticket.id}/associated-tickets/${id}`)
     },
     onSuccess: (_, id) => {
-      queryClient.invalidateQueries(['ticket', id])
-      queryClient.invalidateQueries(['ticket', ticket.id])
-      queryClient.invalidateQueries(['tickets', ticket.authorId])
+      queryClient.invalidateQueries(['ticket'])
+      queryClient.invalidateQueries(['tickets'])
+      queryClient.invalidateQueries(['associatedTickets'])
     },
   })
 
@@ -630,19 +635,13 @@ const AssociateTickets = memo(({ ticket }) => {
     <Form.Group>
       <Form.Label>{t('ticket.associateTicket')}</Form.Label>
       <div>
-        {ticket.associateTickets?.map(({ id, title, nid }) => (
+        {associatedTickets?.map(({ id, title, nid }) => (
           <div key={id} className="d-flex justify-content-between">
             <Link to={`/tickets/${nid}`} title={title} className={styles.link}>
               <span className={styles.nid}>#{nid}</span>
               {title}
             </Link>
-            <Button
-              onClick={() => {
-                disassociate(id)
-              }}
-              variant="light"
-              size="sm"
-            >
+            <Button onClick={() => disassociate(id)} variant="light" size="sm">
               {t('ticket.disassociate')}
             </Button>
           </div>

--- a/next/api/src/controller/ticket.ts
+++ b/next/api/src/controller/ticket.ts
@@ -1,0 +1,102 @@
+import _ from 'lodash';
+import { Context } from 'koa';
+import { z } from 'zod';
+import {
+  BadRequestError,
+  Body,
+  Controller,
+  Ctx,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseMiddlewares,
+} from '@/common/http';
+import { ZodValidationPipe } from '@/common/pipe';
+import { customerServiceOnly } from '@/middleware';
+import { UpdateData } from '@/orm';
+import router from '@/router/ticket';
+import { Ticket } from '@/model/Ticket';
+
+const createAssociatedTicketSchema = z.object({
+  ticketId: z.string(),
+});
+
+@Controller({ router, path: 'tickets' })
+export class TicketController {
+  @Get(':id/associated-tickets')
+  @UseMiddlewares(customerServiceOnly)
+  getAssociatedTickets(@Ctx() ctx: Context) {
+    const ticket = ctx.state.ticket as Ticket;
+    return ticket.getAssociatedTickets({ useMasterKey: true });
+  }
+
+  @Post(':id/associated-tickets')
+  @UseMiddlewares(customerServiceOnly)
+  async createAssociatedTicket(
+    @Ctx() ctx: Context,
+    @Body(new ZodValidationPipe(createAssociatedTicketSchema))
+    data: z.infer<typeof createAssociatedTicketSchema>
+  ) {
+    const ticket = ctx.state.ticket as Ticket;
+
+    const associatedTicket = await Ticket.find(data.ticketId, { useMasterKey: true });
+    if (!associatedTicket) {
+      throw new BadRequestError(`Ticket ${data.ticketId} does not exist`);
+    }
+    if (associatedTicket.authorId !== ticket.authorId) {
+      throw new BadRequestError(`Cannot associate tickets which have different author`);
+    }
+
+    if (associatedTicket.parentId && ticket.parentId) {
+      if (associatedTicket.parentId === ticket.parentId) {
+        return;
+      }
+      throw new BadRequestError(
+        `Ticket ${ticket.id} and ${associatedTicket.id} belong to different groups`
+      );
+    }
+
+    const noParentIdTickets = [ticket, associatedTicket].filter((ticket) => !ticket.parentId);
+    const parentId = ticket.parentId ?? associatedTicket.parentId ?? ticket.id;
+    await Ticket.updateSome(
+      noParentIdTickets.map((ticket) => [ticket, { parentId }]),
+      { useMasterKey: true }
+    );
+  }
+
+  @Delete(':id/associated-tickets/:associatedTicketId')
+  async deleteAssociatedTicket(
+    @Ctx() ctx: Context,
+    @Param('associatedTicketId') associatedTicketId: string
+  ) {
+    const ticket = ctx.state.ticket as Ticket;
+    if (!ticket.parentId) {
+      return;
+    }
+
+    const tickets = await Ticket.queryBuilder()
+      .where('parent', '==', ticket.toPointer())
+      .find({ useMasterKey: true });
+
+    const [[disassociateTicket], restTickets] = _.partition(
+      tickets,
+      (ticket) => ticket.id === associatedTicketId
+    );
+    if (!disassociateTicket) {
+      return;
+    }
+
+    const updatePairs: [Ticket, UpdateData<Ticket>][] = [[disassociateTicket, { parentId: null }]];
+
+    if (restTickets.length === 1) {
+      updatePairs.push([restTickets[0], { parentId: null }]);
+    } else if (disassociateTicket.parentId === disassociateTicket.id) {
+      restTickets.forEach((ticket, i, [mainTicket]) => {
+        updatePairs.push([ticket, { parentId: mainTicket.id }]);
+      });
+    }
+
+    await Ticket.updateSome(updatePairs, { useMasterKey: true });
+  }
+}

--- a/next/api/src/controller/ticket.ts
+++ b/next/api/src/controller/ticket.ts
@@ -76,7 +76,7 @@ export class TicketController {
     }
 
     const tickets = await Ticket.queryBuilder()
-      .where('parent', '==', ticket.toPointer())
+      .where('parent', '==', Ticket.ptr(ticket.parentId))
       .find({ useMasterKey: true });
 
     const [[disassociateTicket], restTickets] = _.partition(

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -216,8 +216,6 @@ export class Ticket extends Model {
   @field()
   channel?: string;
 
-  associateTickets?: Ticket[];
-
   subscribed?: boolean;
 
   getUrl(): string {
@@ -367,10 +365,10 @@ export class Ticket extends Model {
     operator: User,
     options?: UpdateOptions & { cascade?: boolean }
   ): Promise<Ticket> {
-    await this.loadAssociateTickets(options);
+    const associateTickets = await this.getAssociatedTickets(options);
 
     const result = await Promise.all(
-      (options?.cascade ? [...(this.associateTickets ?? []), this] : [this]).map((ticket) => {
+      (options?.cascade ? [...associateTickets, this] : [this]).map((ticket) => {
         const updater = new TicketUpdater(ticket);
         updater.operate(action);
         return updater.update(operator, options);
@@ -386,15 +384,14 @@ export class Ticket extends Model {
     return Status.isClosed(this.status);
   }
 
-  async loadAssociateTickets(options?: AuthOptions) {
-    this.associateTickets = this.parentId
-      ? await Ticket.queryBuilder()
-          .where('parent', '==', Ticket.ptr(this.parentId))
-          .where('objectId', '!=', this.id)
-          .find(options)
-      : undefined;
-
-    return this;
+  async getAssociatedTickets(options?: AuthOptions) {
+    if (!this.parentId) {
+      return [];
+    }
+    return Ticket.queryBuilder()
+      .where('parent', '==', Ticket.ptr(this.parentId))
+      .where('objectId', '!=', this.id)
+      .find(options);
   }
 
   async loadSubscribed(user: User) {

--- a/next/api/src/model/Ticket.ts
+++ b/next/api/src/model/Ticket.ts
@@ -216,8 +216,6 @@ export class Ticket extends Model {
   @field()
   channel?: string;
 
-  subscribed?: boolean;
-
   getUrl(): string {
     return `${config.host}/tickets/${this.nid}`;
   }
@@ -392,14 +390,5 @@ export class Ticket extends Model {
       .where('parent', '==', Ticket.ptr(this.parentId))
       .where('objectId', '!=', this.id)
       .find(options);
-  }
-
-  async loadSubscribed(user: User) {
-    this.subscribed = !!(await Watch.queryBuilder()
-      .where('ticket', '==', this.toPointer())
-      .where('user', '==', user.toPointer())
-      .first({ useMasterKey: true }));
-
-    return this;
   }
 }

--- a/next/api/src/response/ticket.ts
+++ b/next/api/src/response/ticket.ts
@@ -23,7 +23,6 @@ class BaseTicketResponse {
       categoryPath: this.ticket.categoryPath?.map(({ id, name }) => ({ id, name })),
       authorId: this.ticket.authorId,
       author: this.ticket.author ? new UserResponse(this.ticket.author) : undefined,
-      associateTickets: this.ticket.associateTickets?.map((t) => new BaseTicketResponse(t)),
       reporterId: this.ticket.reporterId,
       reporter: this.ticket.reporter ? new UserResponse(this.ticket.reporter) : undefined,
       assigneeId: this.ticket.assigneeId,

--- a/next/api/src/response/ticket.ts
+++ b/next/api/src/response/ticket.ts
@@ -36,7 +36,6 @@ class BaseTicketResponse {
       metaData: this.ticket.metaData ? _.pick(this.ticket.metaData, includeMetaKeys) : undefined,
       firstCustomerServiceReplyAt: this.ticket.firstCustomerServiceReplyAt,
       latestCustomerServiceReplyAt: this.ticket.latestCustomerServiceReplyAt,
-      subscribed: this.ticket.subscribed,
       associated: !!this.ticket.parentId,
       language: this.ticket.language,
       tags: includeTags ? this.ticket.tags : undefined,

--- a/next/api/src/router/index.ts
+++ b/next/api/src/router/index.ts
@@ -3,7 +3,6 @@ import Router from '@koa/router';
 import { initControllers } from '@/common/http';
 import '@/controller';
 import { catchLCError, catchYupError, catchZodError } from '@/middleware/error';
-import ticket from './ticket';
 import organization from './organization';
 import unread from './unread';
 import notification from './notification';
@@ -16,7 +15,6 @@ import config from './config';
 
 const router = new Router({ prefix: '/api/2' }).use(catchYupError, catchLCError, catchZodError);
 
-router.use('/tickets', ticket.routes());
 router.use('/organizations', organization.routes());
 router.use('/unread', unread.routes());
 router.use('/notifications', notification.routes());

--- a/next/api/src/ticket/TicketUpdater.ts
+++ b/next/api/src/ticket/TicketUpdater.ts
@@ -22,11 +22,7 @@ export interface UpdateOptions {
 export class TicketUpdater {
   private organization?: Organization | null;
   private assignee?: User | null;
-  private associateTicket?: Ticket | null;
-  private mainTicket?: Ticket;
   private group?: Group | null;
-
-  private isMain?: boolean;
 
   private data: UpdateData<Ticket> = {};
   private replyCountIncrement = 0;
@@ -90,27 +86,6 @@ export class TicketUpdater {
       this.data.assigneeId = null;
     }
     this.shouldUpdateACL = true;
-    return this;
-  }
-
-  setAssociateTicket(ticket: Ticket | null, mainTicket?: Ticket): this {
-    this.isMain = this.ticket.parentId === this.ticket.id;
-
-    if (ticket) {
-      this.associateTicket = ticket;
-
-      if (!ticket.parentId && !this.ticket.parentId) {
-        this.data.parentId = this.ticket.id;
-      } else if (!this.ticket.parentId) {
-        this.data.parentId = ticket.id;
-      } else if (this.ticket.parentId && ticket.parentId) {
-        this.mainTicket = mainTicket;
-      }
-    } else {
-      this.associateTicket = null;
-      this.data.parentId = null;
-    }
-
     return this;
   }
 
@@ -225,48 +200,6 @@ export class TicketUpdater {
     return this;
   }
 
-  private async processAssociation(options?: ModifyOptions) {
-    if (this.associateTicket === undefined) return;
-
-    if (this.associateTicket === null) {
-      const tickets = await Ticket.queryBuilder()
-        .where('parent', '==', this.ticket.toPointer())
-        .where('objectId', '!=', this.ticket.id)
-        .find({ useMasterKey: true });
-
-      if (tickets.length === 1) {
-        await tickets[0].update({ parentId: null }, options);
-      } else if (this.isMain) {
-        const newMainTicket = tickets[0];
-        await Ticket.updateSome(
-          tickets.map((t) => [t, { parentId: newMainTicket.id }]),
-          options
-        );
-      }
-
-      return;
-    }
-
-    if (!this.associateTicket.parentId) {
-      await Ticket.updateSome(
-        [[this.associateTicket, { parentId: this.data.parentId || this.ticket.parentId }]],
-        options
-      );
-    } else if (this.associateTicket.parentId && this.ticket.parentId) {
-      await Ticket.updateSome(
-        (
-          await Ticket.queryBuilder()
-            .where('parent', 'in', [
-              Ticket.ptr(this.ticket.parentId),
-              Ticket.ptr(this.associateTicket.parentId),
-            ])
-            .find({ useMasterKey: true })
-        ).map((t) => [t, { parentId: this.mainTicket?.id }]),
-        options
-      );
-    }
-  }
-
   private async applyOperation(action: OperateAction, operator: User) {
     const isCustomerService = await operator.isCustomerService();
     switch (action) {
@@ -307,8 +240,7 @@ export class TicketUpdater {
       this.replyCountIncrement > 0 ||
       this.unreadCountIncrement > 0 ||
       this.joinedCustomerServices.length > 0 ||
-      this.operateAction !== undefined ||
-      this.mainTicket !== undefined
+      this.operateAction !== undefined
     );
   }
 
@@ -378,7 +310,6 @@ export class TicketUpdater {
       this.data,
       this.getModifyOptions(operator, options?.useMasterKey)
     );
-    await this.processAssociation(this.getModifyOptions(operator, options?.useMasterKey));
     this.assignRelatedInstance(ticket);
 
     this.saveOpsLogs(operator).catch((error) => {


### PR DESCRIPTION
`PATCH /tickets/:id` 承载了太多的功能，所以想把关联工单的功能切出来。

改用以下几个 API 处理关联工单的功能：

#### `GET  /tickets/:id/associated-tickets`
获取关联工单列表（不包括自己）。

#### `POST /tickets/:id/associated-tickets {"ticketId":"xxx"}`
关联 id 和 ticketId 指向的工单。

#### `DELETE /tickets/:id/associated-tickets/:associatedTicketId`
将 associatedTicketId 指向的工单从 id 指向的工单的组中移除出去。
