### PR TITLE
fix: category form content hidden and feedback condition

### DIFF
--- a/in-app/v1/src/App/Home/index.tsx
+++ b/in-app/v1/src/App/Home/index.tsx
@@ -66,15 +66,16 @@ export default function Home() {
     <>
       <PageHeader />
       {content}
-      {hasTopics &&
-        enableFeedback &&
+      {enableFeedback &&
         (!category.meta?.enableAIClassify ? (
-          <div className="text-center text-gray-400 opacity-80 mt-6 mb-3">
-            {t('topic.hint')}{' '}
-            <Link to="/categories" className="text-tapBlue">
-              {t('feedback.title')}
-            </Link>
-          </div>
+          !!hasTopics && (
+            <div className="text-center text-gray-400 opacity-80 mt-6 mb-3">
+              {t('topic.hint')}{' '}
+              <Link to="/categories" className="text-tapBlue">
+                {t('feedback.title')}
+              </Link>
+            </div>
+          )
         ) : (
           <AiClassify className="mt-3" />
         ))}

--- a/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
+++ b/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
@@ -185,7 +185,7 @@ export function CategoryForm({
 
   const categoryTree = useCategoryTree(activeCategories);
 
-  const isRootCategory = !initData?.parentId;
+  const isProduct = !initData?.alias;
 
   const hasSubCategory = useMemo(() => {
     if (!currentCategoryId) {
@@ -323,7 +323,7 @@ export function CategoryForm({
 
       <Divider />
 
-      {isRootCategory && (
+      {isProduct && (
         <div>
           <div className="text-[18px] mb-4 font-semibold">内容</div>
           <Controller
@@ -379,7 +379,7 @@ export function CategoryForm({
         </div>
       )}
 
-      {isRootCategory && (
+      {isProduct && (
         <>
           <Divider />
           <div className="text-[18px] mb-4 font-semibold">其他</div>
@@ -405,7 +405,7 @@ export function CategoryForm({
         </>
       )}
 
-      {!isRootCategory && hasSubCategory && (
+      {!isProduct && hasSubCategory && (
         <div>
           <div className="text-[16px] mb-4 font-semibold">支持选项</div>
           <Alert message="仅在无子分类时展示" type="info" showIcon style={{ marginBottom: 24 }} />

--- a/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
+++ b/next/web/src/App/Admin/Settings/Categories/CategoryForm.tsx
@@ -185,7 +185,7 @@ export function CategoryForm({
 
   const categoryTree = useCategoryTree(activeCategories);
 
-  const isProduct = !initData?.alias;
+  const isProduct = !!initData?.alias;
 
   const hasSubCategory = useMemo(() => {
     if (!currentCategoryId) {


### PR DESCRIPTION
把分类表单内的 isRootCategory 变成了 isProduct 因为当前设计内 product 作为入口可以不是根分类

同时将 AI 分类的展现条件进行修改，当 product 没有配置 topics 也会展示，但是作为没有开启 AI 分类时的 fallback，还是和以前一样在配置了 topics 的时候展示