### PR TITLE
feat(next/api): remove failed jobs

### DIFF
--- a/next/api/src/integration/taptap-dw/index.ts
+++ b/next/api/src/integration/taptap-dw/index.ts
@@ -300,6 +300,7 @@ export default async function (install: Function) {
   const queue = createQueue<JobData>('ticket_snapshot', {
     defaultJobOptions: {
       removeOnComplete: true,
+      removeOnFail: true,
     },
   });
 

--- a/next/api/src/notification/index.ts
+++ b/next/api/src/notification/index.ts
@@ -322,6 +322,7 @@ const queue = createQueue<JobData>('notification', {
   },
   defaultJobOptions: {
     removeOnComplete: true,
+    removeOnFail: true,
   },
 });
 

--- a/next/api/src/ticket/automation/trigger/index.ts
+++ b/next/api/src/ticket/automation/trigger/index.ts
@@ -83,6 +83,7 @@ const queue = createQueue<JobData>('trigger:v2', {
   },
   defaultJobOptions: {
     removeOnComplete: true,
+    removeOnFail: true,
   },
 });
 


### PR DESCRIPTION
任务失败后从 redis 中删除。现在只能手动重试，没有留着的必要。