### PR TITLE
feat(next/api): reply.edited flag

### DIFF
--- a/next/api/scripts/set-reply-edited-flag.js
+++ b/next/api/scripts/set-reply-edited-flag.js
@@ -1,0 +1,94 @@
+const { createInterface } = require('node:readline');
+const AV = require('leancloud-storage');
+const _ = require('lodash');
+
+main();
+
+async function main() {
+  readAppInfo(({ appId, masterKey, serverURL }) => {
+    AV.init({ appId, masterKey, serverURL, appKey: 'WHATEVER' });
+    migrate().then((count) => {
+      console.log(`${count} replies migrated`);
+    });
+  });
+}
+
+/**
+ * @param {(info: { appId: string; masterKey: string; serverURL: string }) => void} cb
+ */
+function readAppInfo(cb) {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.question('App ID: ', (appId) => {
+    rl.question('Master Key: ', (masterKey) => {
+      rl.question('Server URL: ', (serverURL) => {
+        rl.close();
+        cb({ appId, masterKey, serverURL });
+      });
+    });
+  });
+}
+
+class ReplyRevisionScanner {
+  /**
+   * @type {string | null}
+   */
+  _cursor = null;
+
+  /**
+   * @returns {Promise<AV.Object[]>}
+   */
+  async scan(maxCount = 100) {
+    const query = new AV.Query('ReplyRevision');
+    query.addAscending('createdAt');
+    if (this._cursor) {
+      query.greaterThan('createdAt', this._cursor);
+    }
+    query.limit(maxCount);
+    const revisions = await query.find({ useMasterKey: true });
+    if (revisions.length) {
+      this._cursor = revisions[revisions.length - 1].createdAt;
+    }
+    return revisions;
+  }
+
+  async next() {
+    const revisions = await this.scan();
+    return {
+      value: revisions,
+      done: revisions.length === 0,
+    };
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+async function migrate() {
+  let count = 0;
+  for await (const revisions of new ReplyRevisionScanner()) {
+    const replyIds = _(revisions)
+      .map((r) => r.get('reply')?.id)
+      .compact()
+      .uniq()
+      .value();
+
+    let replies = await new AV.Query('Reply')
+      .containedIn('objectId', replyIds)
+      .find({ useMasterKey: true });
+
+    replies = replies.filter((reply) => !reply.has('edited'));
+
+    if (replies.length) {
+      replies.forEach((reply) => reply.set('edited', true));
+
+      await AV.Object.saveAll(replies, { useMasterKey: true });
+      count += replies.length;
+    }
+  }
+  return count;
+}

--- a/next/api/src/model/Reply.ts
+++ b/next/api/src/model/Reply.ts
@@ -61,6 +61,9 @@ export class Reply extends Model {
   @field()
   deletedAt?: Date;
 
+  @field()
+  edited?: boolean;
+
   getTinyInfo(): TinyReplyInfo {
     if (!this.author) {
       throw new Error('missing reply author');

--- a/next/api/src/response/reply.ts
+++ b/next/api/src/response/reply.ts
@@ -15,6 +15,7 @@ export class ReplyResponse {
       isCustomerService: this.reply.isCustomerService,
       files: this.reply.files?.map((file) => new FileResponse(file)),
       internal: this.reply.internal,
+      edited: this.reply.edited,
       createdAt: this.reply.createdAt.toISOString(),
       updatedAt: this.reply.updatedAt.toISOString(),
       deletedAt: this.reply.deletedAt?.toISOString(),

--- a/resources/schema/Reply.json
+++ b/resources/schema/Reply.json
@@ -52,6 +52,9 @@
       "required": false,
       "hidden": false,
       "read_only": false
+    },
+    "edited": {
+      "type": "Boolean"
     }
   },
   "permissions": {


### PR DESCRIPTION
因为新版详情页里会展示被删除的回复，用 createdAt == updatedAt 判断回复是否被修改过就不准确了。所以给回复添加一个 edited 标志记录内容是否被修改过。

## Deploy.md draft

导入 Reply.json，创建 edited 列。

部署完成后运行 next/api/scripts/set-reply-edited-flag.js，根据提示完成对存量数据的迁移。

