### PR TITLE
feat: merge user

### DIFF
--- a/next/api/src/controller/customer-service.ts
+++ b/next/api/src/controller/customer-service.ts
@@ -26,6 +26,7 @@ import { User } from '@/model/User';
 import { CustomerServiceResponse } from '@/response/customer-service';
 import { GroupResponse } from '@/response/group';
 import { roleService } from '@/service/role';
+import { userService } from '@/user/services/user';
 
 class FindCustomerServicePipe {
   static async transform(id: string, ctx: Context): Promise<User> {
@@ -123,11 +124,7 @@ export class CustomerServiceController {
       if (data.active) {
         processQueue.push(user.update({ inactive: null }, { useMasterKey: true }));
       } else {
-        processQueue.push(
-          user
-            .update({ inactive: true }, { useMasterKey: true })
-            .then(() => user.refreshSessionToken())
-        );
+        processQueue.push(userService.inactiveUser(user));
       }
     }
 

--- a/next/api/src/controller/merge-user-task.ts
+++ b/next/api/src/controller/merge-user-task.ts
@@ -1,0 +1,55 @@
+import { Context } from 'koa';
+import { z } from 'zod';
+
+import {
+  Body,
+  Controller,
+  Ctx,
+  Get,
+  Post,
+  Query,
+  ResponseBody,
+  UseMiddlewares,
+} from '@/common/http';
+import { ParseIntPipe, ZodValidationPipe } from '@/common/pipe';
+import { adminOnly, auth } from '@/middleware';
+import { userService } from '@/user/services/user';
+import { MergeUserTaskResponse } from '@/response/merge-user-task';
+import { MergeUserTask } from '@/model/MergeUserTask';
+
+const MergeUserSchema = z.object({
+  sourceUserId: z.string(),
+  targetUserId: z.string(),
+});
+
+@Controller('merge-user-tasks')
+@UseMiddlewares(auth, adminOnly)
+export class MergeUserTaskController {
+  @Post()
+  @ResponseBody(MergeUserTaskResponse)
+  async createTask(
+    @Body(new ZodValidationPipe(MergeUserSchema))
+    data: z.infer<typeof MergeUserSchema>
+  ) {
+    return userService.mergeUser(data.sourceUserId, data.targetUserId);
+  }
+
+  @Get()
+  @ResponseBody(MergeUserTaskResponse)
+  async getTasks(
+    @Ctx()
+    ctx: Context,
+    @Query('page', new ParseIntPipe({ min: 1 }))
+    page: number,
+    @Query('pageSize', new ParseIntPipe({ min: 1, max: 100 }))
+    pageSize: number
+  ) {
+    const [tasks, totalCount] = await MergeUserTask.queryBuilder()
+      .preload('sourceUser')
+      .preload('targetUser')
+      .paginate(page, pageSize)
+      .findAndCount({ useMasterKey: true });
+    ctx.set('X-Total-Count', totalCount.toString());
+    return tasks;
+  }
+}

--- a/next/api/src/model/MergeUserTask.ts
+++ b/next/api/src/model/MergeUserTask.ts
@@ -1,0 +1,28 @@
+import { field, Model, pointerId, pointTo } from '@/orm';
+import { User } from './User';
+
+export class MergeUserTask extends Model {
+  @pointerId(() => User)
+  sourceUserId!: string;
+
+  @pointTo(() => User)
+  sourceUser?: User;
+
+  @pointerId(() => User)
+  targetUserId!: string;
+
+  @pointTo(() => User)
+  targetUser?: User;
+
+  @field()
+  mergingData!: {
+    authData?: Record<string, any>;
+    email?: string;
+  };
+
+  @field()
+  status!: string;
+
+  @field()
+  completedAt?: Date;
+}

--- a/next/api/src/queue/index.ts
+++ b/next/api/src/queue/index.ts
@@ -12,6 +12,11 @@ export function createQueue<T>(name: string, options?: Bull.QueueOptions): Bull.
   }
   return new Bull<T>(name, {
     ...options,
+    defaultJobOptions: {
+      removeOnComplete: true,
+      removeOnFail: true,
+      ...options?.defaultJobOptions,
+    },
     // https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#reusing-redis-connections
     createClient: (type, redisOptions) => {
       switch (type) {
@@ -34,4 +39,4 @@ export function createQueue<T>(name: string, options?: Bull.QueueOptions): Bull.
   });
 }
 
-export type { Queue } from 'bull';
+export type { Queue, Job } from 'bull';

--- a/next/api/src/response/merge-user-task.ts
+++ b/next/api/src/response/merge-user-task.ts
@@ -1,0 +1,19 @@
+import { MergeUserTask } from '@/model/MergeUserTask';
+import { UserResponse } from './user';
+
+export class MergeUserTaskResponse {
+  constructor(private task: MergeUserTask) {}
+
+  toJSON() {
+    return {
+      id: this.task.id,
+      sourceUserId: this.task.sourceUserId,
+      sourceUser: this.task.sourceUser && new UserResponse(this.task.sourceUser).toJSON(),
+      targetUser: this.task.targetUser && new UserResponse(this.task.targetUser).toJSON(),
+      targetUserId: this.task.targetUserId,
+      status: this.task.status,
+      completedAt: this.task.completedAt?.toISOString(),
+      createdAt: this.task.createdAt.toISOString(),
+    };
+  }
+}

--- a/next/api/src/user/services/user.ts
+++ b/next/api/src/user/services/user.ts
@@ -1,5 +1,9 @@
 import crypto from 'node:crypto';
+
+import { BadRequestError } from '@/common/http';
 import { User } from '@/model/User';
+import { MergeUserTask } from '@/model/MergeUserTask';
+import { ticketService } from '@/service/ticket';
 import { CreateUserData } from '../types';
 
 export class UserService {
@@ -58,6 +62,102 @@ export class UserService {
     }
 
     return password;
+  }
+
+  async inactiveUser(user: User) {
+    const newUser = await user.update({ inactive: true }, { useMasterKey: true });
+    await user.refreshSessionToken();
+    return newUser;
+  }
+
+  async mergeUser(sourceId: string, targetId: string) {
+    if (sourceId === targetId) {
+      throw new BadRequestError('源用户和目标用户不能相同');
+    }
+
+    const sourceUser = await User.find(sourceId, { useMasterKey: true });
+    if (!sourceUser) {
+      throw new BadRequestError('源用户不存在');
+    }
+    const sourceUserTask = await MergeUserTask.queryBuilder()
+      .where('sourceUser', '==', sourceUser.toPointer())
+      .first({ useMasterKey: true });
+    if (sourceUserTask) {
+      throw new BadRequestError('源用户已被合并');
+    }
+
+    const targetUser = await User.find(targetId, { useMasterKey: true });
+    if (!targetUser) {
+      throw new BadRequestError('目标用户不存在');
+    }
+
+    if (sourceUser.authData && targetUser.authData) {
+      throw new BadRequestError('authData conflict');
+    }
+    if (sourceUser.email && targetUser.email) {
+      throw new BadRequestError('email confilct');
+    }
+
+    const task = await MergeUserTask.create(
+      {
+        sourceUserId: sourceUser.id,
+        targetUserId: targetUser.id,
+        mergingData: {
+          authData: sourceUser.authData,
+          email: sourceUser.email,
+        },
+        status: 'pending',
+      },
+      { useMasterKey: true }
+    );
+
+    (async () => {
+      await this.inactiveUser(sourceUser);
+      if (sourceUser.email || sourceUser.authData) {
+        await sourceUser.update(
+          {
+            authData: null,
+            email: null,
+          },
+          { useMasterKey: true }
+        );
+      }
+
+      if (task.mergingData.email || task.mergingData.authData) {
+        await targetUser.update(
+          {
+            authData: task.mergingData.authData,
+            email: task.mergingData.email,
+          },
+          { useMasterKey: true }
+        );
+      }
+
+      await ticketService.addTransferTicketJob({
+        sourceUserId: sourceUser.id,
+        targetUserId: targetUser.id,
+        mergeUserTaskId: task.id,
+      });
+
+      await task.update({ status: 'transfer_tickets' }, { useMasterKey: true });
+    })();
+
+    return task;
+  }
+
+  async transferTicketsCallback(mergeUserTaskId: string) {
+    const task = await MergeUserTask.find(mergeUserTaskId, { useMasterKey: true });
+    if (task) {
+      await task.update(
+        {
+          status: 'complete',
+          completedAt: new Date(),
+        },
+        {
+          useMasterKey: true,
+        }
+      );
+    }
   }
 }
 

--- a/next/web/src/App/Admin/Settings/Users/MergeUser/components/MergeUserForm.tsx
+++ b/next/web/src/App/Admin/Settings/Users/MergeUser/components/MergeUserForm.tsx
@@ -1,0 +1,65 @@
+import { forwardRef } from 'react';
+import { Alert, Form, FormInstance } from 'antd';
+
+import { UserSelect } from '@/components/common';
+
+export interface MergeUserFormData {
+  sourceUserId: string;
+  targetUserId: string;
+}
+
+export interface MergeUserFormProps {
+  onSubmit?: (data: MergeUserFormData) => void;
+}
+
+export const MergeUserForm = forwardRef<FormInstance, MergeUserFormProps>(({ onSubmit }, ref) => {
+  const [form] = Form.useForm<MergeUserFormData>();
+
+  const sourceUserId = Form.useWatch('sourceUserId', form);
+
+  const handleSubmit = (data: MergeUserFormData) => {
+    onSubmit?.(data);
+  };
+
+  return (
+    <Form ref={ref} form={form} layout="vertical" onFinish={handleSubmit}>
+      <Alert
+        type="info"
+        description={
+          <ol className="m-0 pl-4 list-disc">
+            <li>合并后源用户将无法登录</li>
+            <li>源用户的 authData、email 信息将转移到目标用户上</li>
+            <li>源用户名下的工单将会转移至目标用户名下，该过程会持续一段时间</li>
+          </ol>
+        }
+        style={{ marginBottom: 16 }}
+      />
+      <Form.Item
+        name="sourceUserId"
+        label="源用户"
+        rules={[{ required: true }]}
+        style={{ marginBottom: 16 }}
+      >
+        <UserSelect />
+      </Form.Item>
+      <Form.Item
+        name="targetUserId"
+        label="目标用户"
+        rules={[
+          {
+            required: true,
+            validator: (_rule, value) => {
+              if (value === sourceUserId) {
+                return Promise.reject('不能与源用户相同');
+              }
+              return Promise.resolve();
+            },
+          },
+        ]}
+        style={{ marginBottom: 0 }}
+      >
+        <UserSelect />
+      </Form.Item>
+    </Form>
+  );
+});

--- a/next/web/src/App/Admin/Settings/Users/MergeUser/index.tsx
+++ b/next/web/src/App/Admin/Settings/Users/MergeUser/index.tsx
@@ -1,0 +1,92 @@
+import { useRef, useState } from 'react';
+import { useToggle } from 'react-use';
+import { useMutation, useQuery } from 'react-query';
+import { Button, FormInstance, Modal, Table } from 'antd';
+import moment from 'moment';
+
+import { getMergeUserTasks, mergeUser } from '@/api/user';
+import { MergeUserForm } from './components/MergeUserForm';
+
+export function MergeUser() {
+  const [mergeModalOpen, toggleMergeModal] = useToggle(false);
+  const formRef = useRef<FormInstance>(null);
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['MergeUserTasks', page, pageSize],
+    queryFn: () => getMergeUserTasks({ page, pageSize }),
+  });
+
+  const { mutate: _mergeUser, isLoading: isMerging } = useMutation({
+    mutationFn: mergeUser,
+    onSuccess: () => {
+      toggleMergeModal(false);
+      refetch();
+    },
+  });
+
+  return (
+    <div className="p-10">
+      <h1 className="text-[#2f3941] text-[26px] font-normal">合并用户</h1>
+      <div className="my-5 flex flex-row-reverse">
+        <Button type="primary" onClick={toggleMergeModal}>
+          合并
+        </Button>
+      </div>
+
+      <Modal
+        destroyOnClose
+        open={mergeModalOpen}
+        title="创建合并任务"
+        onOk={() => formRef.current?.submit()}
+        onCancel={toggleMergeModal}
+        confirmLoading={isMerging}
+      >
+        <MergeUserForm ref={formRef} onSubmit={_mergeUser} />
+      </Modal>
+
+      <Table
+        dataSource={data?.data}
+        rowKey={(task) => task.id}
+        loading={isLoading}
+        pagination={{
+          current: page,
+          pageSize,
+          total: data?.totalCount,
+          showSizeChanger: true,
+          onChange: (page, pageSize) => {
+            setPage(page);
+            setPageSize(pageSize);
+          },
+        }}
+        columns={[
+          {
+            dataIndex: ['sourceUser', 'username'],
+            title: '源用户',
+          },
+          {
+            dataIndex: ['targetUser', 'username'],
+            title: '目标用户',
+          },
+          {
+            dataIndex: 'status',
+            title: '状态',
+          },
+          {
+            dataIndex: 'createdAt',
+            title: '开始时间',
+            render: (dateString: string) => moment(dateString).format('YYYY-MM-DD HH:mm:ss'),
+          },
+          {
+            dataIndex: 'completedAt',
+            title: '完成时间',
+            render: (dateString?: string) =>
+              dateString ? moment(dateString).format('YYYY-MM-DD HH:mm:ss') : '-',
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/next/web/src/App/Admin/Settings/index.tsx
+++ b/next/web/src/App/Admin/Settings/index.tsx
@@ -37,6 +37,7 @@ import { EditSupportEmail, NewSupportEmail, SupportEmailList } from './SupportEm
 import { useCurrentUserIsAdmin } from '@/leancloud';
 import { Result } from '@/components/antd';
 import { EvaluationConfig } from './Evaluation';
+import { MergeUser } from './Users/MergeUser';
 
 const SettingRoutes = () => (
   <Routes>
@@ -44,6 +45,7 @@ const SettingRoutes = () => (
       <Route index element="Under Construction" />
       <Route path="new" element={<NewUser />} />
       <Route path=":id" element="Under Construction" />
+      <Route path="merge" element={<MergeUser />} />
     </Route>
     <Route path="/members" element={<Members />} />
     <Route path="/groups">
@@ -148,6 +150,10 @@ const routeGroups: MenuDataItem[] = [
       {
         name: '创建用户',
         path: 'users/new',
+      },
+      {
+        name: '合并用户',
+        path: 'users/merge',
       },
       {
         name: '客服',

--- a/next/web/src/api/user.ts
+++ b/next/web/src/api/user.ts
@@ -64,3 +64,37 @@ export interface CreateUserData {
 export const createUser = async (data: CreateUserData) => {
   await http.post('/api/2/users/pre-create', data);
 };
+
+export interface MergeUserTaskSchema {
+  id: string;
+  sourceUserId: string;
+  sourceUser: UserSchema;
+  targetUserId: string;
+  targetUser: UserSchema;
+  status: string;
+  completedAt: string;
+  createdAt: string;
+}
+
+export interface MergeUserRequestData {
+  sourceUserId: string;
+  targetUserId: string;
+}
+
+export async function mergeUser(data: MergeUserRequestData) {
+  const res = await http.post<MergeUserTaskSchema>('/api/2/merge-user-tasks', data);
+  return res.data;
+}
+
+export interface GetMergeUserTasksOptions {
+  page?: number;
+  pageSize?: number;
+}
+
+export async function getMergeUserTasks(options?: GetMergeUserTasksOptions) {
+  const res = await http.get<MergeUserTaskSchema[]>('/api/2/merge-user-tasks', { params: options });
+  return {
+    data: res.data,
+    totalCount: parseInt(res.headers['x-total-count']),
+  };
+}

--- a/resources/schema/MergeUserTask.json
+++ b/resources/schema/MergeUserTask.json
@@ -1,0 +1,77 @@
+{
+  "schema": {
+    "mergingData": {
+      "hidden": false,
+      "read_only": false,
+      "required": false,
+      "type": "Object"
+    },
+    "sourceUser": {
+      "className": "_User",
+      "hidden": false,
+      "read_only": false,
+      "required": false,
+      "type": "Pointer"
+    },
+    "updatedAt": {
+      "type": "Date"
+    },
+    "ACL": {
+      "type": "ACL",
+      "default": {}
+    },
+    "objectId": {
+      "type": "String"
+    },
+    "completedAt": {
+      "hidden": false,
+      "read_only": false,
+      "required": false,
+      "type": "Date"
+    },
+    "createdAt": {
+      "type": "Date"
+    },
+    "targetUser": {
+      "className": "_User",
+      "hidden": false,
+      "read_only": false,
+      "required": false,
+      "type": "Pointer"
+    },
+    "status": {
+      "hidden": false,
+      "read_only": false,
+      "required": false,
+      "type": "String"
+    }
+  },
+  "permissions": {
+    "add_fields": {},
+    "get": {},
+    "find": {},
+    "create": {},
+    "update": {},
+    "delete": {}
+  },
+  "indexes": [
+    {
+      "v": 2,
+      "key": {
+        "sourceUser.$id": 1.0
+      },
+      "name": "-user-sourceUser.$id_1",
+      "ns": "_.MergeUserTask",
+      "background": true
+    },
+    {
+      "v": 2,
+      "key": {
+        "targetUser.$id": 1.0
+      },
+      "name": "-user-targetUser.$id_1",
+      "ns": "_.MergeUserTask",
+      "background": true
+    }
+  ]
+}


### PR DESCRIPTION
# 合并用户

将用户 A 合并到用户 B 将执行以下操作

- 禁用用户 A
- 将用户 A 的 authData 和 email 属性写入用户 B
- 将用户 A 名下的工单转移至用户 B 名下

为避免冲突，用户 A 和用户 B 不能同时存有 authData 或 email。